### PR TITLE
feat: amount max/min error should have prio

### DIFF
--- a/src/components/AddressInput.tsx
+++ b/src/components/AddressInput.tsx
@@ -15,7 +15,7 @@ const AddressInput = () => {
         asset,
         assetReceive,
         reverse,
-        sendAmountValid,
+        amountValid,
         onchainAddress,
         setAddressValid,
         setOnchainAddress,
@@ -37,15 +37,17 @@ const AddressInput = () => {
             setAddressValid(false);
             input.classList.add("invalid");
             input.setCustomValidity(msg);
-            setButtonLabel({
-                key: "invalid_address",
-                params: { asset: asset() },
-            });
+            if (amountValid()) {
+                setButtonLabel({
+                    key: "invalid_address",
+                    params: { asset: asset() },
+                });
+            }
         }
     };
 
     createEffect(
-        on([sendAmountValid, onchainAddress, assetReceive], () => {
+        on([amountValid, onchainAddress, assetReceive], () => {
             if (reverse() && asset() !== RBTC) {
                 validateAddress(inputRef);
             }

--- a/src/components/AddressInput.tsx
+++ b/src/components/AddressInput.tsx
@@ -63,6 +63,7 @@ const AddressInput = () => {
             onPaste={(e) => validateAddress(e.currentTarget)}
             type="text"
             id="onchainAddress"
+            data-testid="onchainAddress"
             name="onchainAddress"
             autocomplete="off"
             placeholder={t("onchain_address", { asset: asset() })}

--- a/src/components/ConnectMetamask.tsx
+++ b/src/components/ConnectMetamask.tsx
@@ -10,12 +10,8 @@ const ConnectMetamask = ({ showAddress }) => {
     const [buttonText, setButtonText] = createSignal<string | undefined>();
 
     const { t } = useGlobalContext();
-    const {
-        addressValid,
-        sendAmountValid,
-        setAddressValid,
-        setOnchainAddress,
-    } = useCreateContext();
+    const { addressValid, amountValid, setAddressValid, setOnchainAddress } =
+        useCreateContext();
 
     const setButtonTextAddress = () => {
         setButtonText(address() || t("connect_to_address"));
@@ -32,7 +28,7 @@ const ConnectMetamask = ({ showAddress }) => {
     });
 
     createEffect(() => {
-        if (sendAmountValid() && !addressValid()) {
+        if (amountValid() && !addressValid()) {
             setButtonLabel({ key: "connect_metamask" });
         }
     });

--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -213,6 +213,7 @@ export const CreateButton = () => {
     return (
         <button
             id="create-swap-button"
+            data-testid="create-swap-button"
             class={buttonClass()}
             disabled={buttonDisable() || !online()}
             onClick={buttonClick}>

--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -36,7 +36,7 @@ export const CreateButton = () => {
         receiveAmount,
         reverse,
         sendAmount,
-        sendAmountValid,
+        amountValid,
         setInvoice,
         setInvoiceValid,
         setLnurl,
@@ -50,7 +50,7 @@ export const CreateButton = () => {
     const [buttonClass, setButtonClass] = createSignal("btn");
 
     const validateButtonDisable = () => {
-        return !valid() && !(lnurl() !== "" && sendAmountValid());
+        return !valid() && !(lnurl() !== "" && amountValid());
     };
 
     createEffect(() => {
@@ -75,7 +75,7 @@ export const CreateButton = () => {
     });
 
     const create = async () => {
-        if (sendAmountValid() && !reverse() && lnurl() !== "") {
+        if (amountValid() && !reverse() && lnurl() !== "") {
             try {
                 const inv = await fetchLnurl(lnurl(), Number(receiveAmount()));
                 setInvoice(inv);

--- a/src/components/InvoiceInput.tsx
+++ b/src/components/InvoiceInput.tsx
@@ -22,7 +22,7 @@ const InvoiceInput = () => {
         receiveAmountFormatted,
         reverse,
         sendAmount,
-        sendAmountValid,
+        amountValid,
         setInvoice,
         setInvoiceValid,
         setLnurl,
@@ -57,13 +57,15 @@ const InvoiceInput = () => {
             setInvoiceValid(false);
             setLnurl("");
             input.setCustomValidity(t(e.message));
-            setButtonLabel({ key: e.message });
+            if (amountValid()) {
+                setButtonLabel({ key: e.message });
+            }
             input.classList.add("invalid");
         }
     };
 
     createEffect(
-        on([sendAmountValid, invoice], () => {
+        on([amountValid, invoice], () => {
             if (!reverse() && asset() !== RBTC) {
                 validate(inputRef);
             }

--- a/src/context/Create.tsx
+++ b/src/context/Create.tsx
@@ -12,9 +12,7 @@ import {
 import { pairs } from "../config";
 import { LN, sideSend } from "../consts";
 
-const defaultSelection = Object.keys(pairs)[0].split("/")[0];
-
-const CreateContext = createContext<{
+export type CreateContextType = {
     reverse: Accessor<boolean>;
     setReverse: Setter<boolean>;
     invoice: Accessor<string>;
@@ -59,7 +57,11 @@ const CreateContext = createContext<{
     setBoltzFee: Setter<number>;
     minerFee: Accessor<number>;
     setMinerFee: Setter<number>;
-}>();
+};
+
+const defaultSelection = Object.keys(pairs)[0].split("/")[0];
+
+const CreateContext = createContext<CreateContextType>();
 
 const CreateProvider = (props: { children: any }) => {
     const [asset, setAsset] = createSignal<string>(defaultSelection);

--- a/src/context/Create.tsx
+++ b/src/context/Create.tsx
@@ -39,8 +39,8 @@ const CreateContext = createContext<{
     setInvoiceValid: Setter<boolean>;
     addressValid: Accessor<boolean>;
     setAddressValid: Setter<boolean>;
-    sendAmountValid: Accessor<boolean>;
-    setSendAmountValid: Setter<boolean>;
+    amountValid: Accessor<boolean>;
+    setAmountValid: Setter<boolean>;
     sendAmount: Accessor<BigNumber>;
     setSendAmount: Setter<BigNumber>;
     receiveAmount: Accessor<BigNumber>;
@@ -95,7 +95,7 @@ const CreateProvider = (props: { children: any }) => {
     const [valid, setValid] = createSignal(false);
     const [invoiceValid, setInvoiceValid] = createSignal(false);
     const [addressValid, setAddressValid] = createSignal(false);
-    const [sendAmountValid, setSendAmountValid] = createSignal(true);
+    const [amountValid, setAmountValid] = createSignal(true);
 
     // amounts
     const [sendAmount, setSendAmount] = createSignal(BigNumber(0));
@@ -139,8 +139,8 @@ const CreateProvider = (props: { children: any }) => {
                 setInvoiceValid,
                 addressValid,
                 setAddressValid,
-                sendAmountValid,
-                setSendAmountValid,
+                amountValid,
+                setAmountValid,
                 sendAmount,
                 setSendAmount,
                 receiveAmount,

--- a/src/context/Global.tsx
+++ b/src/context/Global.tsx
@@ -21,13 +21,7 @@ import { swapStatusFinal } from "../utils/swapStatus";
 import { checkWasmSupported } from "../utils/wasmSupport";
 import { detectWebLNProvider } from "../utils/webln";
 
-// Local storage serializer to support the values created by the deprecated "createStorageSignal"
-const stringSerializer = {
-    serialize: (value: any) => value,
-    deserialize: (value: any) => value,
-};
-
-const GlobalContext = createContext<{
+export type GlobalContextType = {
     online: Accessor<boolean>;
     setOnline: Setter<boolean>;
     config: Accessor<Pairs | undefined>;
@@ -67,7 +61,15 @@ const GlobalContext = createContext<{
     notify: (type: string, message: string) => void;
     fetchPairs: (asset?: string) => void;
     updateSwapStatus: (id: string, newStatus: string) => boolean;
-}>();
+};
+
+// Local storage serializer to support the values created by the deprecated "createStorageSignal"
+const stringSerializer = {
+    serialize: (value: any) => value,
+    deserialize: (value: any) => value,
+};
+
+const GlobalContext = createContext<GlobalContextType>();
 
 const GlobalProvider = (props: { children: any }) => {
     const [online, setOnline] = createSignal<boolean>(true);

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -44,7 +44,7 @@ const Create = () => {
         assetSelected,
         invoiceValid,
         addressValid,
-        sendAmountValid,
+        amountValid,
         sendAmount,
         setSendAmount,
         receiveAmount,
@@ -60,7 +60,7 @@ const Create = () => {
         setInvoice,
         setInvoiceValid,
         setValid,
-        setSendAmountValid,
+        setAmountValid,
         boltzFee,
         minerFee,
     } = useCreateContext();
@@ -99,8 +99,6 @@ const Create = () => {
         setReceiveAmount(satAmount);
         setSendAmount(sendAmount);
         validateAmount();
-        target.setCustomValidity("");
-        target.classList.remove("invalid");
     };
 
     const changeSendAmount = (evt: InputEvent) => {
@@ -119,8 +117,6 @@ const Create = () => {
         setSendAmount(satAmount);
         setReceiveAmount(receiveAmount);
         validateAmount();
-        target.setCustomValidity("");
-        target.classList.remove("invalid");
     };
 
     const createWeblnInvoice = async () => {
@@ -188,10 +184,10 @@ const Create = () => {
             const errorMsg = t(label, params);
             setCustomValidity(errorMsg, amount === 0);
             setButtonLabel({ key: label, params: params });
-            setSendAmountValid(false);
+            setAmountValid(false);
             return;
         }
-        setSendAmountValid(true);
+        setAmountValid(true);
     };
 
     const setAmount = (amount: number) => {
@@ -268,7 +264,7 @@ const Create = () => {
 
     // validation swap
     createMemo(() => {
-        if (sendAmountValid()) {
+        if (amountValid()) {
             if (
                 (reverse() && addressValid()) ||
                 (!reverse() &&

--- a/tests/helper.tsx
+++ b/tests/helper.tsx
@@ -1,12 +1,20 @@
 import { Route, Router } from "@solidjs/router";
 
-import { CreateProvider, useCreateContext } from "../src/context/Create";
-import { GlobalProvider, useGlobalContext } from "../src/context/Global";
+import {
+    CreateContextType,
+    CreateProvider,
+    useCreateContext,
+} from "../src/context/Create";
+import {
+    GlobalContextType,
+    GlobalProvider,
+    useGlobalContext,
+} from "../src/context/Global";
 import { PayProvider } from "../src/context/Pay";
 import { Web3SignerProvider } from "../src/context/Web3";
 
-export let signals: any;
-export let globalSignals: any;
+export let signals: CreateContextType;
+export let globalSignals: GlobalContextType;
 
 export const TestComponent = () => {
     signals = useCreateContext();

--- a/tests/pages/Create.spec.tsx
+++ b/tests/pages/Create.spec.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { BigNumber } from "bignumber.js";
 
-import { BTC, sideReceive, sideSend } from "../../src/consts";
+import { BTC, LN, sideReceive, sideSend } from "../../src/consts";
 import i18n from "../../src/i18n/i18n";
 import Create from "../../src/pages/Create";
 import { calculateReceiveAmount } from "../../src/utils/calculate";
@@ -195,5 +195,51 @@ describe("Create", () => {
                 signals.reverse(),
             ),
         );
+    });
+
+    test("should prioritize amount errors", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Create />
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+        globalSignals.setConfig(cfg);
+        signals.setAssetSend(LN);
+        signals.setAssetReceive(BTC);
+
+        const sendAmountInput = await screen.findByTestId("sendAmount");
+        fireEvent.input(sendAmountInput, {
+            target: {
+                value: `${cfg.reverse["BTC"]["BTC"].limits.minimal}`,
+            },
+        });
+
+        const addressButton = await screen.findByTestId("onchainAddress");
+        fireEvent.input(addressButton, {
+            target: {
+                value: "invalid address",
+            },
+        });
+
+        const createButton = (await screen.findByTestId(
+            "create-swap-button",
+        )) as HTMLButtonElement;
+        expect(createButton.disabled).toEqual(true);
+        expect(createButton.innerHTML).toEqual("Invalid BTC address");
+
+        fireEvent.input(sendAmountInput, {
+            target: {
+                value: "1",
+            },
+        });
+
+        expect(createButton.disabled).toEqual(true);
+        expect(createButton.innerHTML).toEqual("Minimum amount is 50000 sat");
     });
 });


### PR DESCRIPTION
closes #482

renamed signal `sendAmountValid` into `amountValid` because it counts for both