### PR TITLE
feat: deeplinks for wallets

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -160,6 +160,7 @@ const dict = {
         scan_qr_code: "Scan QR Code",
         version: "Version",
         commithash: "Commit Hash",
+        open_in_wallet: "Open in Wallet",
     },
     de: {
         language: "Deutsch",
@@ -329,6 +330,7 @@ const dict = {
         scan_qr_code: "QR Code scannen",
         version: "Version",
         commithash: "Commit Hash",
+        open_in_wallet: "Im Wallet öffnen",
     },
     es: {
         language: "Español",
@@ -497,6 +499,7 @@ const dict = {
         scan_qr_code: "Escanear código QR",
         version: "Versión",
         commithash: "Commit Hash",
+        open_in_wallet: "Abrir en monedero",
     },
     zh: {
         language: "中文",
@@ -651,6 +654,7 @@ const dict = {
         scan_qr_code: "扫描 QR 码",
         version: "版本",
         commithash: "提交哈希",
+        open_in_wallet: "在钱包中打开",
     },
 };
 

--- a/src/pages/Pay.tsx
+++ b/src/pages/Pay.tsx
@@ -163,6 +163,7 @@ const Pay = () => {
                         when={
                             swap().asset !== RBTC &&
                             swapStatus() !== null &&
+                            swapStatus() !== "invoice.set" &&
                             swapStatus() !== "swap.created"
                         }>
                         <BlockExplorer

--- a/src/status/InvoiceSet.tsx
+++ b/src/status/InvoiceSet.tsx
@@ -9,7 +9,7 @@ import { useGlobalContext } from "../context/Global";
 import { usePayContext } from "../context/Pay";
 import { useWeb3Signer } from "../context/Web3";
 import { denominations, formatAmount } from "../utils/denomination";
-import { clipboard, cropString } from "../utils/helper";
+import { clipboard, cropString, isMobile } from "../utils/helper";
 import { decodeInvoice } from "../utils/invoice";
 import { prefix0x, satoshiToWei } from "../utils/rootstock";
 
@@ -64,7 +64,9 @@ const InvoiceSet = () => {
                 })}
             </h2>
             <hr />
-            <QrCode data={swap().reverse ? swap().invoice : swap().bip21} />
+            <a href={swap().bip21}>
+                <QrCode data={swap().bip21} />
+            </a>
             <hr />
             <p
                 onclick={() => clipboard(swap().address)}
@@ -77,9 +79,6 @@ const InvoiceSet = () => {
                 <hr />
             </Show>
             <div class="btns">
-                <span class="btn" onclick={() => clipboard(swap().bip21)}>
-                    {t("copy_bip21")}
-                </span>
                 <span
                     class="btn"
                     onclick={() =>
@@ -92,9 +91,19 @@ const InvoiceSet = () => {
                     }>
                     {t("copy_amount")}
                 </span>
-                <span class="btn" onclick={() => clipboard(swap().address)}>
-                    {t("copy_address")}
+                <Show when={!isMobile}>
+                    <span class="btn" onclick={() => clipboard(swap().address)}>
+                        {t("copy_address")}
+                    </span>
+                </Show>
+                <span class="btn" onclick={() => clipboard(swap().bip21)}>
+                    {t("copy_bip21")}
                 </span>
+                <Show when={isMobile}>
+                    <a href={swap().bip21} class="btn">
+                        {t("open_in_wallet")}
+                    </a>
+                </Show>
             </div>
             <hr />
         </div>

--- a/src/status/InvoiceSet.tsx
+++ b/src/status/InvoiceSet.tsx
@@ -78,6 +78,12 @@ const InvoiceSet = () => {
                 <h3>{t("warning_expiry")}</h3>
                 <hr />
             </Show>
+            <Show when={isMobile}>
+                <a href={swap().bip21} class="btn btn-light">
+                    {t("open_in_wallet")}
+                </a>
+            </Show>
+            <hr />
             <div class="btns">
                 <span
                     class="btn"
@@ -91,21 +97,13 @@ const InvoiceSet = () => {
                     }>
                     {t("copy_amount")}
                 </span>
-                <Show when={!isMobile}>
-                    <span class="btn" onclick={() => clipboard(swap().address)}>
-                        {t("copy_address")}
-                    </span>
-                </Show>
+                <span class="btn" onclick={() => clipboard(swap().address)}>
+                    {t("copy_address")}
+                </span>
                 <span class="btn" onclick={() => clipboard(swap().bip21)}>
                     {t("copy_bip21")}
                 </span>
-                <Show when={isMobile}>
-                    <a href={swap().bip21} class="btn">
-                        {t("open_in_wallet")}
-                    </a>
-                </Show>
             </div>
-            <hr />
         </div>
     );
 };

--- a/src/status/SwapCreated.tsx
+++ b/src/status/SwapCreated.tsx
@@ -53,17 +53,15 @@ const SwapCreated = () => {
                     {t("pay_invoice_webln")}
                 </span>
             </Show>
+            <Show when={isMobile}>
+                <a href={invoicePrefix + swap().invoice} class="btn btn-light">
+                    {t("open_in_wallet")}
+                </a>
+            </Show>
             <hr class="spacer" />
-            <div class="btns">
-                <span class="btn" onclick={() => clipboard(swap().invoice)}>
-                    {t("copy_invoice")}
-                </span>
-                <Show when={isMobile}>
-                    <a href={invoicePrefix + swap().invoice} class="btn">
-                        {t("open_in_wallet")}
-                    </a>
-                </Show>
-            </div>
+            <span class="btn" onclick={() => clipboard(swap().invoice)}>
+                {t("copy_invoice")}
+            </span>
         </div>
     );
 };

--- a/src/status/SwapCreated.tsx
+++ b/src/status/SwapCreated.tsx
@@ -46,7 +46,7 @@ const SwapCreated = () => {
             <hr />
             <h3>{t("warning_return")}</h3>
             <hr />
-            <Show when={webln()}>
+            <Show when={webln() && !isMobile}>
                 <span
                     class="btn btn-light"
                     onClick={() => payWeblnInvoice(swap().invoice)}>

--- a/src/status/SwapCreated.tsx
+++ b/src/status/SwapCreated.tsx
@@ -7,7 +7,8 @@ import { BTC } from "../consts";
 import { useGlobalContext } from "../context/Global";
 import { usePayContext } from "../context/Pay";
 import { denominations, formatAmount } from "../utils/denomination";
-import { clipboard, cropString } from "../utils/helper";
+import { clipboard, cropString, isMobile } from "../utils/helper";
+import { invoicePrefix } from "../utils/invoice";
 import { enableWebln } from "../utils/webln";
 
 const SwapCreated = () => {
@@ -33,7 +34,9 @@ const SwapCreated = () => {
                 })}
             </h2>
             <hr />
-            <QrCode data={swap().reverse ? swap().invoice : swap().bip21} />
+            <a href={invoicePrefix + swap().invoice}>
+                <QrCode data={swap().invoice} />
+            </a>
             <hr />
             <p
                 onclick={() => clipboard(swap().invoice)}
@@ -50,9 +53,17 @@ const SwapCreated = () => {
                     {t("pay_invoice_webln")}
                 </span>
             </Show>
-            <span class="btn" onclick={() => clipboard(swap().invoice)}>
-                {t("copy_invoice")}
-            </span>
+            <hr class="spacer" />
+            <div class="btns">
+                <span class="btn" onclick={() => clipboard(swap().invoice)}>
+                    {t("copy_invoice")}
+                </span>
+                <Show when={isMobile}>
+                    <a href={invoicePrefix + swap().invoice} class="btn">
+                        {t("open_in_wallet")}
+                    </a>
+                </Show>
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
add links on SwapCreated and InvoiceSet on the QR code and as button.

its working for alby on browser for me i did not test bip21 yet.

closes #299

![screenshot-1703075559](https://github.com/BoltzExchange/boltz-web-app/assets/1743657/3e89593c-e6a1-4e16-b1bf-fd8c37c1daa2)


i replaced the copy bip21 for the open in wallet button, usually you don't really want to copy bip21 right? else we get a small ui issue because we have to less room to make it look good.

![screenshot-1704406281](https://github.com/BoltzExchange/boltz-web-app/assets/1743657/28f33111-3fd7-42f3-b1c3-346f33115db4)

