### PR TITLE
bug: remove spaces from copy sat amount

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -10,7 +10,7 @@ const CopyButton = ({ data, label }) => {
     const [buttonClass, setButtonClass] = createSignal<string>("btn");
     const [buttonActive, setButtonActive] = createSignal<boolean>(false);
     const onClick = () => {
-        clipboard(data);
+        clipboard(data.replaceAll(" ", ""));
         setButtonClass("btn btn-active");
         setButtonActive(true);
         setTimeout(() => {

--- a/tests/components/CopyButton.spec.tsx
+++ b/tests/components/CopyButton.spec.tsx
@@ -22,7 +22,7 @@ describe("CopyButton", () => {
             wrapper: contextWrapper,
         });
 
-        let btn = button as HTMLSpanElement;
+        const btn = button as HTMLSpanElement;
 
         expect(btn).not.toBeUndefined();
         expect(btn.textContent).toEqual(i18n.en.copy_bip21);
@@ -32,7 +32,8 @@ describe("CopyButton", () => {
         expect(btn.classList.contains("btn-active")).toBeFalsy();
         expect(navigator.clipboard.writeText).toHaveBeenCalledWith(textToCopy);
     });
-    test("dont copy spaces", async () => {
+
+    test("should not copy spaces", async () => {
         const textToCopy = "50 000";
         const expectedCopy = "50000";
 
@@ -42,7 +43,7 @@ describe("CopyButton", () => {
             wrapper: contextWrapper,
         });
 
-        let btn = button as HTMLSpanElement;
+        const btn = button as HTMLSpanElement;
         fireEvent.click(btn);
         expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
             expectedCopy,

--- a/tests/components/CopyButton.spec.tsx
+++ b/tests/components/CopyButton.spec.tsx
@@ -32,4 +32,20 @@ describe("CopyButton", () => {
         expect(btn.classList.contains("btn-active")).toBeFalsy();
         expect(navigator.clipboard.writeText).toHaveBeenCalledWith(textToCopy);
     });
+    test("dont copy spaces", async () => {
+        const textToCopy = "50 000";
+        const expectedCopy = "50000";
+
+        const {
+            container: { firstChild: button },
+        } = render(() => <CopyButton label="copy_bip21" data={textToCopy} />, {
+            wrapper: contextWrapper,
+        });
+
+        let btn = button as HTMLSpanElement;
+        fireEvent.click(btn);
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+            expectedCopy,
+        );
+    });
 });


### PR DESCRIPTION
should have spaces in sat amount when copying.
spaces can be safely replaced for all copies, its never valid