### PR TITLE
chore: pass referral id in every request header

### DIFF
--- a/src/consts/LocalStorage.ts
+++ b/src/consts/LocalStorage.ts
@@ -1,0 +1,1 @@
+export const referralIdKey = "ref";

--- a/src/context/Global.tsx
+++ b/src/context/Global.tsx
@@ -16,6 +16,7 @@ import type { JSX } from "solid-js";
 
 import { config } from "../config";
 import { Denomination } from "../consts/Enums";
+import { referralIdKey } from "../consts/LocalStorage";
 import { swapStatusFinal } from "../consts/SwapStatus";
 import { detectLanguage } from "../i18n/detect";
 import dict, { DictKey } from "../i18n/i18n";
@@ -133,7 +134,7 @@ const GlobalProvider = (props: { children: JSX.Element }) => {
             isMobile() ? "boltz_webapp_mobile" : "boltz_webapp_desktop",
         ),
         {
-            name: "ref",
+            name: referralIdKey,
             ...stringSerializer,
         },
     );

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -4,6 +4,7 @@ import { ECPairInterface } from "ecpair";
 import { chooseUrl, config } from "../config";
 import { BTC, LN } from "../consts/Assets";
 import { SwapType } from "../consts/Enums";
+import { referralIdKey } from "../consts/LocalStorage";
 import {
     ChainPairTypeTaproot,
     Pairs,
@@ -84,16 +85,25 @@ export const fetcher = async <T = unknown>(
     url: string,
     params?: Record<string, unknown>,
 ): Promise<T> => {
-    let opts = {};
+    // We cannot use the context here, so we get the data directly from local storage
+    const referral = localStorage.getItem(referralIdKey);
+    let opts: RequestInit = {
+        headers: {
+            referral,
+        },
+    };
+
     if (params) {
         opts = {
             method: "POST",
             headers: {
+                ...opts.headers,
                 "Content-Type": "application/json",
             },
             body: JSON.stringify(params),
         };
     }
+
     const apiUrl = getApiUrl() + url;
     const response = await fetch(apiUrl, opts);
     if (!response.ok) {


### PR DESCRIPTION
Needed for a future update which allows fees to change based on the referral id. To show those changed fees, we need to tell the API our referral id in requests that fetch the pairs; easiest way is to just pass the id in every request header