### PR TITLE
fix: web3 add chain prompt

### DIFF
--- a/src/context/Web3.tsx
+++ b/src/context/Web3.tsx
@@ -282,11 +282,11 @@ const Web3SignerProvider = (props: {
                     method: "wallet_addEthereumChain",
                     params: [
                         {
-                            chainId: sanitizedChainId,
+                            ...config.assets[RBTC].network,
                             blockExplorerUrls: [
                                 config.assets[RBTC].blockExplorerUrl.normal,
                             ],
-                            ...config.assets[RBTC].network,
+                            chainId: sanitizedChainId,
                         },
                     ],
                 });


### PR DESCRIPTION
The provider expects the chain ID in hex format