### PR TITLE
chore: make swap not found page look nicer

### DIFF
--- a/src/pages/Pay.tsx
+++ b/src/pages/Pay.tsx
@@ -189,7 +189,7 @@ const Pay = () => {
                 </Show>
             </Show>
             <Show when={!swap()}>
-                <p>{t("pay_swap_404")}</p>
+                <h2 class="not-found">{t("pay_swap_404")}</h2>
             </Show>
             <SettingsMenu />
         </div>

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -655,3 +655,9 @@ textarea {
 header {
     margin-bottom: 1rem;
 }
+
+.not-found {
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+    color: vars.$primary;
+}


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/b7538343-1717-4209-94a4-ad24ac28ef33)

After:

![image](https://github.com/user-attachments/assets/81a03ac6-6aec-45e3-82d2-fdbc9edccc9d)
