### PR TITLE
fix: error message was swallowed by JSON.stringify

### DIFF
--- a/src/utils/logs.ts
+++ b/src/utils/logs.ts
@@ -43,6 +43,9 @@ export const deleteOldLogs = async (logsForage: LocalForage) => {
 export const formatLogLine = (message: any[]) =>
     message
         .map((entry: any) => {
+            if (entry instanceof Error) {
+                return entry;
+            }
             if (typeof entry === "object") {
                 return JSON.stringify(entry);
             }


### PR DESCRIPTION
after trying to reproduce #602 i found that it already was fixed, but there was still an issue where the errormessage wasn't found in the logs. issue was `typeof Error` return `object` so the logger treated is as object and tried to JSON.stringify it. that made it to display just `{}`