### PR TITLE
Clean address input on direction switch

### DIFF
--- a/src/components/AssetSelect.tsx
+++ b/src/components/AssetSelect.tsx
@@ -47,6 +47,8 @@ const SelectAsset = () => {
                 setAssetSend(assetReceive());
             }
             setAssetReceive(newAsset);
+            // always clear onchain address if assetChange did change
+            setOnchainAddress("");
         }
 
         void fetchPairs().catch((err) =>

--- a/src/components/Reverse.tsx
+++ b/src/components/Reverse.tsx
@@ -3,9 +3,15 @@ import { ImArrowDown } from "solid-icons/im";
 import { useCreateContext } from "../context/Create";
 
 const Reverse = () => {
-    const { assetReceive, assetSend, setAssetSend, setAssetReceive } =
-        useCreateContext();
+    const {
+        assetReceive,
+        assetSend,
+        setAssetSend,
+        setAssetReceive,
+        setOnchainAddress,
+    } = useCreateContext();
     const setDirection = () => {
+        setOnchainAddress("");
         const sendOld = assetSend();
         setAssetSend(assetReceive());
         setAssetReceive(sendOld);

--- a/tests/components/AssetSelect.spec.tsx
+++ b/tests/components/AssetSelect.spec.tsx
@@ -157,4 +157,30 @@ describe("AssetSelect", () => {
             expect(signals.onchainAddress()).toEqual(address);
         },
     );
+
+    test("should clear onchain address when assetReceive changes", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <SelectAsset />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        const initialAddress =
+            "el1qqgdvkht3g2puwdwxqzfrekef8anygnvs093hntsz63f42gj5m0zksfvvvsss79pv7le474snv6n2slklg7ujvth99naldh9cy";
+
+        signals.setOnchainAddress(initialAddress);
+        signals.setAssetSelect(true);
+        signals.setAssetSelected(Side.Receive);
+        signals.setAssetSend(BTC);
+        signals.setAssetReceive(LBTC);
+
+        fireEvent.click(await screen.findByTestId(`select-${BTC}`));
+
+        expect(signals.assetReceive()).toEqual(BTC);
+        expect(signals.onchainAddress()).toBe("");
+    });
 });

--- a/tests/components/Reverse.spec.tsx
+++ b/tests/components/Reverse.spec.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render } from "@solidjs/testing-library";
 
 import Reverse from "../../src/components/Reverse";
-import { BTC, LN } from "../../src/consts/Assets";
+import { BTC, LBTC, LN } from "../../src/consts/Assets";
 import { TestComponent, contextWrapper, signals } from "../helper";
 
 describe("Reverse", () => {
@@ -27,5 +27,29 @@ describe("Reverse", () => {
 
         expect(signals.assetSend()).toEqual(LN);
         expect(signals.assetReceive()).toEqual(BTC);
+    });
+
+    test("should clear onChainAddress on reverse", () => {
+        const {
+            container: { firstChild: flip },
+        } = render(
+            () => (
+                <>
+                    <Reverse />
+                    <TestComponent />
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+
+        signals.setOnchainAddress("2N17VNGbi4yUHtkD7vhrc8cpi9JGVmC8scn");
+        signals.setAssetSend(LBTC);
+        signals.setAssetReceive(BTC);
+
+        fireEvent.click(flip);
+
+        expect(signals.onchainAddress()).toEqual("");
     });
 });


### PR DESCRIPTION
Closes #751
Closes #754

- Address input is now cleared when switching directions.
- Invalid addresses are not cleared when switching directions.
