### PR TITLE
chore: disable amounts input autocomplete

### DIFF
--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -363,6 +363,7 @@ const Create = () => {
                             }
                             id="sendAmount"
                             data-testid="sendAmount"
+                            autocomplete="off"
                             value={sendAmountFormatted()}
                             onPaste={(e) => validatePaste(e)}
                             onKeyPress={(e) => validateInput(e)}
@@ -386,6 +387,7 @@ const Create = () => {
                             }
                             id="receiveAmount"
                             data-testid="receiveAmount"
+                            autocomplete="off"
                             value={receiveAmountFormatted()}
                             onPaste={(e) => validatePaste(e)}
                             onKeyPress={(e) => validateInput(e)}


### PR DESCRIPTION
Send and receive amounts autocomplete interferes with asset selection in mobile browsers:

![image](https://github.com/user-attachments/assets/4d93d5e5-50e6-46b0-9d6c-953e045c910a)

This PR removes them.