### PR TITLE
bug: only set failure reason and swap status tx if on current swap

### DIFF
--- a/src/components/SwapChecker.tsx
+++ b/src/components/SwapChecker.tsx
@@ -161,15 +161,15 @@ export const SwapChecker = () => {
         }
         if (swap() && swap().id === currentSwap.id) {
             setSwapStatus(data.status);
+            if (data.transaction) setSwapStatusTransaction(data.transaction);
+            if (data.failureReason) {
+                setFailureReason(data.failureReason);
+            }
         }
-        if (data.transaction) setSwapStatusTransaction(data.transaction);
         if (data.status) {
             await updateSwapStatus(currentSwap.id, data.status);
         }
         await checkForFailed(currentSwap, data);
-        if (data.failureReason) {
-            setFailureReason(data.failureReason);
-        }
     };
 
     const claimSwap = async (swapId: string, data: any) => {


### PR DESCRIPTION
swapchecker was wrongly overwriting the status of the swap status page you were on which lead to wrong error messages