### PR TITLE
fix: test payonchain separator was `,`

### DIFF
--- a/tests/components/PayOnchain.spec.tsx
+++ b/tests/components/PayOnchain.spec.tsx
@@ -36,6 +36,7 @@ describe("PayOnchain", () => {
         )) as HTMLDivElement;
         expect(buttons).not.toBeUndefined();
 
+        globalSignals.setSeparator(".");
         globalSignals.setDenomination(Denomination.Sat);
         fireEvent.click(buttons.children[0]);
 


### PR DESCRIPTION
not sure why but separator was set to `,` and expected a `.` in the test