### PR TITLE
fix: enable() should not expect an object

### DIFF
--- a/src/Create.jsx
+++ b/src/Create.jsx
@@ -160,14 +160,16 @@ const Create = () => {
     };
 
     const createWeblnInvoice = async () => {
-        let check_enable = await window.webln.enable();
-        if (check_enable.enabled) {
+        try {
+            await window.webln.enable();
             let amount = Number(receiveAmount());
             const invoice = await window.webln.makeInvoice({ amount: amount });
             validateAmount();
             log.debug("created webln invoice", invoice);
             setInvoice(invoice.paymentRequest);
             validateAddress(invoiceInputRef);
+        } catch (error) {
+            log.error(error);
         }
     };
 

--- a/src/status/SwapCreated.jsx
+++ b/src/status/SwapCreated.jsx
@@ -7,11 +7,13 @@ const SwapCreated = () => {
     const [t] = useI18n();
 
     const payWeblnInvoice = async (pr) => {
-        let check_enable = await window.webln.enable();
-        if (check_enable.enabled) {
+        try {
+            await window.webln.enable();
             const result = await window.webln.sendPayment(pr);
             log.debug("webln payment result:", result);
             fetchSwapStatus(swap());
+        } catch (error) {
+            log.error(error);
         }
     };
 


### PR DESCRIPTION
may fix https://github.com/BoltzExchange/boltz-web-app/issues/229

This implementation should still be compatible with providers that return an object on `enable()` but will also allow WebLN providers that do not return anything when `enable()` is called to reach the call to `makeInvoice` so users can make payments on boltz.exchange even if they are not using the Alby extension

also see https://github.com/getAlby/lightning-browser-extension/issues/2596 for more context on spec considerations