### PR TITLE
fix: small number BTC denomination

### DIFF
--- a/src/utils/denomination.ts
+++ b/src/utils/denomination.ts
@@ -40,11 +40,11 @@ export const formatAmountDenomination = (
             if (amountBig.isZero()) {
                 amountString = amountBig.toFixed(1);
             }
+
             // 0.00000001.toString() returns "1e-8"
             // 0.0000001.toString() returns "1e-7"
             if (amountBig.toString().indexOf("-") !== -1) {
-                const digits = amountBig.toString().slice(-1);
-                amountString = amountBig.toFixed(Number(digits));
+                amountString = amountBig.toFixed(Number(8)).replace(/0+$/, "");
             }
 
             if (separator === ",") {

--- a/tests/utils/denomination.spec.ts
+++ b/tests/utils/denomination.spec.ts
@@ -36,6 +36,7 @@ describe("denomination utils", () => {
             ${denominations.btc} | ${123123}      | ${"."}    | ${"0.00123123"}
             ${denominations.btc} | ${1}           | ${"."}    | ${"0.00000001"}
             ${denominations.btc} | ${10}          | ${"."}    | ${"0.0000001"}
+            ${denominations.btc} | ${14}          | ${"."}    | ${"0.00000014"}
             ${denominations.btc} | ${100}         | ${"."}    | ${"0.000001"}
             ${denominations.btc} | ${1000}        | ${"."}    | ${"0.00001"}
             ${denominations.btc} | ${10000}       | ${"."}    | ${"0.0001"}


### PR DESCRIPTION
Really small numbers, eg 14 sats, got converted to 0.0000001 BTC, which is not correct. This PR changes the way we handle scientific notation when converting to string to fix that