### PR TITLE
feat: use trash icon instead of `delete` in SwapList component

### DIFF
--- a/src/components/SwapList.tsx
+++ b/src/components/SwapList.tsx
@@ -1,3 +1,4 @@
+import { BiRegularTrash } from "solid-icons/bi";
 import { Accessor, For, Show, createMemo, createSignal } from "solid-js";
 
 import { useGlobalContext } from "../context/Global";
@@ -60,7 +61,7 @@ const SwapList = ({
                                 <span
                                     class="btn-small btn-danger"
                                     onClick={() => deleteSwapAction(swap.id)}>
-                                    {t("delete")}
+                                    <BiRegularTrash size={14} />
                                 </span>
                             </Show>
                         </div>

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -137,7 +137,6 @@ const dict = {
         ios_image_download:
             'Long press and select "Save to Photos" to download refund file',
         created: "Created",
-        delete: "Delete",
         view: "View",
         id: "ID",
         headline: "Privacy First, Non-Custodial Bitcoin Exchange",
@@ -328,7 +327,6 @@ const dict = {
         ios_image_download:
             'Lange drücken und "In Fotos speichern" auswählen, um die Rückerstattungsdatei herunterzuladen',
         created: "Erstellt",
-        delete: "Löschen",
         view: "Anzeigen",
         id: "ID",
         headline: "Privacy First, Non-Custodial Bitcoin Exchange",
@@ -523,7 +521,6 @@ const dict = {
         ios_image_download:
             'Mantén presionado y selecciona "Guardar en Fotos" para descargar el archivo de reembolso.',
         created: "Creado",
-        delete: "Eliminar",
         view: "Ver",
         id: "ID",
         headline: "Intercambio de Bitcoin con privacidad y sin custodia",
@@ -702,7 +699,6 @@ const dict = {
         wasm_not_supported: "请在您的浏览器中激活WebAssembly",
         ios_image_download: "长按并选择“保存到照片”以下载退款文件",
         created: "已创建",
-        delete: "删除",
         view: "查看",
         id: "ID",
         headline: "隐私第一，非托管的比特币交易所",


### PR DESCRIPTION
this makes german translations a one liner again
![screenshot-1716362226](https://github.com/BoltzExchange/boltz-web-app/assets/1743657/49da4343-bb89-45b7-9fd2-462d26ff95d0)
![screenshot-1716362218](https://github.com/BoltzExchange/boltz-web-app/assets/1743657/27fa697d-3e9a-40e0-9055-c317ecdcc0f2)