### PR TITLE
fix: Nginx 404 with Docker on paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20 AS builder
 
 WORKDIR /app
 
-COPY package.json package-lock.json .
+COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
 
@@ -12,6 +12,8 @@ RUN npm run $NETWORK
 RUN npm run build
 
 FROM nginx:alpine AS final
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri /index.html =404;
+    }
+
+    # Redirect server error pages to the static page /50x.html
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
`try_files $uri /index.html =404;` tells Nginx to always serve the `index.html` instead of the default 404 page, when a path that is not `index.html` is accessed.
This is needed so that our router in the web app works on refreshes.