### PR TITLE
fix: handle js error when asset is missing on api

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -14,12 +14,13 @@ import {
     setup,
 } from "./compat";
 import { pairs } from "./config";
-import { RBTC } from "./consts";
+import { BTC, RBTC } from "./consts";
 import { ECPair } from "./ecpair/ecpair";
 import {
     asset,
     ref,
     refundAddress,
+    setAsset,
     setConfig,
     setFailureReason,
     setNotification,
@@ -100,7 +101,13 @@ export const errorHandler = (error) => {
 };
 
 export const getApiUrl = (asset) => {
-    return pairs[`${asset}/BTC`].apiUrl;
+    const pair = pairs[`${asset}/BTC`];
+    if (pair) {
+        return pair.apiUrl;
+    }
+
+    log.error(`no pair found for ${asset}; falling back to ${BTC}`);
+    return getApiUrl(BTC);
 };
 
 export const fetcher = (url, cb, params = null, errorCb = errorHandler) => {


### PR DESCRIPTION
and default to BTC/BTC. this only happens while development, running on the mainnet api which is still missing the new asset beeing worked on.