### PR TITLE
fix: retry claiming on pagereload

### DIFF
--- a/src/components/SwapChecker.tsx
+++ b/src/components/SwapChecker.tsx
@@ -237,14 +237,13 @@ export const SwapChecker = () => {
             urlsToAsset.set(url, (urlsToAsset.get(url) || []).concat(asset));
         }
 
-        const swapsToCheck = (await getSwaps())
-            .filter(
-                (s) =>
-                    !swapStatusFinal.includes(s.status) ||
-                    (s.status === swapStatusSuccess.InvoiceSettled &&
-                        s.claimTx === undefined),
-            )
-            .filter((s) => s.id !== swap()?.id);
+        const swapsToCheck = (await getSwaps()).filter(
+            (s) =>
+                !swapStatusFinal.includes(s.status) ||
+                (s.status === swapStatusSuccess.InvoiceSettled &&
+                    s.claimTx === undefined),
+        );
+
         for (const [url, assets] of urlsToAsset.entries()) {
             log.debug(`opening ws for assets [${assets.join(", ")}]: ${url}`);
             const ws = new BoltzWebSocket(
@@ -278,11 +277,11 @@ export const SwapChecker = () => {
         if (activeSwap === undefined || activeSwap === null) {
             return;
         }
+        // on page reload assetWebsocket is not yet initialized
         const ws = assetWebsocket.get(activeSwap.asset);
         if (ws === undefined) {
             return;
         }
-
         ws.subscribeUpdates([activeSwap.id]);
     });
 


### PR DESCRIPTION
dont filter swap().id from the swapchecker, createEffect wont work on a reload, because the websockets are not yet initialized when the effect is triggered thus never subscribung to the active swap. also because we use a set here, i think there is no worry of duplicate listeners anyway