### PR TITLE
chore: update vite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7736,9 +7736,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-            "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+            "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
             "dev": true,
             "dependencies": {
                 "esbuild": "^0.18.10",


### PR DESCRIPTION
security  update