### PR TITLE
fix: refund files for non RBTC pairs in mobile EVM browsers

### DIFF
--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -362,7 +362,8 @@ export const CreateButton = () => {
                 isRecklessMode() ||
                 swapType() === SwapType.Reverse ||
                 assetSend() === RBTC ||
-                isMobileEvmBrowser()
+                // Only disable refund files on mobile EVM browsers when one side is RSK
+                (assetReceive() === RBTC && isMobileEvmBrowser())
             ) {
                 navigate("/swap/" + data.id);
             } else {


### PR DESCRIPTION
Closes #774