### PR TITLE
fix: increase refund QR size

### DIFF
--- a/src/components/DownloadRefund.tsx
+++ b/src/components/DownloadRefund.tsx
@@ -19,7 +19,7 @@ const DownloadRefund = () => {
     const { t } = useGlobalContext();
 
     const downloadRefundQr = (swap: any) => {
-        QRCode.toDataURL(JSON.stringify(swap), { width: 400 })
+        QRCode.toDataURL(JSON.stringify(swap), { width: 1200 })
             .then((url: string) => {
                 if (isIos()) {
                     // Compatibility with third party iOS browsers


### PR DESCRIPTION
Taproot swaps and especially chain swaps save much more data in the refund file. We need to increase the size of the QR code so that it can be scanned properly.