### PR TITLE
Add labels to denomination buttons

### DIFF
--- a/src/components/settings/Denomination.tsx
+++ b/src/components/settings/Denomination.tsx
@@ -1,7 +1,9 @@
 import btcSvg from "../../assets/btc.svg";
 import satSvg from "../../assets/sat.svg";
+import { BTC } from "../../consts/Assets";
 import { Denomination as Denoms } from "../../consts/Enums";
 import { useGlobalContext } from "../../context/Global";
+import { formatDenomination } from "../../utils/denomination";
 
 const Denomination = () => {
     const { denomination, setDenomination, t } = useGlobalContext();
@@ -12,9 +14,32 @@ const Denomination = () => {
         );
     };
 
-    return (
+    const Desktop = () => (
+        <div class="denomination-desktop" title={t("denomination_tooltip")}>
+            <button
+                data-testid="btc-denomination-button"
+                class={denomination() == Denoms.Btc ? "active" : ""}
+                onClick={() => setDenomination(Denoms.Btc)}>
+                <span class="denominator" data-denominator={Denoms.Btc} />
+                <span class="denominator-label">
+                    {formatDenomination(Denoms.Btc, BTC)}
+                </span>
+            </button>
+            <button
+                data-testid="sats-denomination-button"
+                class={denomination() == Denoms.Sat ? "active" : ""}
+                onClick={() => setDenomination(Denoms.Sat)}>
+                <span class="denominator" data-denominator={Denoms.Sat} />
+                <span class="denominator-label">
+                    {formatDenomination(Denoms.Sat, Denoms.Sat)}
+                </span>
+            </button>
+        </div>
+    );
+
+    const Mobile = () => (
         <div
-            class="denomination toggle"
+            class="denomination-mobile denomination toggle"
             title={t("denomination_tooltip")}
             onClick={toggleDenomination}>
             <img
@@ -28,6 +53,13 @@ const Denomination = () => {
                 alt="denominator"
             />
         </div>
+    );
+
+    return (
+        <>
+            <Mobile />
+            <Desktop />
+        </>
     );
 };
 

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -90,7 +90,7 @@ hr.spacer {
     left: 10px;
     cursor: pointer;
     &:hover {
-        background-color: rgba(255, 255, 255, 0.25);
+        background: rgb(20, 40, 63);
     }
 }
 

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -383,6 +383,72 @@ textarea {
         border: 1px solid rgba(255, 255, 255, 0.25);
     }
 }
+.denomination-desktop {
+    display: flex;
+    max-width: max-content;
+    flex-grow: 0;
+    gap: 1px;
+    padding: 2px;
+    height: fit-content;
+    border: 1px dashed rgba(255, 255, 255, 0.2);
+    background: rgb(11, 22, 34);
+    border-radius: 20px;
+    span {
+        filter: grayscale(1);
+    }
+    button {
+        font-size: 14px;
+        display: flex;
+        align-items: center;
+        flex-grow: 0;
+        gap: 10px;
+        padding: 0.3rem 0.9rem;
+        background: rgb(11, 22, 34);
+        color: rgba(255, 255, 255, 0.5);
+        cursor: pointer;
+        position: relative;
+        box-sizing: border-box;
+        border: 1px solid transparent; // ensures the button is always the same size
+        &:first-child {
+            border-radius: 20px 0 0 20px;
+        }
+        &:last-child {
+            border-radius: 0 20px 20px 0;
+        }
+        &:hover {
+            background: rgb(20, 40, 63);
+            color: rgba(255, 255, 255, 0.8);
+            border: 1px dashed rgba(255, 175, 75, 0.15);
+        }
+        &.active {
+            color: vars.$primary;
+            background-color: rgb(30, 45, 60);
+            border: 1px dashed rgba(255, 175, 75, 0.2);
+            span {
+                filter: none;
+            }
+        }
+        // for keyboard navigation
+        &:focus-visible {
+            outline: none;
+            border: 1px solid vars.$primary;
+        }
+        &.active:focus-visible {
+            outline: none;
+            border: 1px solid vars.$primary;
+        }
+    }
+}
+@media (max-width: 488px) {
+    .denomination-desktop {
+        display: none;
+    }
+}
+@media (min-width: 489px) {
+    .denomination-mobile {
+        display: none;
+    }
+}
 .denomination img {
     filter: brightness(10);
     cursor: pointer;

--- a/tests/components/Denomination.spec.tsx
+++ b/tests/components/Denomination.spec.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+
+import Denomination from "../../src/components/settings/Denomination";
+import { TestComponent, contextWrapper, globalSignals } from "../helper";
+
+describe("Denomination", () => {
+    test("should change denomination on button click", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Denomination />
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+
+        const btcDenomination = (await screen.findByTestId(
+            "btc-denomination-button",
+        )) as HTMLDivElement;
+        const satsDenomination = (await screen.findByTestId(
+            "sats-denomination-button",
+        )) as HTMLDivElement;
+
+        expect(btcDenomination.classList.contains("active")).toBeFalsy();
+        expect(satsDenomination.classList.contains("active")).toBeTruthy();
+        expect(globalSignals.denomination()).toEqual("sat");
+
+        fireEvent.click(btcDenomination);
+
+        expect(btcDenomination.classList.contains("active")).toBeTruthy();
+        expect(satsDenomination.classList.contains("active")).toBeFalsy();
+        expect(globalSignals.denomination()).toEqual("btc");
+    });
+});


### PR DESCRIPTION
Add labels to denomination buttons as a way of increasing clarity on the meaning of each symbol.

### Screenshots

#### Desktop / Tablet
![image](https://github.com/user-attachments/assets/2798beb6-fc26-4129-ad9e-f8143d7ae425)

#### Mobile
Aligned items on center to prevent elements from overlapping on small screens

![image](https://github.com/user-attachments/assets/296c47c8-aebb-4c51-a724-6edab2c36897)
