### PR TITLE
bug: catch exception on refund page

### DIFF
--- a/src/pages/Refund.tsx
+++ b/src/pages/Refund.tsx
@@ -131,8 +131,8 @@ const Refund = () => {
                         await getSubmarineTransaction(swap.asset, swap.id);
                         addToRefundableSwaps(swap);
                     }
-                } catch (_) {
-                    log.warn("failed to get swap status", swap.id);
+                } catch (e) {
+                    log.warn("failed to get swap status", swap.id, e);
                 }
             });
     });

--- a/src/pages/Refund.tsx
+++ b/src/pages/Refund.tsx
@@ -116,19 +116,23 @@ const Refund = () => {
                         undefined,
             )
             .map(async (swap) => {
-                const res = await getSwapStatus(swap.asset, swap.id);
-                if (
-                    !updateSwapStatus(swap.id, res.status) &&
-                    Object.values(swapStatusFailed).includes(res.status)
-                ) {
-                    if (res.status !== swapStatusFailed.SwapExpired) {
-                        addToRefundableSwaps(swap);
-                        return;
-                    }
+                try {
+                    const res = await getSwapStatus(swap.asset, swap.id);
+                    if (
+                        !updateSwapStatus(swap.id, res.status) &&
+                        Object.values(swapStatusFailed).includes(res.status)
+                    ) {
+                        if (res.status !== swapStatusFailed.SwapExpired) {
+                            addToRefundableSwaps(swap);
+                            return;
+                        }
 
-                    // Make sure coins were locked for the swap with status "swap.expired"
-                    await getSubmarineTransaction(swap.asset, swap.id);
-                    addToRefundableSwaps(swap);
+                        // Make sure coins were locked for the swap with status "swap.expired"
+                        await getSubmarineTransaction(swap.asset, swap.id);
+                        addToRefundableSwaps(swap);
+                    }
+                } catch (_) {
+                    // do nothing, there is already a request error in the console
                 }
             });
     });

--- a/src/pages/Refund.tsx
+++ b/src/pages/Refund.tsx
@@ -132,7 +132,7 @@ const Refund = () => {
                         addToRefundableSwaps(swap);
                     }
                 } catch (_) {
-                    // do nothing, there is already a request error in the console
+                    log.warn("failed to get swap status", swap.id);
                 }
             });
     });


### PR DESCRIPTION
![screenshot-1711526219](https://github.com/BoltzExchange/boltz-web-app/assets/1743657/d0d5d1ef-0444-41b1-95df-50ba438f732d)

happened if status returned a 404, request errors are already logged so do nothing. ps. this should never happen in production :)