### PR TITLE
fix: Lightning Nodes i18, remove link from headline

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,6 @@ const defaults = {
 
     loglevel: "info" as log.LogLevelDesc,
     defaultLanguage: "en",
-    lightningExplorerUrl: "https://amboss.space/node",
     discordUrl: "https://discord.gg/QBvZGcW",
     twitterUrl: "https://twitter.com/boltzhq",
     githubUrl: "https://github.com/BoltzExchange",

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -11,8 +11,8 @@ const dict = {
         non_custodial: "Non-Custodial",
         non_custodial_sub:
             "Swaps on Boltz are atomic, cryptography ensures that users are always in control of their money",
-        node: "Lightning Node",
-        lightningnode: "view lightning node",
+        node: "Lightning Nodes",
+        lightningnode: "View Lightning Nodes",
         error: "Error",
         error_subline: "Invalid response from the API, something is wrong.",
         error_wasm: "WebAssembly not supported",
@@ -215,8 +215,8 @@ const dict = {
         non_custodial: "Non-Custodial",
         non_custodial_sub:
             "Swaps auf Boltz sind atomar, Kryptografie stellt sicher, dass Nutzer stets die Kontrolle über ihre Bitcoin behalten",
-        node: "Knoten",
-        lightningnode: "Knoten anzeigen",
+        node: "Lightning Knoten",
+        lightningnode: "Lightning Knoten anzeigen",
         error: "Fehler",
         error_subline:
             "Ungültige Antwort von der API, irgendwas ist hier falsch.",
@@ -427,8 +427,8 @@ const dict = {
         non_custodial: "Sin Custodia",
         non_custodial_sub:
             "Los intercambios en Boltz son atomicos, la criptografía garantiza que los usuarios siempre tienen el control de su Bitcoin",
-        node: "Nodo",
-        lightningnode: "Ver nodo Lightning",
+        node: "Nodos de Lightning",
+        lightningnode: "Ver nodos de Lightning",
         error: "Error",
         error_subline: "Respuesta inválida de la API, algo está mal :/",
         error_wasm: "WebAssembly no soportado",

--- a/src/pages/Hero.tsx
+++ b/src/pages/Hero.tsx
@@ -27,10 +27,6 @@ export const Hero = () => {
     const { hideHero, setHideHero, t, denomination, separator } =
         useGlobalContext();
 
-    const openNodeInfo = async () => {
-        window.open(`https://api.boltz.exchange/v2/nodes/`, "_blank");
-    };
-
     const formatStatsAmount = (
         value: number,
         denom: Denomination = Denomination.Sat,
@@ -100,9 +96,7 @@ export const Hero = () => {
                         <img src={liquid} alt="Liquid Bitcoin" />
                     </div>
                 </div>
-                <h2 class="headline pointer" onclick={openNodeInfo}>
-                    {t("node")}
-                </h2>
+                <h2 class="headline">{t("node")}</h2>
                 <div id="numbers">
                     <div class="number">
                         {formatStatsAmount(numChannel())}{" "}
@@ -128,7 +122,6 @@ export const Hero = () => {
                         <small>{t("oldest_channel")}</small>
                     </div>
                 </div>
-
                 <h2 class="headline">{t("integrations")}</h2>
                 <div id="integrations">
                     <div>

--- a/src/pages/Hero.tsx
+++ b/src/pages/Hero.tsx
@@ -11,7 +11,7 @@ import { Denomination } from "../consts/Enums";
 import { useGlobalContext } from "../context/Global";
 import Create from "../pages/Create";
 import "../style/hero.scss";
-import { getNodeStats, getNodes } from "../utils/boltzClient";
+import { getNodeStats } from "../utils/boltzClient";
 import { formatAmountDenomination } from "../utils/denomination";
 
 export const Hero = () => {
@@ -32,11 +32,7 @@ export const Hero = () => {
 
     onMount(async () => {
         try {
-            const [nodesRes, statsRes] = await Promise.all([
-                getNodes(BTC),
-                getNodeStats(BTC),
-            ]);
-            log.debug("node", nodesRes);
+            const statsRes = await getNodeStats(BTC);
 
             log.debug("node stats", statsRes);
             const stats = statsRes.BTC.total;

--- a/src/pages/Hero.tsx
+++ b/src/pages/Hero.tsx
@@ -28,7 +28,7 @@ export const Hero = () => {
         useGlobalContext();
 
     const openNodeInfo = async () => {
-        window.open(`${config.lightningExplorerUrl}/${nodePubkey()}`, "_blank");
+        window.open(`https://api.boltz.exchange/v2/nodes/`, "_blank");
     };
 
     const formatStatsAmount = (

--- a/src/pages/Hero.tsx
+++ b/src/pages/Hero.tsx
@@ -6,7 +6,6 @@ import { Show, createSignal, onMount } from "solid-js";
 import bitcoin from "../assets/bitcoin-icon.svg";
 import lightning from "../assets/lightning-icon.svg";
 import liquid from "../assets/liquid-icon.svg";
-import { config } from "../config";
 import { BTC } from "../consts/Assets";
 import { Denomination } from "../consts/Enums";
 import { useGlobalContext } from "../context/Global";
@@ -18,7 +17,6 @@ import { formatAmountDenomination } from "../utils/denomination";
 export const Hero = () => {
     const navigate = useNavigate();
 
-    const [nodePubkey, setNodePubkey] = createSignal<string | null>(null);
     const [numChannel, setNumChannel] = createSignal(0);
     const [numPeers, setNumPeers] = createSignal(0);
     const [capacity, setCapacity] = createSignal(0);
@@ -39,9 +37,6 @@ export const Hero = () => {
                 getNodeStats(BTC),
             ]);
             log.debug("node", nodesRes);
-            setNodePubkey(
-                nodesRes.BTC.LND?.publicKey || nodesRes.BTC.CLN?.publicKey,
-            );
 
             log.debug("node stats", statsRes);
             const stats = statsRes.BTC.total;


### PR DESCRIPTION
- node*s* (plural)
- remove link in the headline, with public explorers it can only link to one node and it was broken on testnet 