### PR TITLE
input validation should only work on send amount

### DIFF
--- a/src/Create.jsx
+++ b/src/Create.jsx
@@ -288,8 +288,6 @@ const Create = () => {
                         id="sendAmount"
                         maxlength="10"
                         step={denomination() == "btc" ? 0.00000001 : 1}
-                        min={minimum()}
-                        max={maximum()}
                         value={sendAmountFormatted()}
                         onInput={(e) => changeSendAmount(e.currentTarget.value)}
                     />


### PR DESCRIPTION
#5 input now only validate send amount

![screenshot-1684011517](https://github.com/BoltzExchange/boltz-webapp-3.0/assets/1743657/f463a853-6157-44d8-a7fd-2ce192aecb7a)
![screenshot-1684011494](https://github.com/BoltzExchange/boltz-webapp-3.0/assets/1743657/c5946a3b-60f6-4cab-91fc-c330aa21ee53)
