### PR TITLE
chore: use compareTrees function from boltz-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@bitcoinerlab/secp256k1": "^1.1.1",
                 "@fontsource/noto-sans": "^5.0.21",
-                "@scure/base": "^1.1.5",
+                "@scure/base": "^1.1.6",
                 "@solid-primitives/i18n": "^2.1.1",
                 "@solid-primitives/storage": "^2.1.4",
                 "@solidjs/router": "^0.13.1",
@@ -18,7 +18,7 @@
                 "bignumber.js": "^9.1.2 ",
                 "bitcoinjs-lib": "^6.1.5",
                 "bolt11": "^1.4.1",
-                "boltz-core": "^2.1.1",
+                "boltz-core": "^2.1.2",
                 "buffer": "^6.0.3",
                 "create-hmac": "^1.1.7",
                 "ecpair": "^2.1.0",
@@ -29,12 +29,12 @@
                 "qr-scanner": "^1.4.2",
                 "qrcode": "^1.5.3",
                 "solid-icons": "^1.1.0",
-                "solid-js": "^1.8.15"
+                "solid-js": "^1.8.16"
             },
             "devDependencies": {
-                "@babel/core": "^7.24.1",
+                "@babel/core": "^7.24.3",
                 "@babel/plugin-transform-modules-commonjs": "^7.24.1",
-                "@babel/preset-env": "^7.24.1",
+                "@babel/preset-env": "^7.24.3",
                 "@babel/preset-typescript": "^7.24.1",
                 "@solidjs/testing-library": "^0.8.6",
                 "@testing-library/jest-dom": "^6.4.2",
@@ -44,7 +44,7 @@
                 "@webbtc/webln-types": "^3.0.0",
                 "babel-jest": "^29.7.0",
                 "babel-preset-jest": "^29.6.3",
-                "babel-preset-solid": "^1.8.15",
+                "babel-preset-solid": "^1.8.16",
                 "eventsource": "^2.0.2",
                 "git-cliff": "^2.1.2",
                 "jest": "^29.7.0",
@@ -53,9 +53,9 @@
                 "prettier": "^3.2.5",
                 "sass": "^1.72.0",
                 "solid-jest": "^0.2.0",
-                "typescript": "^5.4.2",
-                "vite": "^5.1.6",
-                "vite-plugin-mkcert": "^1.17.4",
+                "typescript": "^5.4.3",
+                "vite": "^5.2.4",
+                "vite-plugin-mkcert": "^1.17.5",
                 "vite-plugin-node-polyfills": "^0.21.0",
                 "vite-plugin-solid": "^2.10.2"
             }
@@ -107,13 +107,13 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.1.tgz",
-            "integrity": "sha512-F82udohVyIgGAY2VVj/g34TpFUG606rumIHjTfVbssPg2zTR7PuuEpZcX8JA6sgBfIYmJrFtWgPvHQuJamVqZQ==",
+            "version": "7.24.3",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.3.tgz",
+            "integrity": "sha512-5FcvN1JHw2sHJChotgx8Ek0lyuh4kCKelgMTTqhYJJtloNvUfpAFMeNQUtdlIaktwrSV9LtCdqwk48wL2wBacQ==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.24.1",
+                "@babel/code-frame": "^7.24.2",
                 "@babel/generator": "^7.24.1",
                 "@babel/helper-compilation-targets": "^7.23.6",
                 "@babel/helper-module-transforms": "^7.23.3",
@@ -892,9 +892,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-generator-functions": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.24.1.tgz",
-            "integrity": "sha512-OTkLJM0OtmzcpOgF7MREERUCdCnCBtBsq3vVFbuq/RKMK0/jdYqdMexWi3zNs7Nzd95ase65MbTGrpFJflOb6A==",
+            "version": "7.24.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.24.3.tgz",
+            "integrity": "sha512-Qe26CMYVjpQxJ8zxM1340JFNjZaF+ISWpr1Kt/jGo+ZTUzKkfw/pphEWbRCb+lmSM6k/TOgfYLvmbHkUQ0asIg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.22.20",
@@ -1666,9 +1666,9 @@
             }
         },
         "node_modules/@babel/preset-env": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.1.tgz",
-            "integrity": "sha512-CwCMz1Z28UHLI2iE+cbnWT2epPMV9bzzoBGM6A3mOS22VQd/1TPoWItV7S7iL9TkPmPEf5L/QzurmztyyDN9FA==",
+            "version": "7.24.3",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.3.tgz",
+            "integrity": "sha512-fSk430k5c2ff8536JcPvPWK4tZDwehWLGlBp0wrsBUjZVdeQV6lePbwKWZaZfK2vnh/1kQX1PzAJWsnBmVgGJA==",
             "dev": true,
             "dependencies": {
                 "@babel/compat-data": "^7.24.1",
@@ -1698,7 +1698,7 @@
                 "@babel/plugin-syntax-top-level-await": "^7.14.5",
                 "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
                 "@babel/plugin-transform-arrow-functions": "^7.24.1",
-                "@babel/plugin-transform-async-generator-functions": "^7.24.1",
+                "@babel/plugin-transform-async-generator-functions": "^7.24.3",
                 "@babel/plugin-transform-async-to-generator": "^7.24.1",
                 "@babel/plugin-transform-block-scoped-functions": "^7.24.1",
                 "@babel/plugin-transform-block-scoping": "^7.24.1",
@@ -1747,7 +1747,7 @@
                 "@babel/plugin-transform-unicode-sets-regex": "^7.24.1",
                 "@babel/preset-modules": "0.1.6-no-external-plugins",
                 "babel-plugin-polyfill-corejs2": "^0.4.10",
-                "babel-plugin-polyfill-corejs3": "^0.10.1",
+                "babel-plugin-polyfill-corejs3": "^0.10.4",
                 "babel-plugin-polyfill-regenerator": "^0.6.1",
                 "core-js-compat": "^3.31.0",
                 "semver": "^6.3.1"
@@ -1880,9 +1880,9 @@
             "integrity": "sha512-AM7vFNwSD7B4XI6yeRKccWbbD/lvwoFr8U3pqhzryBQo4uMkYe5V3/kMVnml4SNuxzyqdIFu4ur3TId02sC33A=="
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
-            "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+            "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
             "cpu": [
                 "ppc64"
             ],
@@ -1896,9 +1896,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
-            "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+            "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
             "cpu": [
                 "arm"
             ],
@@ -1912,9 +1912,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
-            "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+            "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
             "cpu": [
                 "arm64"
             ],
@@ -1928,9 +1928,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
-            "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+            "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
             "cpu": [
                 "x64"
             ],
@@ -1944,9 +1944,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
-            "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+            "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
             "cpu": [
                 "arm64"
             ],
@@ -1960,9 +1960,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
-            "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+            "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
             "cpu": [
                 "x64"
             ],
@@ -1976,9 +1976,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
-            "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+            "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
             "cpu": [
                 "arm64"
             ],
@@ -1992,9 +1992,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
-            "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+            "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
             "cpu": [
                 "x64"
             ],
@@ -2008,9 +2008,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
-            "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+            "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
             "cpu": [
                 "arm"
             ],
@@ -2024,9 +2024,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
-            "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+            "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
             "cpu": [
                 "arm64"
             ],
@@ -2040,9 +2040,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
-            "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+            "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
             "cpu": [
                 "ia32"
             ],
@@ -2056,9 +2056,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
-            "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+            "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
             "cpu": [
                 "loong64"
             ],
@@ -2072,9 +2072,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
-            "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+            "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
             "cpu": [
                 "mips64el"
             ],
@@ -2088,9 +2088,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
-            "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+            "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
             "cpu": [
                 "ppc64"
             ],
@@ -2104,9 +2104,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
-            "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+            "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
             "cpu": [
                 "riscv64"
             ],
@@ -2120,9 +2120,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
-            "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+            "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
             "cpu": [
                 "s390x"
             ],
@@ -2136,9 +2136,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
-            "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+            "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
             "cpu": [
                 "x64"
             ],
@@ -2152,9 +2152,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
-            "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+            "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
             "cpu": [
                 "x64"
             ],
@@ -2168,9 +2168,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
-            "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+            "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
             "cpu": [
                 "x64"
             ],
@@ -2184,9 +2184,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
-            "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+            "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
             "cpu": [
                 "x64"
             ],
@@ -2200,9 +2200,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
-            "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+            "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2216,9 +2216,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
-            "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+            "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
             "cpu": [
                 "ia32"
             ],
@@ -2232,9 +2232,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
-            "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+            "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
             "cpu": [
                 "x64"
             ],
@@ -3324,9 +3324,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.2.tgz",
-            "integrity": "sha512-RKzxFxBHq9ysZ83fn8Iduv3A283K7zPPYuhL/z9CQuyFrjwpErJx0h4aeb/bnJ+q29GRLgJpY66ceQ/Wcsn3wA==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.13.0.tgz",
+            "integrity": "sha512-5ZYPOuaAqEH/W3gYsRkxQATBW3Ii1MfaT4EQstTnLKViLi2gLSQmlmtTpGucNP3sXEpOiI5tdGhjdE111ekyEg==",
             "cpu": [
                 "arm"
             ],
@@ -3337,9 +3337,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.2.tgz",
-            "integrity": "sha512-yZ+MUbnwf3SHNWQKJyWh88ii2HbuHCFQnAYTeeO1Nb8SyEiWASEi5dQUygt3ClHWtA9My9RQAYkjvrsZ0WK8Xg==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.13.0.tgz",
+            "integrity": "sha512-BSbaCmn8ZadK3UAQdlauSvtaJjhlDEjS5hEVVIN3A4bbl3X+otyf/kOJV08bYiRxfejP3DXFzO2jz3G20107+Q==",
             "cpu": [
                 "arm64"
             ],
@@ -3350,9 +3350,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.2.tgz",
-            "integrity": "sha512-vqJ/pAUh95FLc/G/3+xPqlSBgilPnauVf2EXOQCZzhZJCXDXt/5A8mH/OzU6iWhb3CNk5hPJrh8pqJUPldN5zw==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.13.0.tgz",
+            "integrity": "sha512-Ovf2evVaP6sW5Ut0GHyUSOqA6tVKfrTHddtmxGQc1CTQa1Cw3/KMCDEEICZBbyppcwnhMwcDce9ZRxdWRpVd6g==",
             "cpu": [
                 "arm64"
             ],
@@ -3363,9 +3363,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.2.tgz",
-            "integrity": "sha512-otPHsN5LlvedOprd3SdfrRNhOahhVBwJpepVKUN58L0RnC29vOAej1vMEaVU6DadnpjivVsNTM5eNt0CcwTahw==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.13.0.tgz",
+            "integrity": "sha512-U+Jcxm89UTK592vZ2J9st9ajRv/hrwHdnvyuJpa5A2ngGSVHypigidkQJP+YiGL6JODiUeMzkqQzbCG3At81Gg==",
             "cpu": [
                 "x64"
             ],
@@ -3376,9 +3376,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.2.tgz",
-            "integrity": "sha512-ewG5yJSp+zYKBYQLbd1CUA7b1lSfIdo9zJShNTyc2ZP1rcPrqyZcNlsHgs7v1zhgfdS+kW0p5frc0aVqhZCiYQ==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.13.0.tgz",
+            "integrity": "sha512-8wZidaUJUTIR5T4vRS22VkSMOVooG0F4N+JSwQXWSRiC6yfEsFMLTYRFHvby5mFFuExHa/yAp9juSphQQJAijQ==",
             "cpu": [
                 "arm"
             ],
@@ -3389,9 +3389,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.2.tgz",
-            "integrity": "sha512-pL6QtV26W52aCWTG1IuFV3FMPL1m4wbsRG+qijIvgFO/VBsiXJjDPE/uiMdHBAO6YcpV4KvpKtd0v3WFbaxBtg==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.13.0.tgz",
+            "integrity": "sha512-Iu0Kno1vrD7zHQDxOmvweqLkAzjxEVqNhUIXBsZ8hu8Oak7/5VTPrxOEZXYC1nmrBVJp0ZcL2E7lSuuOVaE3+w==",
             "cpu": [
                 "arm64"
             ],
@@ -3402,9 +3402,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.2.tgz",
-            "integrity": "sha512-On+cc5EpOaTwPSNetHXBuqylDW+765G/oqB9xGmWU3npEhCh8xu0xqHGUA+4xwZLqBbIZNcBlKSIYfkBm6ko7g==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.13.0.tgz",
+            "integrity": "sha512-C31QrW47llgVyrRjIwiOwsHFcaIwmkKi3PCroQY5aVq4H0A5v/vVVAtFsI1nfBngtoRpeREvZOkIhmRwUKkAdw==",
             "cpu": [
                 "arm64"
             ],
@@ -3415,9 +3415,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.2.tgz",
-            "integrity": "sha512-Wnx/IVMSZ31D/cO9HSsU46FjrPWHqtdF8+0eyZ1zIB5a6hXaZXghUKpRrC4D5DcRTZOjml2oBhXoqfGYyXKipw==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.13.0.tgz",
+            "integrity": "sha512-Oq90dtMHvthFOPMl7pt7KmxzX7E71AfyIhh+cPhLY9oko97Zf2C9tt/XJD4RgxhaGeAraAXDtqxvKE1y/j35lA==",
             "cpu": [
                 "riscv64"
             ],
@@ -3428,9 +3428,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.2.tgz",
-            "integrity": "sha512-ym5x1cj4mUAMBummxxRkI4pG5Vht1QMsJexwGP8547TZ0sox9fCLDHw9KCH9c1FO5d9GopvkaJsBIOkTKxksdw==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.13.0.tgz",
+            "integrity": "sha512-yUD/8wMffnTKuiIsl6xU+4IA8UNhQ/f1sAnQebmE/lyQ8abjsVyDkyRkWop0kdMhKMprpNIhPmYlCxgHrPoXoA==",
             "cpu": [
                 "x64"
             ],
@@ -3441,9 +3441,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.2.tgz",
-            "integrity": "sha512-m0hYELHGXdYx64D6IDDg/1vOJEaiV8f1G/iO+tejvRCJNSwK4jJ15e38JQy5Q6dGkn1M/9KcyEOwqmlZ2kqaZg==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.13.0.tgz",
+            "integrity": "sha512-9RyNqoFNdF0vu/qqX63fKotBh43fJQeYC98hCaf89DYQpv+xu0D8QFSOS0biA7cGuqJFOc1bJ+m2rhhsKcw1hw==",
             "cpu": [
                 "x64"
             ],
@@ -3454,9 +3454,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.2.tgz",
-            "integrity": "sha512-x1CWburlbN5JjG+juenuNa4KdedBdXLjZMp56nHFSHTOsb/MI2DYiGzLtRGHNMyydPGffGId+VgjOMrcltOksA==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.13.0.tgz",
+            "integrity": "sha512-46ue8ymtm/5PUU6pCvjlic0z82qWkxv54GTJZgHrQUuZnVH+tvvSP0LsozIDsCBFO4VjJ13N68wqrKSeScUKdA==",
             "cpu": [
                 "arm64"
             ],
@@ -3467,9 +3467,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.2.tgz",
-            "integrity": "sha512-VVzCB5yXR1QlfsH1Xw1zdzQ4Pxuzv+CPr5qpElpKhVxlxD3CRdfubAG9mJROl6/dmj5gVYDDWk8sC+j9BI9/kQ==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.13.0.tgz",
+            "integrity": "sha512-P5/MqLdLSlqxbeuJ3YDeX37srC8mCflSyTrUsgbU1c/U9j6l2g2GiIdYaGD9QjdMQPMSgYm7hgg0551wHyIluw==",
             "cpu": [
                 "ia32"
             ],
@@ -3480,9 +3480,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.2.tgz",
-            "integrity": "sha512-SYRedJi+mweatroB+6TTnJYLts0L0bosg531xnQWtklOI6dezEagx4Q0qDyvRdK+qgdA3YZpjjGuPFtxBmddBA==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.13.0.tgz",
+            "integrity": "sha512-UKXUQNbO3DOhzLRwHSpa0HnhhCgNODvfoPWv2FCXme8N/ANFfhIPMGuOT+QuKd16+B5yxZ0HdpNlqPvTMS1qfw==",
             "cpu": [
                 "x64"
             ],
@@ -3493,9 +3493,9 @@
             ]
         },
         "node_modules/@scure/base": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
-            "integrity": "sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.6.tgz",
+            "integrity": "sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==",
             "funding": {
                 "url": "https://paulmillr.com/funding/"
             }
@@ -4259,12 +4259,12 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.6.7",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-            "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+            "version": "1.6.8",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+            "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
             "dev": true,
             "dependencies": {
-                "follow-redirects": "^1.15.4",
+                "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
             }
@@ -4392,9 +4392,9 @@
             }
         },
         "node_modules/babel-plugin-jsx-dom-expressions": {
-            "version": "0.37.17",
-            "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.37.17.tgz",
-            "integrity": "sha512-1bv8rOTzs6TR3DVyVZ7ElxyPEhnS556FMWRIsB3gBPfkn/cSKaLvXLGk+X1lvI+SzcUo4G+UcmJrn3vr1ig8mQ==",
+            "version": "0.37.19",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.37.19.tgz",
+            "integrity": "sha512-nef2eLpWBgFggwrYwN6O3dNKn3RnlX6n4DIamNEAeHwp03kVQUaKUiLaEPnHPJHwxie1KwPelyIY9QikU03vUA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-module-imports": "7.18.6",
@@ -4434,13 +4434,13 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs3": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.1.tgz",
-            "integrity": "sha512-XiFei6VGwM4ii6nKC1VCenGD8Z4bjiNYcrdkM8oqM3pbuemmyb8biMgrDX1ZHSbIuMLXatM6JJ/StPYIuTl6MQ==",
+            "version": "0.10.4",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.4.tgz",
+            "integrity": "sha512-25J6I8NGfa5YkCDogHRID3fVCadIR8/pGl1/spvCkzb6lVn6SR3ojpx9nOn9iEBcUsjY24AmdKm5khcfKdylcg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-define-polyfill-provider": "^0.6.1",
-                "core-js-compat": "^3.36.0"
+                "core-js-compat": "^3.36.1"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -4498,12 +4498,12 @@
             }
         },
         "node_modules/babel-preset-solid": {
-            "version": "1.8.15",
-            "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.8.15.tgz",
-            "integrity": "sha512-P2yOQbB7Hn/m4YvpXV6ExHIMcgNWXWXcvY4kJzG3yqAB3hKS58OZRsvJ7RObsZWqXRvZTITBIwnpK0BMGu+ZIQ==",
+            "version": "1.8.16",
+            "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.8.16.tgz",
+            "integrity": "sha512-b4HFg/xaKM+H3Tu5iUlZ/43TJOZnhi85xrm3JrXDQ0s4cmtmU37bXXYzb2m55G4QKiFjxLAjvb7sUorPrAMs5w==",
             "dev": true,
             "dependencies": {
-                "babel-plugin-jsx-dom-expressions": "^0.37.17"
+                "babel-plugin-jsx-dom-expressions": "^0.37.19"
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0"
@@ -4709,12 +4709,12 @@
             "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
         "node_modules/boltz-core": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/boltz-core/-/boltz-core-2.1.1.tgz",
-            "integrity": "sha512-nbbMQbWcpJKoPvf1KNKZOlcOoflIrcretVhdt4rQ+QXVRULj+lCbl8t3FCfYLNKurWxl7OC3j/f+ILFCU7tkIw==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/boltz-core/-/boltz-core-2.1.2.tgz",
+            "integrity": "sha512-b19P5dFIWl/bf/sqBlSRbTj7+/48hWaTUfR1qVkWaPr+OR1T0gNuYP86EOi3yQwR689GxXk0adeV5rKc9ue3Xw==",
             "dependencies": {
                 "@boltz/bitcoin-ops": "^2.0.0",
-                "@openzeppelin/contracts": "^5.0.1",
+                "@openzeppelin/contracts": "^5.0.2",
                 "@vulpemventures/secp256k1-zkp": "^3.2.1",
                 "bip32": "^4.0.0",
                 "bip65": "^1.0.3",
@@ -5771,9 +5771,9 @@
             "dev": true
         },
         "node_modules/esbuild": {
-            "version": "0.19.12",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
-            "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+            "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
             "dev": true,
             "hasInstallScript": true,
             "bin": {
@@ -5783,29 +5783,29 @@
                 "node": ">=12"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.19.12",
-                "@esbuild/android-arm": "0.19.12",
-                "@esbuild/android-arm64": "0.19.12",
-                "@esbuild/android-x64": "0.19.12",
-                "@esbuild/darwin-arm64": "0.19.12",
-                "@esbuild/darwin-x64": "0.19.12",
-                "@esbuild/freebsd-arm64": "0.19.12",
-                "@esbuild/freebsd-x64": "0.19.12",
-                "@esbuild/linux-arm": "0.19.12",
-                "@esbuild/linux-arm64": "0.19.12",
-                "@esbuild/linux-ia32": "0.19.12",
-                "@esbuild/linux-loong64": "0.19.12",
-                "@esbuild/linux-mips64el": "0.19.12",
-                "@esbuild/linux-ppc64": "0.19.12",
-                "@esbuild/linux-riscv64": "0.19.12",
-                "@esbuild/linux-s390x": "0.19.12",
-                "@esbuild/linux-x64": "0.19.12",
-                "@esbuild/netbsd-x64": "0.19.12",
-                "@esbuild/openbsd-x64": "0.19.12",
-                "@esbuild/sunos-x64": "0.19.12",
-                "@esbuild/win32-arm64": "0.19.12",
-                "@esbuild/win32-ia32": "0.19.12",
-                "@esbuild/win32-x64": "0.19.12"
+                "@esbuild/aix-ppc64": "0.20.2",
+                "@esbuild/android-arm": "0.20.2",
+                "@esbuild/android-arm64": "0.20.2",
+                "@esbuild/android-x64": "0.20.2",
+                "@esbuild/darwin-arm64": "0.20.2",
+                "@esbuild/darwin-x64": "0.20.2",
+                "@esbuild/freebsd-arm64": "0.20.2",
+                "@esbuild/freebsd-x64": "0.20.2",
+                "@esbuild/linux-arm": "0.20.2",
+                "@esbuild/linux-arm64": "0.20.2",
+                "@esbuild/linux-ia32": "0.20.2",
+                "@esbuild/linux-loong64": "0.20.2",
+                "@esbuild/linux-mips64el": "0.20.2",
+                "@esbuild/linux-ppc64": "0.20.2",
+                "@esbuild/linux-riscv64": "0.20.2",
+                "@esbuild/linux-s390x": "0.20.2",
+                "@esbuild/linux-x64": "0.20.2",
+                "@esbuild/netbsd-x64": "0.20.2",
+                "@esbuild/openbsd-x64": "0.20.2",
+                "@esbuild/sunos-x64": "0.20.2",
+                "@esbuild/win32-arm64": "0.20.2",
+                "@esbuild/win32-ia32": "0.20.2",
+                "@esbuild/win32-x64": "0.20.2"
             }
         },
         "node_modules/escalade": {
@@ -10402,9 +10402,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
-            "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
+            "version": "8.4.38",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+            "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
             "dev": true,
             "funding": [
                 {
@@ -10423,7 +10423,7 @@
             "dependencies": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
+                "source-map-js": "^1.2.0"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -10834,10 +10834,13 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.2.tgz",
-            "integrity": "sha512-66RB8OtFKUTozmVEh3qyNfH+b+z2RXBVloqO2KCC/pjFaGaHtxP9fVfOQKPSGXg2mElmjmxjW/fZ7iKrEpMH5Q==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.13.0.tgz",
+            "integrity": "sha512-3YegKemjoQnYKmsBlOHfMLVPPA5xLkQ8MHLLSw/fBrFaVkEayL51DilPpNNLq1exr98F2B1TzrV0FUlN3gWRPg==",
             "dev": true,
+            "dependencies": {
+                "@types/estree": "1.0.5"
+            },
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
@@ -10846,19 +10849,19 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.9.2",
-                "@rollup/rollup-android-arm64": "4.9.2",
-                "@rollup/rollup-darwin-arm64": "4.9.2",
-                "@rollup/rollup-darwin-x64": "4.9.2",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.9.2",
-                "@rollup/rollup-linux-arm64-gnu": "4.9.2",
-                "@rollup/rollup-linux-arm64-musl": "4.9.2",
-                "@rollup/rollup-linux-riscv64-gnu": "4.9.2",
-                "@rollup/rollup-linux-x64-gnu": "4.9.2",
-                "@rollup/rollup-linux-x64-musl": "4.9.2",
-                "@rollup/rollup-win32-arm64-msvc": "4.9.2",
-                "@rollup/rollup-win32-ia32-msvc": "4.9.2",
-                "@rollup/rollup-win32-x64-msvc": "4.9.2",
+                "@rollup/rollup-android-arm-eabi": "4.13.0",
+                "@rollup/rollup-android-arm64": "4.13.0",
+                "@rollup/rollup-darwin-arm64": "4.13.0",
+                "@rollup/rollup-darwin-x64": "4.13.0",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.13.0",
+                "@rollup/rollup-linux-arm64-gnu": "4.13.0",
+                "@rollup/rollup-linux-arm64-musl": "4.13.0",
+                "@rollup/rollup-linux-riscv64-gnu": "4.13.0",
+                "@rollup/rollup-linux-x64-gnu": "4.13.0",
+                "@rollup/rollup-linux-x64-musl": "4.13.0",
+                "@rollup/rollup-win32-arm64-msvc": "4.13.0",
+                "@rollup/rollup-win32-ia32-msvc": "4.13.0",
+                "@rollup/rollup-win32-x64-msvc": "4.13.0",
                 "fsevents": "~2.3.2"
             }
         },
@@ -11401,12 +11404,12 @@
             }
         },
         "node_modules/solid-js": {
-            "version": "1.8.15",
-            "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.8.15.tgz",
-            "integrity": "sha512-d0QP/efr3UVcwGgWVPveQQ0IHOH6iU7yUhc2piy8arNG8wxKmvUy1kFxyF8owpmfCWGB87usDKMaVnsNYZm+Vw==",
+            "version": "1.8.16",
+            "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.8.16.tgz",
+            "integrity": "sha512-rja94MNU9flF3qQRLNsu60QHKBDKBkVE1DldJZPIfn2ypIn3NV2WpSbGTQIvsyGPBo+9E2IMjwqnqpbgfWuzeg==",
             "dependencies": {
                 "csstype": "^3.1.0",
-                "seroval": "^1.0.3",
+                "seroval": "^1.0.4",
                 "seroval-plugins": "^1.0.3"
             }
         },
@@ -11434,9 +11437,9 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -11796,9 +11799,9 @@
             "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
         },
         "node_modules/typescript": {
-            "version": "5.4.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-            "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+            "version": "5.4.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+            "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -11966,14 +11969,14 @@
             }
         },
         "node_modules/vite": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.6.tgz",
-            "integrity": "sha512-yYIAZs9nVfRJ/AiOLCA91zzhjsHUgMjB+EigzFb6W2XTLO8JixBCKCjvhKZaye+NKYHCrkv3Oh50dH9EdLU2RA==",
+            "version": "5.2.4",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.4.tgz",
+            "integrity": "sha512-vjFghvHWidBTinu5TCymJk/lRHlR5ljqB83yugr0HA1xspUPdOZHqbqDLnZ8f9/jINrtFHTCYYyIUi+o+Q5iyg==",
             "dev": true,
             "dependencies": {
-                "esbuild": "^0.19.3",
-                "postcss": "^8.4.35",
-                "rollup": "^4.2.0"
+                "esbuild": "^0.20.1",
+                "postcss": "^8.4.36",
+                "rollup": "^4.13.0"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -12021,13 +12024,13 @@
             }
         },
         "node_modules/vite-plugin-mkcert": {
-            "version": "1.17.4",
-            "resolved": "https://registry.npmjs.org/vite-plugin-mkcert/-/vite-plugin-mkcert-1.17.4.tgz",
-            "integrity": "sha512-P/B/tXhsUdpFO4Go1f2obu8WL3xxA3lbsbz4YzflbWfqWl15uwFiXaiCCBztJu1f4WnilrdXYihGrGT9jU743A==",
+            "version": "1.17.5",
+            "resolved": "https://registry.npmjs.org/vite-plugin-mkcert/-/vite-plugin-mkcert-1.17.5.tgz",
+            "integrity": "sha512-KKGY3iHx/9zb7ow8JJ+nLN2HiNIBuPBwj34fJ+jAJT89/8qfk7msO7G7qipR8VDEm9xMCys0xT11QOJbZcg3/Q==",
             "dev": true,
             "dependencies": {
                 "@octokit/rest": "^20.0.2",
-                "axios": "^1.6.5",
+                "axios": "^1.6.8",
                 "debug": "^4.3.4",
                 "picocolors": "^1.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
         "changelog": "git-cliff -o CHANGELOG.md"
     },
     "devDependencies": {
-        "@babel/core": "^7.24.1",
+        "@babel/core": "^7.24.3",
         "@babel/plugin-transform-modules-commonjs": "^7.24.1",
-        "@babel/preset-env": "^7.24.1",
+        "@babel/preset-env": "^7.24.3",
         "@babel/preset-typescript": "^7.24.1",
         "@solidjs/testing-library": "^0.8.6",
         "@testing-library/jest-dom": "^6.4.2",
@@ -30,7 +30,7 @@
         "@webbtc/webln-types": "^3.0.0",
         "babel-jest": "^29.7.0",
         "babel-preset-jest": "^29.6.3",
-        "babel-preset-solid": "^1.8.15",
+        "babel-preset-solid": "^1.8.16",
         "eventsource": "^2.0.2",
         "git-cliff": "^2.1.2",
         "jest": "^29.7.0",
@@ -39,16 +39,16 @@
         "prettier": "^3.2.5",
         "sass": "^1.72.0",
         "solid-jest": "^0.2.0",
-        "typescript": "^5.4.2",
-        "vite": "^5.1.6",
-        "vite-plugin-mkcert": "^1.17.4",
+        "typescript": "^5.4.3",
+        "vite": "^5.2.4",
+        "vite-plugin-mkcert": "^1.17.5",
         "vite-plugin-node-polyfills": "^0.21.0",
         "vite-plugin-solid": "^2.10.2"
     },
     "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.1.1",
         "@fontsource/noto-sans": "^5.0.21",
-        "@scure/base": "^1.1.5",
+        "@scure/base": "^1.1.6",
         "@solid-primitives/i18n": "^2.1.1",
         "@solid-primitives/storage": "^2.1.4",
         "@solidjs/router": "^0.13.1",
@@ -56,7 +56,7 @@
         "bignumber.js": "^9.1.2 ",
         "bitcoinjs-lib": "^6.1.5",
         "bolt11": "^1.4.1",
-        "boltz-core": "^2.1.1",
+        "boltz-core": "^2.1.2",
         "buffer": "^6.0.3",
         "create-hmac": "^1.1.7",
         "ecpair": "^2.1.0",
@@ -67,6 +67,6 @@
         "qr-scanner": "^1.4.2",
         "qrcode": "^1.5.3",
         "solid-icons": "^1.1.0",
-        "solid-js": "^1.8.15"
+        "solid-js": "^1.8.16"
     }
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -4,6 +4,7 @@ import {
     Scripts,
     SwapTreeSerializer,
     Types,
+    compareTrees,
     reverseSwapTree,
     swapTree,
 } from "boltz-core";
@@ -52,19 +53,6 @@ type SwapResponseLiquid = SwapResponse & {
 };
 
 type ContractGetter = () => Promise<BaseContract>;
-
-const compareTrees = (
-    tree: Types.SwapTree,
-    compare: Types.SwapTree,
-): boolean => {
-    const compareLeaf = (leaf: Types.Tapleaf, compareLeaf: Types.Tapleaf) =>
-        leaf.version === compareLeaf.version &&
-        leaf.output.equals(compareLeaf.output);
-
-    return (tree.tree as Types.Tapleaf[]).every((leaf, i) =>
-        compareLeaf(leaf, compare.tree[i] as Types.Tapleaf),
-    );
-};
 
 const validateContract = async (getEtherSwap: ContractGetter) => {
     const code = await (await getEtherSwap()).getDeployedCode();


### PR DESCRIPTION
This PR updates some dependencies, including boltz-core to be able to use the new [`compareTrees`](https://github.com/BoltzExchange/boltz-core/commit/ce129faed3c3914358e5b697a4d1e4d612e711e7) function in v2.1.2