### PR TITLE
feat: Implement Satscomma Formatting for Sats Amounts

### DIFF
--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -82,7 +82,7 @@ const Create = () => {
 
     const changeReceiveAmount = (evt: InputEvent) => {
         const target = evt.currentTarget as HTMLInputElement;
-        const amount = target.value.trim();
+        const amount = target.value.trim().replaceAll(' ', '');
         checkEmptyAmount(amount);
         changeDenomination(amount);
         const satAmount = convertAmount(BigNumber(amount), denomination());

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -82,7 +82,7 @@ const Create = () => {
 
     const changeReceiveAmount = (evt: InputEvent) => {
         const target = evt.currentTarget as HTMLInputElement;
-        const amount = target.value.trim().replaceAll(' ', '');
+        const amount = target.value.trim().replaceAll(" ", "");
         checkEmptyAmount(amount);
         changeDenomination(amount);
         const satAmount = convertAmount(BigNumber(amount), denomination());
@@ -100,7 +100,7 @@ const Create = () => {
 
     const changeSendAmount = (evt: InputEvent) => {
         const target = evt.currentTarget as HTMLInputElement;
-        const amount = target.value.trim().replaceAll(' ', '');
+        const amount = target.value.trim().replaceAll(" ", "");
         checkEmptyAmount(amount);
         changeDenomination(amount);
         const satAmount = convertAmount(BigNumber(amount), denomination());

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -100,7 +100,7 @@ const Create = () => {
 
     const changeSendAmount = (evt: InputEvent) => {
         const target = evt.currentTarget as HTMLInputElement;
-        const amount = target.value.trim();
+        const amount = target.value.trim().replaceAll(' ', '');
         checkEmptyAmount(amount);
         changeDenomination(amount);
         const satAmount = convertAmount(BigNumber(amount), denomination());

--- a/src/utils/denomination.ts
+++ b/src/utils/denomination.ts
@@ -84,7 +84,7 @@ export const calculateDigits = (
     if (denomination === denominations.btc && digits < 10) {
         digits = 10;
     } else {
-        digits += 1;
+        digits += 2;
     }
 
     return digits;

--- a/src/utils/denomination.ts
+++ b/src/utils/denomination.ts
@@ -55,7 +55,7 @@ export const formatAmountDenomination = (
     }
 };
 
-const satsComma = (sats: string): string => {
+export const satsComma = (sats: string): string => {
     const chars = sats.split("").reverse();
     const formattedSats: string = chars
         .reduce(

--- a/src/utils/denomination.ts
+++ b/src/utils/denomination.ts
@@ -55,16 +55,19 @@ export const formatAmountDenomination = (
     }
 };
 
-function satsComma(sats: string): string {
-    const chars = sats.split('').reverse();
+const satsComma = (sats: string): string => {
+    const chars = sats.split("").reverse();
     const formattedSats: string = chars
-        .reduce((acc, char, i) => i % 3 === 0 ? acc + ' ' + char : acc + char, '')
+        .reduce(
+            (acc, char, i) => (i % 3 === 0 ? acc + " " + char : acc + char),
+            "",
+        )
         .trim()
-        .split('')
+        .split("")
         .reverse()
-        .join('');
+        .join("");
     return formattedSats;
-}
+};
 
 export const convertAmount = (amount: BigNumber, denom: string): BigNumber => {
     switch (denom) {

--- a/src/utils/denomination.ts
+++ b/src/utils/denomination.ts
@@ -51,22 +51,19 @@ export const formatAmountDenomination = (
             return amountBig.toString();
 
         default:
-            return satsComma(amount.toString());
+            const chars = amount.toString().split("").reverse();
+            const formattedSats: string = chars
+                .reduce(
+                    (acc, char, i) =>
+                        i % 3 === 0 ? acc + " " + char : acc + char,
+                    "",
+                )
+                .trim()
+                .split("")
+                .reverse()
+                .join("");
+            return formattedSats;
     }
-};
-
-export const satsComma = (sats: string): string => {
-    const chars = sats.split("").reverse();
-    const formattedSats: string = chars
-        .reduce(
-            (acc, char, i) => (i % 3 === 0 ? acc + " " + char : acc + char),
-            "",
-        )
-        .trim()
-        .split("")
-        .reverse()
-        .join("");
-    return formattedSats;
 };
 
 export const convertAmount = (amount: BigNumber, denom: string): BigNumber => {
@@ -86,8 +83,12 @@ export const calculateDigits = (
     let digits = maximum.toString().length;
     if (denomination === denominations.btc && digits < 10) {
         digits = 10;
+    } else if (denomination === denominations.btc) {
+        // account for decimal point
+        digits += 1;
     } else {
-        digits += 2;
+        // account for spaces
+        digits += Math.floor((digits - 1) / 3);
     }
 
     return digits;

--- a/src/utils/denomination.ts
+++ b/src/utils/denomination.ts
@@ -11,11 +11,10 @@ export const getValidationRegex = (
     maximum: number,
     denomination: string,
 ): RegExp => {
-    const digits = calculateDigits(maximum, denomination);
     const regex =
         denomination === denominations.sat
-            ? `^[0-9]{1,${digits}}$`
-            : `^[0-9](.[0-9]{1,${digits}}){0,1}$`;
+            ? `^[0-9]{1,${maximum.toString().length}}$`
+            : `^[0-9](.[0-9]{1,10}){0,1}$`;
     return new RegExp(regex);
 };
 

--- a/src/utils/denomination.ts
+++ b/src/utils/denomination.ts
@@ -51,9 +51,20 @@ export const formatAmountDenomination = (
             return amountBig.toString();
 
         default:
-            return amount.toString();
+            return satsComma(amount.toString());
     }
 };
+
+function satsComma(sats: string): string {
+    const chars = sats.split('').reverse();
+    const formattedSats: string = chars
+        .reduce((acc, char, i) => i % 3 === 0 ? acc + ' ' + char : acc + char, '')
+        .trim()
+        .split('')
+        .reverse()
+        .join('');
+    return formattedSats;
+}
 
 export const convertAmount = (amount: BigNumber, denom: string): BigNumber => {
     switch (denom) {

--- a/tests/pages/Create.spec.tsx
+++ b/tests/pages/Create.spec.tsx
@@ -12,6 +12,7 @@ import {
     globalSignals,
     signals,
 } from "../helper";
+import { satsComma } from "../../src/utils/denomination";
 
 describe("Create", () => {
     test("should render Create", async () => {
@@ -184,7 +185,7 @@ describe("Create", () => {
         const amount =
             extrema === "min" ? signals.minimum() : signals.maximum();
 
-        fireEvent.click(await screen.findByText(amount));
+        fireEvent.click(await screen.findByText(satsComma(amount.toString())));
 
         expect(signals.sendAmount()).toEqual(BigNumber(amount));
         expect(signals.receiveAmount()).toEqual(
@@ -240,6 +241,6 @@ describe("Create", () => {
         });
 
         expect(createButton.disabled).toEqual(true);
-        expect(createButton.innerHTML).toEqual("Minimum amount is 50000 sat");
+        expect(createButton.innerHTML).toEqual("Minimum amount is 50 000 sat");
     });
 });

--- a/tests/pages/Create.spec.tsx
+++ b/tests/pages/Create.spec.tsx
@@ -5,6 +5,7 @@ import { BTC, LN, sideReceive, sideSend } from "../../src/consts";
 import i18n from "../../src/i18n/i18n";
 import Create from "../../src/pages/Create";
 import { calculateReceiveAmount } from "../../src/utils/calculate";
+import { satsComma } from "../../src/utils/denomination";
 import { cfg } from "../config";
 import {
     TestComponent,
@@ -12,7 +13,6 @@ import {
     globalSignals,
     signals,
 } from "../helper";
-import { satsComma } from "../../src/utils/denomination";
 
 describe("Create", () => {
     test("should render Create", async () => {

--- a/tests/pages/Create.spec.tsx
+++ b/tests/pages/Create.spec.tsx
@@ -167,7 +167,7 @@ describe("Create", () => {
         extrema
         ${"min"}
         ${"max"}
-    `("should set $extrema amount on click", async (extrema) => {
+    `("should set $extrema amount on click", async ({ extrema }) => {
         render(
             () => (
                 <>

--- a/tests/pages/Create.spec.tsx
+++ b/tests/pages/Create.spec.tsx
@@ -5,7 +5,7 @@ import { BTC, LN, sideReceive, sideSend } from "../../src/consts";
 import i18n from "../../src/i18n/i18n";
 import Create from "../../src/pages/Create";
 import { calculateReceiveAmount } from "../../src/utils/calculate";
-import { satsComma } from "../../src/utils/denomination";
+import { denominations, formatAmount } from "../../src/utils/denomination";
 import { cfg } from "../config";
 import {
     TestComponent,
@@ -185,7 +185,11 @@ describe("Create", () => {
         const amount =
             extrema === "min" ? signals.minimum() : signals.maximum();
 
-        fireEvent.click(await screen.findByText(satsComma(amount.toString())));
+        const formattedAmount = formatAmount(
+            BigNumber(amount),
+            denominations.sat,
+        );
+        fireEvent.click(await screen.findByText(formattedAmount));
 
         expect(signals.sendAmount()).toEqual(BigNumber(amount));
         expect(signals.receiveAmount()).toEqual(

--- a/tests/utils/denomination.spec.ts
+++ b/tests/utils/denomination.spec.ts
@@ -52,18 +52,18 @@ describe("denomination utils", () => {
     describe("calculate allowed digits", () => {
         test.each`
             denomination         | digits | amount
-            ${denominations.sat} | ${6}   | ${1000}
-            ${denominations.sat} | ${8}   | ${100000}
-            ${denominations.sat} | ${11}  | ${100000000}
-            ${denominations.sat} | ${12}  | ${1000000000}
-            ${denominations.sat} | ${13}  | ${10000000000}
-            ${denominations.btc} | ${10}  | ${1000}
-            ${denominations.btc} | ${10}  | ${100000}
-            ${denominations.btc} | ${10}  | ${10000000}
-            ${denominations.btc} | ${10}  | ${100000000}
-            ${denominations.btc} | ${12}  | ${1000000000}
-            ${denominations.btc} | ${13}  | ${10000000000}
-            ${denominations.btc} | ${14}  | ${100000000000}
+            ${denominations.sat} | ${5}   | ${1_000}
+            ${denominations.sat} | ${7}   | ${100_000}
+            ${denominations.sat} | ${11}  | ${100_000_000}
+            ${denominations.sat} | ${13}  | ${1_000_000_000}
+            ${denominations.sat} | ${14}  | ${10_000_000_000}
+            ${denominations.btc} | ${10}  | ${1_000}
+            ${denominations.btc} | ${10}  | ${100_000}
+            ${denominations.btc} | ${10}  | ${10_000_000}
+            ${denominations.btc} | ${10}  | ${100_000_000}
+            ${denominations.btc} | ${11}  | ${1_000_000_000}
+            ${denominations.btc} | ${12}  | ${10_000_000_000}
+            ${denominations.btc} | ${13}  | ${100_000_000_000}
         `(
             "calculate digits for $amount in $denomination",
             ({ denomination, digits, amount }) => {

--- a/tests/utils/denomination.spec.ts
+++ b/tests/utils/denomination.spec.ts
@@ -30,8 +30,8 @@ describe("denomination utils", () => {
     describe("format amount", () => {
         test.each`
             denomination         | amount         | formatted
-            ${denominations.sat} | ${123123}      | ${"123123"}
-            ${denominations.sat} | ${12312300000} | ${"12312300000"}
+            ${denominations.sat} | ${123123}      | ${"123 123"}
+            ${denominations.sat} | ${12312300000} | ${"12 312 300 000"}
             ${denominations.btc} | ${100123123}   | ${"1.00123123"}
             ${denominations.btc} | ${123123}      | ${"0.00123123"}
             ${denominations.btc} | ${1}           | ${"0.00000001"}
@@ -52,18 +52,18 @@ describe("denomination utils", () => {
     describe("calculate allowed digits", () => {
         test.each`
             denomination         | digits | amount
-            ${denominations.sat} | ${5}   | ${1000}
-            ${denominations.sat} | ${7}   | ${100000}
-            ${denominations.sat} | ${10}  | ${100000000}
-            ${denominations.sat} | ${11}  | ${1000000000}
-            ${denominations.sat} | ${12}  | ${10000000000}
+            ${denominations.sat} | ${6}   | ${1000}
+            ${denominations.sat} | ${8}   | ${100000}
+            ${denominations.sat} | ${11}  | ${100000000}
+            ${denominations.sat} | ${12}  | ${1000000000}
+            ${denominations.sat} | ${13}  | ${10000000000}
             ${denominations.btc} | ${10}  | ${1000}
             ${denominations.btc} | ${10}  | ${100000}
             ${denominations.btc} | ${10}  | ${10000000}
             ${denominations.btc} | ${10}  | ${100000000}
-            ${denominations.btc} | ${11}  | ${1000000000}
-            ${denominations.btc} | ${12}  | ${10000000000}
-            ${denominations.btc} | ${13}  | ${100000000000}
+            ${denominations.btc} | ${12}  | ${1000000000}
+            ${denominations.btc} | ${13}  | ${10000000000}
+            ${denominations.btc} | ${14}  | ${100000000000}
         `(
             "calculate digits for $amount in $denomination",
             ({ denomination, digits, amount }) => {
@@ -78,7 +78,7 @@ describe("denomination utils", () => {
         test.each`
             denomination         | amount                  | valid
             ${denominations.sat} | ${"123123"}             | ${true}
-            ${denominations.sat} | ${"12312300000"}        | ${false}
+            ${denominations.sat} | ${"12312300000"}        | ${true}
             ${denominations.sat} | ${max}                  | ${true}
             ${denominations.sat} | ${"lol"}                | ${false}
             ${denominations.btc} | ${"lol"}                | ${false}

--- a/tests/utils/denomination.spec.ts
+++ b/tests/utils/denomination.spec.ts
@@ -78,8 +78,8 @@ describe("denomination utils", () => {
         test.each`
             denomination         | amount                  | valid
             ${denominations.sat} | ${"123123"}             | ${true}
-            ${denominations.sat} | ${"12312300000"}        | ${true}
             ${denominations.sat} | ${max}                  | ${true}
+            ${denominations.sat} | ${max * 10}             | ${false}
             ${denominations.sat} | ${"lol"}                | ${false}
             ${denominations.btc} | ${"lol"}                | ${false}
             ${denominations.btc} | ${"123123"}             | ${true}


### PR DESCRIPTION
**Description:**

This PR introduces the satcomma standard for formatting sats amounts. You can read [Bitcoin Magazine's 2021 article](https://bitcoinmagazine.com/culture/satcomma-standard-look-at-bitcoin-this) on the subject if you're not familiar with it.

The satcomma standard promotes readability and clarity when dealing with satoshis, by inserting a separator such as spaces or commas every three digits, starting from the decimal point for BTC values or from the least significant digit for satoshi amounts.

**Reasoning:**

- **User Experience**: Improving the way sats amounts are displayed can enhance the user experience, making it easier for users to verify amounts at a glance without counting digits
- **Standardization** - Satscomma is a standard recommended by [bitcoin.design](https://bitcoin.design/guide/designing-products/units-and-symbols/#satcomma)
- **Future-Proof**: As Bitcoin's adoption grows, and transactions in satoshis become more common, having a clear and consistent formatting standard will become increasingly important.