### PR TITLE
refactor: show tx links for RSK

### DIFF
--- a/src/Pay.jsx
+++ b/src/Pay.jsx
@@ -71,7 +71,7 @@ const Pay = () => {
     createEffect(() => {
         const tx = swapStatusTransaction();
 
-        if (swap().asset === RBTC && tx) {
+        if (swap().asset === RBTC && tx && swap().claimTx === undefined) {
             setEthereumTransaction(tx.id);
         }
     });

--- a/src/Pay.jsx
+++ b/src/Pay.jsx
@@ -1,17 +1,7 @@
 import log from "loglevel";
-import { Show, createEffect, onCleanup } from "solid-js";
-import {
-    setReverse,
-    setInvoiceQr,
-    swap,
-    setSwap,
-    swapStatus,
-    setSwapStatus,
-    setSwapStatusTransaction,
-    setFailureReason,
-    swaps,
-} from "./signals";
+import { Show, createEffect, createSignal, onCleanup } from "solid-js";
 import t from "./i18n";
+import { RBTC } from "./consts.js";
 import { useParams } from "@solidjs/router";
 import InvoiceSet from "./status/InvoiceSet";
 import SwapCreated from "./status/SwapCreated";
@@ -28,9 +18,25 @@ import TransactionClaimed from "./status/TransactionClaimed";
 import TransactionMempool from "./status/TransactionMempool";
 import TransactionConfirmed from "./status/TransactionConfirmed";
 import TransactionLockupFailed from "./status/TransactionLockupFailed";
+import {
+    swap,
+    swaps,
+    setSwap,
+    setReverse,
+    swapStatus,
+    setInvoiceQr,
+    setSwapStatus,
+    setFailureReason,
+    swapStatusTransaction,
+    setSwapStatusTransaction,
+} from "./signals";
 
 const Pay = () => {
     const params = useParams();
+    const [ethereumTransaction, setEthereumTransaction] =
+        createSignal(undefined);
+    const [ethereumTransactionType, setEthereumTransactionType] =
+        createSignal("lockup_tx");
 
     createEffect(() => {
         let tmpSwaps = swaps();
@@ -59,6 +65,31 @@ const Pay = () => {
                     setInvoiceQr,
                 );
             }
+        }
+    });
+
+    createEffect(() => {
+        const tx = swapStatusTransaction();
+
+        if (swap().asset === RBTC && tx) {
+            setEthereumTransaction(tx.id);
+        }
+    });
+
+    createEffect(() => {
+        const claimTx = swap().claimTx;
+
+        if (swap().asset === RBTC && claimTx) {
+            setEthereumTransaction(claimTx);
+            setEthereumTransactionType("claim_tx");
+        }
+    });
+
+    createEffect(() => {
+        const lockupTx = swap().lockupTx;
+
+        if (swap().asset === RBTC && lockupTx) {
+            setEthereumTransaction(lockupTx);
         }
     });
 
@@ -138,8 +169,10 @@ const Pay = () => {
                     <Show when={swapStatus() == "swap.created"}>
                         <SwapCreated />
                     </Show>
+
                     <Show
                         when={
+                            swap().asset !== RBTC &&
                             swapStatus() !== null &&
                             swapStatus() !== "swap.created"
                         }>
@@ -151,6 +184,17 @@ const Pay = () => {
                                     ? swap().address
                                     : swap().lockupAddress
                             }
+                        />
+                    </Show>
+                    <Show
+                        when={
+                            swap().asset === RBTC &&
+                            ethereumTransaction() !== undefined
+                        }>
+                        <BlockExplorer
+                            asset={swap().asset}
+                            txId={ethereumTransaction()}
+                            typeLabel={ethereumTransactionType()}
                         />
                     </Show>
                 </Show>

--- a/src/components/BlockExplorer.jsx
+++ b/src/components/BlockExplorer.jsx
@@ -1,6 +1,5 @@
 import t from "../i18n";
 import { pairs } from "../config";
-import { createEffect } from "solid-js";
 
 const blockExplorerLink = (asset, isTxId, val) => {
     const basePath = pairs[`${asset}/BTC`].blockExplorerUrl;

--- a/src/components/BlockExplorer.jsx
+++ b/src/components/BlockExplorer.jsx
@@ -1,22 +1,26 @@
 import t from "../i18n";
 import { pairs } from "../config";
+import { createEffect } from "solid-js";
 
 const blockExplorerLink = (asset, isTxId, val) => {
     const basePath = pairs[`${asset}/BTC`].blockExplorerUrl;
     return `${basePath}/${isTxId ? "tx" : "address"}/${val}`;
 };
 
-const BlockExplorer = ({ asset, address, txId, typeLabel }) => {
-    const href =
-        txId !== undefined
-            ? blockExplorerLink(asset, true, txId)
-            : blockExplorerLink(asset, false, address);
-    typeLabel =
-        typeLabel || (txId !== undefined ? "claim_tx" : "lockup_address");
+const BlockExplorer = (props) => {
+    const href = () =>
+        props.txId !== undefined
+            ? blockExplorerLink(props.asset, true, props.txId)
+            : blockExplorerLink(props.asset, false, props.address);
+    const typeLabel = () =>
+        props.typeLabel ||
+        (props.txId !== undefined ? "claim_tx" : "lockup_address");
 
     return (
-        <a class="btn btn-explorer" target="_blank" href={href}>
-            {t("blockexplorer", { typeLabel: t(`blockexplorer_${typeLabel}`) })}
+        <a class="btn btn-explorer" target="_blank" href={href()}>
+            {t("blockexplorer", {
+                typeLabel: t(`blockexplorer_${typeLabel()}`),
+            })}
         </a>
     );
 };

--- a/src/components/ConnectMetamask.jsx
+++ b/src/components/ConnectMetamask.jsx
@@ -27,7 +27,10 @@ const ConnectMetamask = ({ showAddress }) => {
             </Show>
             <Show when={address() !== undefined}>
                 <Show when={showAddress}>
-                    <button onClick={() => setAddress(undefined)} class="btn btn-light" type="text">
+                    <button
+                        onClick={() => setAddress(undefined)}
+                        class="btn btn-light"
+                        type="text">
                         {address() || t("connect_to_address")}
                     </button>
                 </Show>

--- a/src/components/EthereumTransaction.jsx
+++ b/src/components/EthereumTransaction.jsx
@@ -6,6 +6,7 @@ const EthereumTransaction = ({
     promptText,
     buttonText,
     waitingText,
+    showHr,
 }) => {
     const [txSent, setTxSent] = createSignal(false);
 
@@ -21,12 +22,15 @@ const EthereumTransaction = ({
                     }}>
                     {buttonText}
                 </button>
-                <hr />
+                <Show when={showHr}>
+                    <hr />
+                </Show>
             </Show>
 
             <Show when={txSent()}>
                 <p>{waitingText}</p>
                 <LoadingSpinner />
+                <hr />
             </Show>
         </>
     );

--- a/src/configs/config.regtest.js
+++ b/src/configs/config.regtest.js
@@ -1,7 +1,7 @@
 const apiUrl = "http://localhost:9001";
 const blockExplorerUrl = "http://localhost:8090";
 const blockExplorerUrlLiquid = "http://localhost:8091";
-const blockExplorerUrlRsk = "https://explorer.rsk.co";
+const blockExplorerUrlRsk = "http://localhost:8092";
 
 export const defaultLanguage = "en";
 export const network = "regtest";

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -24,6 +24,7 @@ const dict = {
         onion: "Onion",
         blockexplorer: "open {{ typeLabel }}",
         blockexplorer_lockup_address: "lockup address",
+        blockexplorer_lockup_tx: "lockup transaction",
         blockexplorer_claim_tx: "claim transaction",
         blockexplorer_refund_tx: "refund transaction",
         help: "Help",

--- a/src/status/InvoiceSet.jsx
+++ b/src/status/InvoiceSet.jsx
@@ -6,8 +6,15 @@ import { decodeInvoice } from "../utils/validation";
 import { formatAmount } from "../utils/denomination";
 import DownloadRefund from "../components/DownloadRefund";
 import { prefix0x, satoshiToWei } from "../utils/ethereum";
-import { invoiceQr, swap, denomination, asset } from "../signals";
 import EthereumTransaction from "../components/EthereumTransaction.jsx";
+import {
+    swap,
+    asset,
+    swaps,
+    setSwaps,
+    invoiceQr,
+    denomination,
+} from "../signals";
 
 const InvoiceSet = () => {
     if (asset() === RBTC) {
@@ -18,7 +25,7 @@ const InvoiceSet = () => {
                 onClick={async () => {
                     const contract = await getEtherSwap();
 
-                    await contract.lock(
+                    const tx = await contract.lock(
                         prefix0x(decodeInvoice(swap().invoice).preimageHash),
                         swap().claimAddress,
                         swap().timeoutBlockHeight,
@@ -26,10 +33,18 @@ const InvoiceSet = () => {
                             value: satoshiToWei(swap().expectedAmount),
                         },
                     );
+
+                    const swapsTmp = swaps();
+                    const currentSwap = swapsTmp.find(
+                        (s) => swap().id === s.id,
+                    );
+                    currentSwap.lockupTx = tx.hash;
+                    setSwaps(swapsTmp);
                 }}
                 promptText={t("send_prompt")}
                 buttonText={t("send")}
                 waitingText={t("tx_in_mempool_subline")}
+                showHr={false}
             />
         );
     }

--- a/src/status/TransactionConfirmed.jsx
+++ b/src/status/TransactionConfirmed.jsx
@@ -1,7 +1,7 @@
 import t from "../i18n";
 import { RBTC } from "../consts";
-import { asset, swap } from "../signals";
 import { useWeb3Signer } from "../context/Web3";
+import { asset, setSwaps, swap, swaps } from "../signals";
 import LoadingSpinner from "../components/LoadingSpinner";
 import { prefix0x, satoshiToWei } from "../utils/ethereum";
 import EthereumTransaction from "../components/EthereumTransaction.jsx";
@@ -15,16 +15,24 @@ const TransactionConfirmed = () => {
                 onClick={async () => {
                     const contract = await getEtherSwap();
 
-                    await contract.claim(
+                    const tx = await contract.claim(
                         prefix0x(swap().preimage),
                         satoshiToWei(swap().onchainAmount),
                         swap().refundAddress,
                         swap().timeoutBlockHeight,
                     );
+
+                    const swapsTmp = swaps();
+                    const currentSwap = swapsTmp.find(
+                        (s) => swap().id === s.id,
+                    );
+                    currentSwap.claimTx = tx.hash;
+                    setSwaps(swapsTmp);
                 }}
                 buttonText={t("claim")}
                 promptText={t("claim_prompt")}
                 waitingText={t("tx_ready_to_claim")}
+                showHr={true}
             />
         );
     }

--- a/src/utils/swapChecker.js
+++ b/src/utils/swapChecker.js
@@ -6,6 +6,7 @@ import { setSwapStatusAndClaim, getApiUrl, fetcher } from "../helper";
 
 const swapCheckInterval = 3000;
 
+let activeStreamId = undefined;
 let activeSwapStream = undefined;
 
 export const [checkInterval, setCheckInterval] = createSignal(undefined);
@@ -13,10 +14,14 @@ export const [checkInterval, setCheckInterval] = createSignal(undefined);
 export const swapChecker = () => {
     createEffect(() => {
         const activeSwap = swap();
+        if (swap()?.id == activeStreamId) {
+            return;
+        }
 
         if (activeSwapStream !== undefined) {
             activeSwapStream.close();
             activeSwapStream = undefined;
+            activeStreamId = undefined;
         }
 
         if (activeSwap === null) {
@@ -24,6 +29,7 @@ export const swapChecker = () => {
         }
 
         log.debug(`subscribing to SSE of swap`, activeSwap.id);
+        activeStreamId = activeSwap.id;
         activeSwapStream = handleStream(
             `${getApiUrl(activeSwap.asset)}/streamswapstatus?id=${
                 activeSwap.id


### PR DESCRIPTION
It makes no sense to show the contract address for RSK swaps, because every RSK swap uses the same contract address.

So this PR refactors what we show on the block explorer link for RSK swaps, which is either the lockup or claim transaction, whichever is relevant at a given step