### PR TITLE
feat: add blockexplorer setting for links and claiming

### DIFF
--- a/src/components/BlockExplorer.tsx
+++ b/src/components/BlockExplorer.tsx
@@ -2,7 +2,8 @@ import { chooseUrl, config } from "../config";
 import { useGlobalContext } from "../context/Global";
 
 const blockExplorerLink = (asset: string, isTxId: boolean, val: string) => {
-    const basePath = chooseUrl(config.assets[asset].blockExplorerUrl);
+    const url = config.assets[asset].blockExplorerUrls?.mempool;
+    const basePath = chooseUrl(config.assets[asset].blockExplorerUrls?.mempool);
     return `${basePath}/${isTxId ? "tx" : "address"}/${val}`;
 };
 

--- a/src/components/SwapChecker.tsx
+++ b/src/components/SwapChecker.tsx
@@ -130,8 +130,15 @@ export const SwapChecker = () => {
         setSwapStatusTransaction,
         setFailureReason,
     } = usePayContext();
-    const { notify, updateSwapStatus, getSwap, getSwaps, setSwapStorage, t } =
-        useGlobalContext();
+    const {
+        blockExplorer,
+        notify,
+        updateSwapStatus,
+        getSwap,
+        getSwaps,
+        setSwapStorage,
+        t,
+    } = useGlobalContext();
 
     const assetWebsocket = new Map<string, BoltzWebSocket>();
 
@@ -206,6 +213,8 @@ export const SwapChecker = () => {
                 const res = await claim(
                     currentSwap as ReverseSwap | ChainSwap,
                     data.transaction,
+                    true,
+                    blockExplorer(),
                 );
                 const claimedSwap = (await getSwap(res.id)) as
                     | ReverseSwap

--- a/src/components/settings/BlockExplorerSetting.tsx
+++ b/src/components/settings/BlockExplorerSetting.tsx
@@ -1,0 +1,38 @@
+import { RiArrowsArrowDropDownFill } from "solid-icons/ri";
+import { createSignal } from "solid-js";
+
+import { BlockExplorer } from "../../consts/Enums";
+import { useGlobalContext } from "../../context/Global";
+
+const BlockExplorerSetting = () => {
+    const { blockExplorer, setBlockExplorer } = useGlobalContext();
+
+    const [dropdown, setDropdown] = createSignal(false);
+
+    const toggleBlockExplorer = (evt: MouseEvent) => {
+        setDropdown(!dropdown());
+        evt.stopPropagation();
+    };
+
+    const explorers = [BlockExplorer.Blockstream, BlockExplorer.Mempool];
+
+    return (
+        <>
+            <div
+                class="blockexplorer-setting toggle select"
+                data-dropdown={dropdown()}
+                onClick={toggleBlockExplorer}>
+                <RiArrowsArrowDropDownFill />
+                {explorers.map((explorer) => (
+                    <span
+                        class={blockExplorer() === explorer ? "active" : ""}
+                        onClick={() => setBlockExplorer(explorer)}>
+                        {explorer}
+                    </span>
+                ))}
+            </div>
+        </>
+    );
+};
+
+export default BlockExplorerSetting;

--- a/src/components/settings/BroadcastSetting.tsx
+++ b/src/components/settings/BroadcastSetting.tsx
@@ -1,0 +1,42 @@
+import { RiArrowsArrowDropDownFill } from "solid-icons/ri";
+import { createSignal } from "solid-js";
+
+import { BlockExplorer } from "../../consts/Enums";
+import { useGlobalContext } from "../../context/Global";
+
+const BroadcastSetting = () => {
+    const { broadcaster, setBroadcaster } = useGlobalContext();
+
+    const [dropdown, setDropdown] = createSignal(false);
+
+    const toggleBroadcaster = (evt: MouseEvent) => {
+        setDropdown(!dropdown());
+        evt.stopPropagation();
+    };
+
+    const explorers = [
+        BlockExplorer.Boltz,
+        BlockExplorer.Blockstream,
+        BlockExplorer.Mempool,
+    ];
+
+    return (
+        <>
+            <div
+                class="blockexplorer-setting toggle select"
+                data-dropdown={dropdown()}
+                onClick={toggleBroadcaster}>
+                <RiArrowsArrowDropDownFill />
+                {explorers.map((explorer) => (
+                    <span
+                        class={broadcaster() === explorer ? "active" : ""}
+                        onClick={() => setBroadcaster(explorer)}>
+                        {explorer}
+                    </span>
+                ))}
+            </div>
+        </>
+    );
+};
+
+export default BroadcastSetting;

--- a/src/components/settings/SettingsMenu.tsx
+++ b/src/components/settings/SettingsMenu.tsx
@@ -6,6 +6,8 @@ import { config } from "../../config";
 import { useGlobalContext } from "../../context/Global";
 import "../../style/settings.scss";
 import AudioNotificationSetting from "./AudioNotificationSetting";
+import BlockExplorerSetting from "./BlockExplorerSetting";
+import BroadcastSetting from "./BroadcastSetting";
 import BrowserNotification from "./BrowserNotification";
 import Denomination from "./Denomination";
 import Logs from "./Logs";
@@ -75,6 +77,16 @@ const SettingsMenu = () => {
                         settingElement={<RecklessModeSetting />}
                     />
                 </Show>
+                <Entry
+                    label={"broadcast_setting"}
+                    tooltipLabel={"broadcast_setting_tooltip"}
+                    settingElement={<BroadcastSetting />}
+                />
+                <Entry
+                    label={"blockexplorer_setting"}
+                    tooltipLabel={"blockexplorer_setting_tooltip"}
+                    settingElement={<BlockExplorerSetting />}
+                />
                 <Entry
                     label={"logs"}
                     tooltipLabel={"logs_tooltip"}

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,7 +28,7 @@ const defaults = {
 };
 
 type Asset = {
-    blockExplorerUrl?: Url;
+    blockExplorerUrls?: Record<string, Url>;
     apiUrl?: Url;
 };
 

--- a/src/configs/beta.json
+++ b/src/configs/beta.json
@@ -12,12 +12,30 @@
             "blockExplorerUrl": {
                 "normal": "https://mempool.space",
                 "tor": "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion"
+            },
+            "broadcastUrl": {
+                "blockstream": {
+                    "normal": "https://blockstream.info/api/tx"
+                },
+                "mempool": {
+                    "normal": "https://mempool.space/api/tx",
+                    "tor": "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/api/tx"
+                }
             }
         },
         "L-BTC": {
             "blockExplorerUrl": {
                 "normal": "https://liquid.network",
                 "tor": "http://liquidmom47f6s3m53ebfxn47p76a6tlnxib3wp6deux7wuzotdr6cyd.onion"
+            },
+            "broadcastUrl": {
+                "blockstream": {
+                    "normal": "https://blockstream.info/liquid/tx"
+                },
+                "mempool": {
+                    "normal": "https://liquid.network/api/tx",
+                    "tor": "http://liquidmom47f6s3m53ebfxn47p76a6tlnxib3wp6deux7wuzotdr6cyd.onion/api/tx"
+                }
             }
         }
     }

--- a/src/configs/mainnet.json
+++ b/src/configs/mainnet.json
@@ -8,15 +8,25 @@
     },
     "assets": {
         "BTC": {
-            "blockExplorerUrl": {
-                "normal": "https://mempool.space",
-                "tor": "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion"
+            "blockExplorerUrls": {
+                "mempool": {
+                    "normal": "https://mempool.space/api/tx",
+                    "tor": "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/api/tx"
+                },
+                "blockstream": {
+                    "normal": "https://blockstream.info/api/tx"
+                }
             }
         },
         "L-BTC": {
-            "blockExplorerUrl": {
-                "normal": "https://liquid.network",
-                "tor": "http://liquidmom47f6s3m53ebfxn47p76a6tlnxib3wp6deux7wuzotdr6cyd.onion"
+            "blockExplorerUrls": {
+                "mempool": {
+                    "normal": "https://liquid.network/api/tx",
+                    "tor": "http://liquidmom47f6s3m53ebfxn47p76a6tlnxib3wp6deux7wuzotdr6cyd.onion/api/tx"
+                },
+                "blockstream": {
+                    "normal": "https://blockstream.info/liquid/tx"
+                }
             }
         }
     }

--- a/src/configs/regtest.json
+++ b/src/configs/regtest.json
@@ -6,11 +6,27 @@
     },
     "assets": {
         "BTC": {
+            "broadcastUrl": {
+                "blockstream": {
+                    "normal": "http://localhost:8090/tx"
+                },
+                "mempool": {
+                    "normal": "http://localhost:8090/tx"
+                }
+            },
             "blockExplorerUrl": {
                 "normal": "http://localhost:8090"
             }
         },
         "L-BTC": {
+            "broadcastUrl": {
+                "blockstream": {
+                    "normal": "http://localhost:8090/tx"
+                },
+                "mempool": {
+                    "normal": "http://localhost:8090/tx"
+                }
+            },
             "blockExplorerUrl": {
                 "normal": "http://localhost:8091"
             }

--- a/src/configs/testnet.json
+++ b/src/configs/testnet.json
@@ -6,11 +6,27 @@
     },
     "assets": {
         "BTC": {
+            "broadcastUrl": {
+                "blockstream": {
+                    "normal": "https://blockstream.info/testnet/api/tx"
+                },
+                "mempool": {
+                    "normal": "https://mempool.space/testnet/api/tx"
+                }
+            },
             "blockExplorerUrl": {
                 "normal": "https://blockstream.info/testnet"
             }
         },
         "L-BTC": {
+            "broadcastUrl": {
+                "blockstream": {
+                    "normal": "https://blockstream.info/liquidtestnet/api/tx"
+                },
+                "mempool": {
+                    "normal": "https://liquid.network/testnet/api/tx"
+                }
+            },
             "blockExplorerUrl": {
                 "normal": "https://blockstream.info/liquidtestnet"
             }

--- a/src/consts/Enums.ts
+++ b/src/consts/Enums.ts
@@ -1,3 +1,9 @@
+export enum BlockExplorer {
+    Boltz = "boltz",
+    Mempool = "mempool",
+    Blockstream = "blockstream",
+}
+
 export enum SwapType {
     Submarine = "submarine",
     Reverse = "reverse",

--- a/src/context/Global.tsx
+++ b/src/context/Global.tsx
@@ -14,7 +14,7 @@ import {
 
 import { config } from "../config";
 import { BTC } from "../consts/Assets";
-import { Denomination } from "../consts/Enums";
+import { BlockExplorer, Denomination } from "../consts/Enums";
 import { swapStatusFinal } from "../consts/SwapStatus";
 import { detectLanguage } from "../i18n/detect";
 import dict from "../i18n/i18n";
@@ -67,6 +67,10 @@ export type GlobalContextType = {
     setAudioNotification: Setter<boolean>;
     browserNotification: Accessor<boolean>;
     setBrowserNotification: Setter<boolean>;
+    blockExplorer: Accessor<BlockExplorer>;
+    setBlockExplorer: Setter<BlockExplorer>;
+    broadcaster: Accessor<BlockExplorer>;
+    setBroadcaster: Setter<BlockExplorer>;
     // functions
     t: (key: string, values?: Record<string, any>) => string;
     notify: (
@@ -161,6 +165,22 @@ const GlobalProvider = (props: { children: any }) => {
         createSignal(localeSeparator),
         {
             name: "separator",
+        },
+    );
+
+    const [blockExplorer, setBlockExplorer] = makePersisted(
+        createSignal<BlockExplorer>(BlockExplorer.Mempool),
+        {
+            name: "blockExplorer",
+            ...stringSerializer,
+        },
+    );
+
+    const [broadcaster, setBroadcaster] = makePersisted(
+        createSignal<BlockExplorer>(BlockExplorer.Boltz),
+        {
+            name: "broadcaster",
+            ...stringSerializer,
         },
     );
 
@@ -356,6 +376,10 @@ const GlobalProvider = (props: { children: any }) => {
                 setAudioNotification,
                 browserNotification,
                 setBrowserNotification,
+                blockExplorer,
+                setBlockExplorer,
+                broadcaster,
+                setBroadcaster,
                 // functions
                 t,
                 notify,

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -201,6 +201,12 @@ const dict = {
         reckless_mode_setting: "Reckless Mode",
         reckless_mode_setting_tooltip:
             "Disables prompts to download refund file and other confirmation steps",
+        blockexplorer_setting: "Block Explorer",
+        blockexplorer_setting_tooltip:
+            "Choose your preferred service for viewing onchain tx's",
+        broadcast_setting: "Broadcaster",
+        broadcast_setting_tooltip:
+            "Choose your preferred service for broadcasting claim and refund tx's",
     },
     de: {
         language: "Deutsch",

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -500,10 +500,10 @@ textarea {
     position: absolute;
     width: 100%;
     left: 0;
-    top: 64px;
+    top: 0;
     z-index: 999;
     display: none;
-    box-shadow: 0 0 12px black;
+    box-shadow: 0 0 16px rgba(0, 0, 0, 0.7);
     margin: 0;
 }
 .assets-select.active {

--- a/src/style/settings.scss
+++ b/src/style/settings.scss
@@ -40,3 +40,26 @@
 .setting .spacer {
     flex-grow: 1;
 }
+
+.toggle.select {
+    > * {
+        width: auto;
+        padding: 0 5px;
+        border-radius: 12px;
+        display: none;
+    }
+    > :first-child {
+        width: auto;
+        margin: 0;
+        padding: 0;
+    }
+    > .active,
+    > :first-child {
+        display: flex;
+    }
+    &[data-dropdown="true"] {
+        > * {
+            display: flex;
+        }
+    }
+}

--- a/src/utils/blockExplorer.ts
+++ b/src/utils/blockExplorer.ts
@@ -1,0 +1,29 @@
+import log from "loglevel";
+
+import { chooseUrl, config } from "../config";
+import { BlockExplorer } from "../consts/Enums";
+import { broadcastTransaction as boltzBroadcastTransaction } from "./boltzClient";
+import { fetcher } from "./helper";
+
+export const broadcastTransaction = async (
+    blockExplorer: BlockExplorer,
+    asset: string,
+    txHex: string,
+) => {
+    if (blockExplorer === BlockExplorer.Boltz) {
+        return boltzBroadcastTransaction(asset, txHex);
+    }
+    let url = undefined;
+    if (blockExplorer === BlockExplorer.Mempool) {
+        url = chooseUrl(config.assets[asset].broadcastUrl?.mempool);
+    }
+    if (blockExplorer === BlockExplorer.Blockstream) {
+        url = chooseUrl(config.assets[asset].broadcastUrl?.blockstream);
+    }
+    if (!url) {
+        log.error("No broadcast URL found for asset", asset, blockExplorer);
+    }
+    return fetcher<{ id: string }>(url, asset, {
+        hex: txHex,
+    });
+};

--- a/src/utils/claim.ts
+++ b/src/utils/claim.ts
@@ -10,10 +10,10 @@ import { Network as LiquidNetwork } from "liquidjs-lib/src/networks";
 import log from "loglevel";
 
 import { LBTC, RBTC } from "../consts/Assets";
-import { SwapType } from "../consts/Enums";
+import { BlockExplorer, SwapType } from "../consts/Enums";
+import { broadcastTransaction } from "./blockExplorer";
 import {
     TransactionInterface,
-    broadcastTransaction,
     getChainSwapClaimDetails,
     getPartialReverseClaimSignature,
     getSubmarineClaimDetails,
@@ -303,6 +303,7 @@ export const claim = async <T extends ReverseSwap | ChainSwap>(
     swap: T,
     swapStatusTransaction: { hex: string },
     cooperative: boolean = true,
+    blockExplorer: BlockExplorer = BlockExplorer.Boltz,
 ): Promise<T | undefined> => {
     await setup();
 
@@ -331,7 +332,11 @@ export const claim = async <T extends ReverseSwap | ChainSwap>(
     }
 
     log.debug("Broadcasting claim transaction");
-    const res = await broadcastTransaction(asset, claimTransaction.toHex());
+    const res = await broadcastTransaction(
+        blockExplorer,
+        asset,
+        claimTransaction.toHex(),
+    );
     log.debug("Claim transaction broadcast result", res);
     if (res.id) {
         swap.claimTx = res.id;


### PR DESCRIPTION
- adds setting to choose a blockexplorer for addresses/txid's
- adds functionality to choose where to broadcast your claim/refund tx. related to https://github.com/BoltzExchange/boltz-web-app/issues/521