### PR TITLE
fix: failure reason is overwritten

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -176,7 +176,7 @@ export const setSwapStatusAndClaim = (data, activeSwap) => {
         claim(currentSwap);
     }
     checkForFailed(currentSwap, data);
-    setFailureReason(data.failureReason);
+    if (data.failureReason) setFailureReason(data.failureReason);
 };
 
 export async function refund(swap, t) {


### PR DESCRIPTION
fixes: failure reason disappearing on lockup failed status page after a reload