### PR TITLE
feat: browser language detection

### DIFF
--- a/src/Nav.jsx
+++ b/src/Nav.jsx
@@ -1,25 +1,14 @@
 import { A } from "@solidjs/router";
 import { For, Show } from "solid-js";
-import log from "loglevel";
 import t from "./i18n";
 import "./style/nav.scss";
 import locales from "./i18n/i18n.js";
 import logo from "./assets/boltz.svg";
 import Warnings from "./components/Warnings";
-import { i18n, setI18n, hamburger, setHamburger } from "./signals";
-import { defaultLanguage } from "./config";
+import { setI18nCached, hamburger, setHamburger } from "./signals";
 
 const Nav = ({ network }) => {
     let timeout;
-
-    if (i18n() === null && navigator.language) {
-        const lang = navigator.language.split("-")[0];
-        log.info("detected navigator.language", navigator.language, lang);
-        setI18n(lang);
-    } else if (i18n() === null) {
-        log.info("setting default language", defaultLanguage);
-        setI18n(defaultLanguage);
-    }
 
     return (
         <nav>
@@ -52,7 +41,7 @@ const Nav = ({ network }) => {
                             {(lang) => (
                                 <span
                                     class="lang"
-                                    onClick={() => setI18n(lang)}>
+                                    onClick={() => setI18nCached(lang)}>
                                     {locales[lang].language}
                                 </span>
                             )}

--- a/src/Nav.jsx
+++ b/src/Nav.jsx
@@ -1,14 +1,25 @@
 import { A } from "@solidjs/router";
 import { For, Show } from "solid-js";
+import log from "loglevel";
 import t from "./i18n";
 import "./style/nav.scss";
 import locales from "./i18n/i18n.js";
 import logo from "./assets/boltz.svg";
 import Warnings from "./components/Warnings";
-import { setI18n, hamburger, setHamburger } from "./signals";
+import { i18n, setI18n, hamburger, setHamburger } from "./signals";
+import { defaultLanguage } from "./config";
 
 const Nav = ({ network }) => {
     let timeout;
+
+    if (i18n() === null && navigator.language) {
+        log.info("detected navigator.language", navigator.language);
+        const lang = navigator.language.split("-")[0];
+        setI18n(lang);
+    } else {
+        log.info("setting default language", defaultLanguage);
+        setI18n(defaultLanguage);
+    }
 
     return (
         <nav>

--- a/src/Nav.jsx
+++ b/src/Nav.jsx
@@ -13,10 +13,10 @@ const Nav = ({ network }) => {
     let timeout;
 
     if (i18n() === null && navigator.language) {
-        log.info("detected navigator.language", navigator.language);
         const lang = navigator.language.split("-")[0];
+        log.info("detected navigator.language", navigator.language, lang);
         setI18n(lang);
-    } else {
+    } else if (i18n() === null) {
         log.info("setting default language", defaultLanguage);
         setI18n(defaultLanguage);
     }

--- a/src/Nav.jsx
+++ b/src/Nav.jsx
@@ -5,7 +5,7 @@ import "./style/nav.scss";
 import locales from "./i18n/i18n.js";
 import logo from "./assets/boltz.svg";
 import Warnings from "./components/Warnings";
-import { setI18nCached, hamburger, setHamburger } from "./signals";
+import { setI18nConfigured, hamburger, setHamburger } from "./signals";
 
 const Nav = ({ network }) => {
     let timeout;
@@ -41,7 +41,7 @@ const Nav = ({ network }) => {
                             {(lang) => (
                                 <span
                                     class="lang"
-                                    onClick={() => setI18nCached(lang)}>
+                                    onClick={() => setI18nConfigured(lang)}>
                                     {locales[lang].language}
                                 </span>
                             )}

--- a/src/i18n/detect.js
+++ b/src/i18n/detect.js
@@ -1,26 +1,30 @@
 import log from "loglevel";
 import locales from "./i18n";
-import { i18nCached, setI18n } from "../signals";
 import { defaultLanguage } from "../config";
+import { i18nConfigured, setI18n } from "../signals";
 
 export const getNavigatorLanguage = (language) => {
     if (language === undefined) {
         log.info(
-            `navigator.language undefined, using default: ${defaultLanguage}`,
+            `browser language undefined; using default: ${defaultLanguage}`,
         );
         return defaultLanguage;
     }
+
     const lang = language.split("-")[0];
     if (!Object.keys(locales).includes(lang)) {
-        log.info(`Locale not found: ${lang}, using default: ${detectLanguage}`);
+        log.info(
+            `browser language "${lang}" not found; using default: ${defaultLanguage}`,
+        );
         return defaultLanguage;
     }
-    log.info("detected navigator.language", language, lang);
+
+    log.info(`detected browser language ${lang}`);
     return lang;
 };
 
 export const detectLanguage = () => {
-    if (i18nCached() === null) {
+    if (i18nConfigured() === null) {
         setI18n(getNavigatorLanguage(navigator.language));
     }
 };

--- a/src/i18n/detect.js
+++ b/src/i18n/detect.js
@@ -1,0 +1,26 @@
+import log from "loglevel";
+import locales from "./i18n";
+import { i18nCached, setI18n } from "../signals";
+import { defaultLanguage } from "../config";
+
+
+export const getNavigatorLanguage = (language) => {
+    if (language === undefined) {
+        log.info(`navigator.language undefined, using default: ${defaultLanguage}`);
+        return defaultLanguage;
+    }
+    const lang = language.split("-")[0];
+    if (!Object.keys(locales).includes(lang)) {
+        log.info(`Locale not found: ${lang}, using default: ${detectLanguage}`);
+        return defaultLanguage;
+    }
+    log.info("detected navigator.language", language, lang);
+    return lang
+};
+
+
+export const detectLanguage = () => {
+    if (i18nCached() === null) {
+        setI18n(getNavigatorLanguage(navigator.language));
+    }
+};

--- a/src/i18n/detect.js
+++ b/src/i18n/detect.js
@@ -3,10 +3,11 @@ import locales from "./i18n";
 import { i18nCached, setI18n } from "../signals";
 import { defaultLanguage } from "../config";
 
-
 export const getNavigatorLanguage = (language) => {
     if (language === undefined) {
-        log.info(`navigator.language undefined, using default: ${defaultLanguage}`);
+        log.info(
+            `navigator.language undefined, using default: ${defaultLanguage}`,
+        );
         return defaultLanguage;
     }
     const lang = language.split("-")[0];
@@ -15,9 +16,8 @@ export const getNavigatorLanguage = (language) => {
         return defaultLanguage;
     }
     log.info("detected navigator.language", language, lang);
-    return lang
+    return lang;
 };
-
 
 export const detectLanguage = () => {
     if (i18nCached() === null) {

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -3,6 +3,6 @@ import { translator, flatten, resolveTemplate } from "@solid-primitives/i18n";
 import dict from "./i18n";
 import { i18n } from "../signals";
 
-const dictLocale = createMemo(() => flatten(dict[i18n()]));
+const dictLocale = createMemo(() => (i18n() ? flatten(dict[i18n()]) : {}));
 
 export default translator(dictLocale, resolveTemplate);

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,13 +1,11 @@
 import { createMemo } from "solid-js";
 import { translator, flatten, resolveTemplate } from "@solid-primitives/i18n";
 import dict from "./i18n";
-import { i18n, i18nCached, setI18n } from "../signals";
 import { defaultLanguage } from "../config";
+import { i18n, i18nConfigured, setI18n } from "../signals";
 
-createMemo(() => setI18n(i18nCached()));
+createMemo(() => setI18n(i18nConfigured()));
 
-const dictLocale = createMemo(() =>
-    i18n() ? flatten(dict[i18n()]) : flatten(dict[defaultLanguage]),
-);
+const dictLocale = createMemo(() => flatten(dict[i18n() || defaultLanguage]));
 
 export default translator(dictLocale, resolveTemplate);

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,8 +1,13 @@
 import { createMemo } from "solid-js";
 import { translator, flatten, resolveTemplate } from "@solid-primitives/i18n";
 import dict from "./i18n";
-import { i18n } from "../signals";
+import { i18n, i18nCached, setI18n } from "../signals";
+import { defaultLanguage } from "../config";
 
-const dictLocale = createMemo(() => (i18n() ? flatten(dict[i18n()]) : {}));
+createMemo(() => setI18n(i18nCached()));
+
+const dictLocale = createMemo(() =>
+    i18n() ? flatten(dict[i18n()]) : flatten(dict[defaultLanguage]),
+);
 
 export default translator(dictLocale, resolveTemplate);

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -18,14 +18,16 @@ import { checkReferralId } from "./helper";
 import { loglevel, network } from "./config";
 import { swapChecker } from "./utils/swapChecker";
 import { detectWebLNProvider } from "./utils/webln";
-import { setWebln, setWasmSupported, setI18n } from "./signals";
+import { setWebln, setWasmSupported } from "./signals";
 import { checkWasmSupported } from "./utils/wasmSupport";
+import { detectLanguage } from "./i18n/detect";
 
 log.setLevel(loglevel);
 
 detectWebLNProvider().then((state) => setWebln(state));
 setWasmSupported(checkWasmSupported());
 checkReferralId();
+detectLanguage();
 
 swapChecker();
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -16,11 +16,11 @@ import NotFound from "./NotFound";
 import Notification from "./Notification";
 import { checkReferralId } from "./helper";
 import { loglevel, network } from "./config";
+import { detectLanguage } from "./i18n/detect";
 import { swapChecker } from "./utils/swapChecker";
 import { detectWebLNProvider } from "./utils/webln";
 import { setWebln, setWasmSupported } from "./signals";
 import { checkWasmSupported } from "./utils/wasmSupport";
-import { detectLanguage } from "./i18n/detect";
 
 log.setLevel(loglevel);
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -18,7 +18,7 @@ import { checkReferralId } from "./helper";
 import { loglevel, network } from "./config";
 import { swapChecker } from "./utils/swapChecker";
 import { detectWebLNProvider } from "./utils/webln";
-import { setWebln, setWasmSupported } from "./signals";
+import { setWebln, setWasmSupported, setI18n } from "./signals";
 import { checkWasmSupported } from "./utils/wasmSupport";
 
 log.setLevel(loglevel);

--- a/src/signals.js
+++ b/src/signals.js
@@ -65,10 +65,13 @@ export const [ref, setRef] = makePersisted(
         ...stringSerializer,
     },
 );
-export const [i18nCached, setI18nCached] = makePersisted(createSignal(null), {
-    name: "i18n",
-    ...stringSerializer,
-});
+export const [i18nConfigured, setI18nConfigured] = makePersisted(
+    createSignal(null),
+    {
+        name: "i18n",
+        ...stringSerializer,
+    },
+);
 export const [denomination, setDenomination] = makePersisted(
     createSignal("sat"),
     { name: "denomination", ...stringSerializer },

--- a/src/signals.js
+++ b/src/signals.js
@@ -2,7 +2,7 @@ import { createEffect, createSignal } from "solid-js";
 import { makePersisted } from "@solid-primitives/storage";
 import { isMobile } from "./helper";
 import { LN, sideSend } from "./consts";
-import { defaultLanguage, pairs } from "./config";
+import { pairs } from "./config";
 
 const defaultSelection = Object.keys(pairs)[0].split("/")[0];
 
@@ -63,7 +63,7 @@ export const [ref, setRef] = makePersisted(
         ...stringSerializer,
     },
 );
-export const [i18n, setI18n] = makePersisted(createSignal(defaultLanguage), {
+export const [i18n, setI18n] = makePersisted(createSignal(null), {
     name: "i18n",
     ...stringSerializer,
 });

--- a/src/signals.js
+++ b/src/signals.js
@@ -48,6 +48,8 @@ export const [timeoutBlockHeight, setTimeoutBlockheight] = createSignal(0);
 export const [refundTx, setRefundTx] = createSignal("");
 export const [transactionToRefund, setTransactionToRefund] = createSignal(null);
 
+export const [i18n, setI18n] = createSignal(null);
+
 // local storage
 
 // To support the values created by the deprecated "createStorageSignal"
@@ -63,7 +65,7 @@ export const [ref, setRef] = makePersisted(
         ...stringSerializer,
     },
 );
-export const [i18n, setI18n] = makePersisted(createSignal(null), {
+export const [i18nCached, setI18nCached] = makePersisted(createSignal(null), {
     name: "i18n",
     ...stringSerializer,
 });

--- a/tests/i18n/detect.spec.js
+++ b/tests/i18n/detect.spec.js
@@ -1,0 +1,21 @@
+import { describe, expect } from "vitest";
+import { defaultLanguage } from "../../src/config";
+import { getNavigatorLanguage } from "../../src/i18n/detect";
+
+describe("getNavigatorLanguage", () => {
+    test.each`
+        navigatorLanguage | expected
+        ${"en-US"}        | ${"en"}
+        ${"de-DE"}        | ${"de"}
+        ${"es-ES"}        | ${"es"}
+        ${"de"}           | ${"de"}
+        ${"none-DE"}      | ${defaultLanguage}
+        ${"ro-RO"}        | ${defaultLanguage}
+        ${undefined}      | ${defaultLanguage}
+    `(
+        "getNavigatorLanguage $navigatorLanguage <=> $expected",
+        ({ navigatorLanguage, expected }) => {
+            expect(getNavigatorLanguage(navigatorLanguage)).toEqual(expected);
+        },
+    );
+});

--- a/tests/i18n/detect.spec.js
+++ b/tests/i18n/detect.spec.js
@@ -2,11 +2,15 @@ import { describe, expect } from "vitest";
 import { defaultLanguage } from "../../src/config";
 import { getNavigatorLanguage } from "../../src/i18n/detect";
 
-describe("getNavigatorLanguage", () => {
+describe("detect", () => {
     test.each`
         navigatorLanguage | expected
         ${"en-US"}        | ${"en"}
+        ${"en-UK"}        | ${"en"}
         ${"de-DE"}        | ${"de"}
+        ${"de-AT"}        | ${"de"}
+        ${"de-CH"}        | ${"de"}
+        ${"de-LUX"}       | ${"de"}
         ${"es-ES"}        | ${"es"}
         ${"de"}           | ${"de"}
         ${"none-DE"}      | ${defaultLanguage}


### PR DESCRIPTION
works for chromium, did not work for firefox for me, navigator.language still returned en-EN despite configure it to german. maybe i did something wrong?

detect the `navigator.language` browser language setting and set the wepapps i18n accordingly.
i18n is only saved into localstorage when manually selected and used from there on.

closes #270