### PR TITLE
refactor: use a for swap history links

### DIFF
--- a/src/components/SwapList.tsx
+++ b/src/components/SwapList.tsx
@@ -1,26 +1,15 @@
-import { useNavigate } from "@solidjs/router";
-import {
-    Accessor,
-    For,
-    Setter,
-    Show,
-    createMemo,
-    createSignal,
-} from "solid-js";
+import { Accessor, For, Show, createMemo, createSignal } from "solid-js";
 
 import { useGlobalContext } from "../context/Global";
 import "../style/swaplist.scss";
 
 const SwapList = ({
     swapsSignal,
-    setSwapSignal,
     onDelete,
 }: {
     swapsSignal: Accessor<any[]>;
-    setSwapSignal?: Setter<any[]>;
     onDelete?: () => Promise<any>;
 }) => {
-    const navigate = useNavigate();
     const { deleteSwap, t } = useGlobalContext();
     const [sortedSwaps, setSortedSwaps] = createSignal([]);
     const [lastSwap, setLastSwap] = createSignal();
@@ -52,11 +41,9 @@ const SwapList = ({
                 {(swap) => (
                     <>
                         <div class="swaplist-item">
-                            <span
-                                class="btn-small"
-                                onClick={() => navigate("/swap/" + swap.id)}>
+                            <a class="btn-small" href={`/swap/${swap.id}`}>
                                 {t("view")}
-                            </span>
+                            </a>
                             <span
                                 data-reverse={swap.reverse}
                                 data-asset={swap.asset}

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -158,6 +158,7 @@ hr.spacer {
     border-radius: 7px;
     padding: 0 6px;
     cursor: pointer;
+    text-decoration: none;
 }
 
 [data-status="swap.expired"] .btn-small,

--- a/tests/components/SwapList.spec.tsx
+++ b/tests/components/SwapList.spec.tsx
@@ -18,17 +18,9 @@ describe("SwapList", () => {
 
         const {
             container: { firstChild: firstChild },
-        } = render(
-            () => (
-                <SwapList
-                    swapsSignal={swapsSignal}
-                    setSwapSignal={() => {
-                        return undefined;
-                    }}
-                />
-            ),
-            { wrapper: contextWrapper },
-        );
+        } = render(() => <SwapList swapsSignal={swapsSignal} />, {
+            wrapper: contextWrapper,
+        });
 
         const childNodes = [];
         firstChild.childNodes.forEach((node) => {


### PR DESCRIPTION
Uses `<a>` for the links in the swap history, so that they can be clicked with Ctrl + click and open in a new tab. Useful for when you are searching for a specific swap so just open buncha tabs from your history and scroll through them instead of going back and forth. Should be safe to have lots of tabs open now, that we fixed the race condition.

Also removes an unused property from `SwapList`