### PR TITLE
Allow unconfidential addresses again

### DIFF
--- a/src/components/Fees.tsx
+++ b/src/components/Fees.tsx
@@ -3,6 +3,7 @@ import { createEffect } from "solid-js";
 
 import btcSvg from "../assets/btc.svg";
 import satSvg from "../assets/sat.svg";
+import { LBTC } from "../consts";
 import { useCreateContext } from "../context/Create";
 import { useGlobalContext } from "../context/Global";
 import {
@@ -13,6 +14,7 @@ import {
     calculateBoltzFeeOnSend,
     calculateSendAmount,
 } from "../utils/calculate";
+import { isConfidentialAddress } from "../utils/compat";
 import { denominations, formatAmount } from "../utils/denomination";
 import { getPair } from "../utils/helper";
 
@@ -29,6 +31,8 @@ const Fees = () => {
         setMinerFee,
         boltzFee,
         setBoltzFee,
+        onchainAddress,
+        addressValid,
     } = useCreateContext();
 
     createEffect(() => {
@@ -38,9 +42,17 @@ const Fees = () => {
             if (reverse()) {
                 const reverseCfg = cfg as ReversePairTypeTaproot;
 
-                const fee =
+                let fee =
                     reverseCfg.fees.minerFees.claim +
                     reverseCfg.fees.minerFees.lockup;
+
+                if (
+                    asset() === LBTC &&
+                    addressValid() &&
+                    !isConfidentialAddress(onchainAddress())
+                ) {
+                    fee += 1;
+                }
 
                 setBoltzFee(reverseCfg.fees.percentage);
                 setMinerFee(fee);

--- a/src/utils/compat.ts
+++ b/src/utils/compat.ts
@@ -86,6 +86,16 @@ const decodeAddress = (asset: string, addr: string): DecodedAddress => {
     };
 };
 
+export const isConfidentialAddress = (addr: string): boolean => {
+    try {
+        const address = getAddress(LBTC);
+        (address as typeof LiquidAddress).fromConfidential(addr);
+        return true;
+    } catch (e) {
+        return false;
+    }
+};
+
 const probeUserInputOption = (asset: string, input: string): boolean => {
     switch (asset) {
         case LN:
@@ -171,7 +181,10 @@ const getConstructClaimTransaction = (asset: string) => {
     };
 };
 
-const getConstructRefundTransaction = (asset: string) => {
+const getConstructRefundTransaction = (
+    asset: string,
+    addOneSatBuffer: boolean,
+) => {
     const fn = asset === LBTC ? lcRT : constructRefundTransaction;
     return (
         refundDetails: RefundDetails[] | LiquidRefundDetails[],
@@ -187,7 +200,7 @@ const getConstructRefundTransaction = (asset: string) => {
                 refundDetails as any[],
                 outputScript,
                 timeoutBlockHeight,
-                fee,
+                addOneSatBuffer ? fee + 1 : fee,
                 isRbf,
                 liquidNetwork,
                 blindingKey,

--- a/src/utils/compat.ts
+++ b/src/utils/compat.ts
@@ -68,14 +68,17 @@ const decodeAddress = (asset: string, addr: string): DecodedAddress => {
     );
 
     if (asset === LBTC) {
-        const decoded = (address as typeof LiquidAddress).fromConfidential(
-            addr,
-        );
+        // This throws for unconfidential addresses -> fallback to output script decoding
+        try {
+            const decoded = (address as typeof LiquidAddress).fromConfidential(
+                addr,
+            );
 
-        return {
-            script,
-            blindingKey: decoded.blindingKey,
-        };
+            return {
+                script,
+                blindingKey: decoded.blindingKey,
+            };
+        } catch (e) {}
     }
 
     return {

--- a/src/utils/refund.ts
+++ b/src/utils/refund.ts
@@ -58,6 +58,7 @@ const refundTaproot = async (
 
     const constructRefundTransaction = getConstructRefundTransaction(
         swap.asset,
+        swap.asset === LBTC && decodedAddress.blindingKey === undefined,
     );
     const claimTx = constructRefundTransaction(
         details,
@@ -103,8 +104,7 @@ export async function refund(
 
     const assetName = swap.asset;
 
-    let output: DecodedAddress;
-    output = decodeAddress(assetName, refundAddress);
+    const output = decodeAddress(assetName, refundAddress);
     log.info("refunding swap: ", swap.id);
     await setup();
 
@@ -131,8 +131,10 @@ export async function refund(
         const swapOutput = detectSwap(redeemScript, tx);
         log.debug("swapOutput", swapOutput);
 
-        const constructRefundTransaction =
-            getConstructRefundTransaction(assetName);
+        const constructRefundTransaction = getConstructRefundTransaction(
+            assetName,
+            swap.asset === LBTC && output.blindingKey === undefined,
+        );
         refundTransaction = constructRefundTransaction(
             [
                 {

--- a/tests/components/AddressInput.spec.tsx
+++ b/tests/components/AddressInput.spec.tsx
@@ -20,9 +20,9 @@ describe("AddressInput", () => {
         ${true}  | ${LBTC} | ${"CTEyTteD4cQg2NfF1yGWUU1rWSDC8sKHrj5BZJzr8kzyKFXwNCJ8VyDhi45Q98KdSf3jeTkbjJy18JkP"}
         ${true}  | ${LBTC} | ${"AzpjfmC41JpC6ieu3odwFBqtF4isFeY8RHv1e699EM2RgiyHd49og66a8qLLMDrhL8pCLeWAxJat1ebD"}
         ${true}  | ${LBTC} | ${"el1qqt7nl8pw6278yxv38fezzw8lmqh40prpusfurcvsh2xn3sl0pvnz3whllcapdnxcxn2u0wumpu7u2u6anh2juvmz7spx6snmn"}
-        ${false} | ${LBTC} | ${"2do9j7MdMJSVKWosUmcLzhoR8E5mhabtUju"}
-        ${false} | ${LBTC} | ${"XUWfSHgUE1G72X9oGHXfecgzgf1N5A7WD2"}
-        ${false} | ${LBTC} | ${"ert1qhtlluwskenvrf4w8hwds70w9wdwem4fwsd0pk8"}
+        ${true}  | ${LBTC} | ${"2do9j7MdMJSVKWosUmcLzhoR8E5mhabtUju"}
+        ${true}  | ${LBTC} | ${"XUWfSHgUE1G72X9oGHXfecgzgf1N5A7WD2"}
+        ${true}  | ${LBTC} | ${"ert1qhtlluwskenvrf4w8hwds70w9wdwem4fwsd0pk8"}
     `(
         "should validate address $network $address -> $valid",
         async ({ valid, network, address }) => {

--- a/tests/components/Fees.spec.tsx
+++ b/tests/components/Fees.spec.tsx
@@ -2,23 +2,17 @@ import { render } from "@solidjs/testing-library";
 import { BigNumber } from "bignumber.js";
 
 import Fees from "../../src/components/Fees";
-import { BTC } from "../../src/consts";
-import { useCreateContext } from "../../src/context/Create";
-import { useGlobalContext } from "../../src/context/Global";
+import { BTC, LBTC } from "../../src/consts";
 import { calculateSendAmount } from "../../src/utils/calculate";
-import { contextWrapper } from "../helper";
+import {
+    TestComponent,
+    contextWrapper,
+    globalSignals,
+    signals,
+} from "../helper";
 import { pairs } from "../pairs";
 
 describe("Fees component", () => {
-    let signals: any;
-    let globalSignals: any;
-
-    const TestComponent = () => {
-        signals = useCreateContext();
-        globalSignals = useGlobalContext();
-        return "";
-    };
-
     test("should render", async () => {
         render(
             () => (
@@ -68,6 +62,30 @@ describe("Fees component", () => {
                 signals.minerFee(),
                 signals.reverse(),
             ).toNumber(),
+        );
+    });
+
+    test("should increase the miner fee by 1 when sending to an unconfidential Liquid address", () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Fees />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+        globalSignals.setPairs(pairs);
+        signals.setAsset(LBTC);
+        signals.setReverse(true);
+        signals.setAddressValid(true);
+        signals.setOnchainAddress(
+            "ert1q2vf850cshpedhvn9x0lv33j8az4ela04afuzp0",
+        );
+
+        const fees = pairs.reverse[BTC][LBTC].fees;
+        expect(signals.minerFee()).toEqual(
+            fees.minerFees.lockup + fees.minerFees.claim + 1,
         );
     });
 });

--- a/tests/utils/compat.spec.ts
+++ b/tests/utils/compat.spec.ts
@@ -31,6 +31,9 @@ describe("parse network correctly", () => {
         ${LBTC} | ${"el1qq2yjqfz9evc3c5m0rzw0cdtfcdfl5kmcf9xsskpsgza34zhezxzq7y6y4dnldxhtd935k8dn63n8cywy3jlzuvftycsmytjmu"}
         ${LBTC} | ${"AzppAMAawpcRLuVGJVec1EmDQPubCprhC8wTrKvLeYC9s73W4jpGN1sDaKs76y5ndvJ1k8ZBcNm8gtxo"}
         ${LBTC} | ${"CTEwXiS8q9to1ES8GifsLYkiv2FKmuMKMeHAiiyumH5DJzowybcEaAUyYtENoG9EKzgapFP3FhoMpbHs"}
+        ${LBTC} | ${"ert1qzdz2kelknt4kjc6trkeagenuz8zge03wc88dqw"}
+        ${LBTC} | ${"XRPsyVYUGJpRhwoBLZAoqSdxLLqvdyoNN9"}
+        ${LBTC} | ${"2ddhmWyNVftuDm6o23hL8pxvmmCQUH2pN96"}
         ${LN}   | ${"lnbcrt4294u1pjlmqy7pp5g9tj83k3k54ajzktdv8dq5nqsc8336j4f0v3wphq37x8hklntsxsdqqcqzzsxqyz5vqsp53qupg459fzdhajwjmzs8vd3elge0rmkzkmrmnpeuwy6kme47ns4q9qyyssqvncgzrmmghmtxu9m7wvw0yvtgckz4078xwam7exjpka2c89ga0y3jenhv6hhzuccj9hkl7a7f20nuslh3wqa4lfduq76ycxaf3w56zcq32d5fv"}
         ${LN}   | ${"LNURL1DP68GURN8GHJ7MRWW4EXCTNDD93KSCT9DSCNQVF39ESHGTMPWP5J7MRWW4EXCUQGY84ZH"}
         ${LN}   | ${"admin@bol.tz"}
@@ -39,16 +42,4 @@ describe("parse network correctly", () => {
             expect(probeUserInput(expectedAsset, input)).toEqual(asset);
         }
     });
-
-    test.each`
-        input
-        ${"ert1qzdz2kelknt4kjc6trkeagenuz8zge03wc88dqw"}
-        ${"XRPsyVYUGJpRhwoBLZAoqSdxLLqvdyoNN9"}
-        ${"2ddhmWyNVftuDm6o23hL8pxvmmCQUH2pN96"}
-    `(
-        "should not allow unconfidential Liquid address $input",
-        ({ input, asset }) => {
-            expect(probeUserInput(LBTC, input)).toEqual(null);
-        },
-    );
 });

--- a/tests/utils/compat.spec.ts
+++ b/tests/utils/compat.spec.ts
@@ -3,7 +3,11 @@ import { initEccLib, networks } from "bitcoinjs-lib";
 import { networks as LiquidNetworks } from "liquidjs-lib";
 
 import { BTC, LBTC, LN } from "../../src/consts";
-import { getNetwork, probeUserInput } from "../../src/utils/compat";
+import {
+    getNetwork,
+    isConfidentialAddress,
+    probeUserInput,
+} from "../../src/utils/compat";
 
 describe("parse network correctly", () => {
     beforeAll(() => {
@@ -42,4 +46,15 @@ describe("parse network correctly", () => {
             expect(probeUserInput(expectedAsset, input)).toEqual(asset);
         }
     });
+
+    test.each`
+        addr                                                                                                       | expected
+        ${"el1qqtwazfjrctweqy8lzg4k7as5y2c5ea3dqnvgqmrzd6s8yvmftn8v65cj0gl3pwrjmwex2vl7erry069tnl6l2u5junx22mnra"} | ${true}
+        ${"ert1q2vf850cshpedhvn9x0lv33j8az4ela04afuzp0"}                                                           | ${false}
+    `(
+        "should detect if Liquid address $addr is confidential",
+        ({ addr, expected }) => {
+            expect(isConfidentialAddress(addr)).toEqual(expected);
+        },
+    );
 });

--- a/tests/utils/validation.spec.ts
+++ b/tests/utils/validation.spec.ts
@@ -263,24 +263,15 @@ describe("validate onchain addresses", () => {
         asset   | address
         ${BTC}  | ${"moEsJRFF6y3d5oSjHj6GBocVPw2GEeQ6WY"}
         ${BTC}  | ${"bcrt1q78qtnjrt53gauk6h2w32wane62jjg2gvval6w5"}
+        ${LBTC} | ${"XaGQJMVzMDn7DNwKtRA9fJVEVkxVE1FjgW"}
+        ${LBTC} | ${"2dsdhiFYQADKEEkcdafMXcGtSL96HSmsr16"}
         ${LBTC} | ${"CTEr9psVs76yrPL9PNrcSNx3Es1tC4EyboR4rtXYJguB6oFZWAUy3Kw7jSLTLee3xoiZc3fjsCi93Kfg"}
         ${LBTC} | ${"AzpoeCb1nyd1D3SWHCvDJsbYDPtA6ith4uGRYz9RdjHttsDG7HhCrshphLYtApYBtzxy6rsXYZeS9h6a"}
+        ${LBTC} | ${"ert1q4k67l66z0nwgcsgzw20638cpm75d6tpl4f4vyrp76fnnutn0ulvqwe7ahr"}
         ${LBTC} | ${"el1qqdmeywy40z2aasvaydsnmgqqqcgk92cvd9p9h4mpeh2x83dy79mhltd4al45ylxu33qsyu5l4z0srhagm5krl2n2cgxra5n88chxle7ctnpml5s983jr"}
     `("should validate $address", async ({ asset, address }) => {
         decodeAddress(asset, address);
     });
-
-    test.each`
-        asset   | address
-        ${LBTC} | ${"XaGQJMVzMDn7DNwKtRA9fJVEVkxVE1FjgW"}
-        ${LBTC} | ${"2dsdhiFYQADKEEkcdafMXcGtSL96HSmsr16"}
-        ${LBTC} | ${"ert1q4k67l66z0nwgcsgzw20638cpm75d6tpl4f4vyrp76fnnutn0ulvqwe7ahr"}
-    `(
-        "should not validate unconfidential Liquid address $address",
-        ({ asset, address }) => {
-            expect(() => decodeAddress(asset, address)).toThrow();
-        },
-    );
 
     test.each`
         asset   | address


### PR DESCRIPTION
When sending to an unconfidential address from a confidential input we have to add a confidential OP_RETURN. That OP_RETURN output contains 1 sat (because blinding 0 sats is flaky) which is then missing from the fee.

This PR adds 1 sat to the fee when sending to an unconfidential address.