### PR TITLE
Refund: use 3rd party blockexplorer endpoints to double check if a lockup address has funds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,8 +36,6 @@ jobs:
           cache: "npm"
 
       - name: Start regtest
-        env:
-          COMPOSE_PROFILES: ci
         run: |
           git submodule init
           git submodule update

--- a/src/components/BlockExplorerLink.tsx
+++ b/src/components/BlockExplorerLink.tsx
@@ -7,7 +7,6 @@ import {
     createSignal,
 } from "solid-js";
 
-import { RBTC } from "../consts/Assets";
 import { SwapType } from "../consts/Enums";
 import {
     ChainSwap,
@@ -15,6 +14,7 @@ import {
     SomeSwap,
     SubmarineSwap,
     getRelevantAssetForSwap,
+    isRsk,
 } from "../utils/swapCreator";
 import BlockExplorer from "./BlockExplorer";
 
@@ -50,8 +50,6 @@ const BlockExplorerLink = (props: {
     swap: Accessor<SomeSwap>;
     swapStatus: Accessor<string>;
 }) => {
-    const isRsk = () => getRelevantAssetForSwap(props.swap()) === RBTC;
-
     return (
         <Show
             when={props.swap().type !== SwapType.Chain}
@@ -62,7 +60,7 @@ const BlockExplorerLink = (props: {
                 />
             }>
             <Switch>
-                <Match when={!isRsk()}>
+                <Match when={!isRsk(props.swap())}>
                     {/* Refund transactions are handled in SwapRefunded */}
                     <Show
                         when={
@@ -85,7 +83,7 @@ const BlockExplorerLink = (props: {
                 </Match>
 
                 {/* Showing addresses makes no sense for EVM based chains */}
-                <Match when={isRsk()}>
+                <Match when={isRsk(props.swap())}>
                     <Show
                         when={props.swap().claimTx !== undefined}
                         fallback={

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,153 @@
+import { useSearchParams } from "@solidjs/router";
+import {
+    Accessor,
+    For,
+    Setter,
+    createMemo,
+    mergeProps,
+    onMount,
+} from "solid-js";
+
+import { useGlobalContext } from "../context/Global";
+import "../style/pagination.scss";
+
+const Pagination = <T,>(initialProps: {
+    items: Accessor<T[]>;
+    setDisplayedItems: (items: T[]) => void;
+    currentPage: Accessor<number>;
+    setCurrentPage: Setter<number>;
+    sort?: (items: T[]) => T[];
+    itemsPerPage?: number;
+    totalItems: number;
+}) => {
+    const props = mergeProps({ itemsPerPage: 15 }, initialProps);
+    const { t } = useGlobalContext();
+
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const updateDisplayedItems = () => {
+        const indexOfLastItem = props.currentPage() * props.itemsPerPage;
+        const indexOfFirstItem = indexOfLastItem - props.itemsPerPage;
+
+        let displayedItems = props.items();
+
+        if (typeof props.sort === "function") {
+            displayedItems = props.sort(displayedItems);
+        }
+
+        props.setDisplayedItems(
+            displayedItems.slice(indexOfFirstItem, indexOfLastItem),
+        );
+    };
+
+    onMount(() => updateDisplayedItems());
+
+    const numberOfPages = createMemo(() => {
+        const totalPages = Math.ceil(props.totalItems / props.itemsPerPage);
+        const numberOfPages = Array.from(
+            { length: totalPages },
+            (_, index) => index + 1,
+        );
+
+        let page = Number(searchParams.page);
+
+        if (isNaN(page) || page < 1 || page > numberOfPages.length) {
+            page = 1;
+            setSearchParams({ page });
+        }
+
+        props.setCurrentPage(page);
+
+        return numberOfPages;
+    });
+
+    const navigatePreviously = () => {
+        const page = props.setCurrentPage((prev: number) => prev - 1);
+        setSearchParams({ page });
+        updateDisplayedItems();
+    };
+
+    const navigateToNumber = (pageNumber: number) => {
+        const page = props.setCurrentPage(pageNumber);
+        setSearchParams({ page });
+        updateDisplayedItems();
+    };
+
+    const navigateNext = () => {
+        const page = props.setCurrentPage((prev: number) => prev + 1);
+        setSearchParams({ page });
+        updateDisplayedItems();
+    };
+
+    const pageNumbers = () => {
+        const current = props.currentPage();
+        const total = numberOfPages().length;
+
+        let start: number;
+        let end: number;
+
+        // Always displays a maximum of 5 page numbers
+        if (current <= 2) {
+            start = 0;
+            end = 5;
+        } else if (current >= total - 1) {
+            start = total - 5;
+            end = total;
+        } else {
+            start = current - 3;
+            end = current + 2;
+        }
+
+        return numberOfPages().slice(Math.max(0, start), Math.min(total, end));
+    };
+
+    return (
+        <>
+            <nav class="pagination">
+                <ul>
+                    <li>
+                        <button
+                            data-testid="previous-page"
+                            disabled={props.currentPage() === 1}
+                            onClick={navigatePreviously}>
+                            {t("back").toUpperCase()}
+                        </button>
+                    </li>
+                    <For each={pageNumbers()}>
+                        {(pageNumber) => (
+                            <li class="pagination-item">
+                                <button
+                                    data-testid={`page-${pageNumber}`}
+                                    class={`${props.currentPage() === pageNumber ? "active" : ""}`}
+                                    onClick={() =>
+                                        navigateToNumber(pageNumber)
+                                    }>
+                                    {pageNumber}
+                                </button>
+                            </li>
+                        )}
+                    </For>
+                    <li>
+                        <button
+                            data-testid="next-page"
+                            disabled={
+                                props.currentPage() ===
+                                numberOfPages()[numberOfPages().length - 1]
+                            }
+                            onClick={navigateNext}>
+                            {t("next").toUpperCase()}
+                        </button>
+                    </li>
+                </ul>
+            </nav>
+            <p>
+                {t("pagination_info", {
+                    start: props.currentPage,
+                    end: numberOfPages().length,
+                })}
+            </p>
+        </>
+    );
+};
+
+export default Pagination;

--- a/src/components/SwapList.tsx
+++ b/src/components/SwapList.tsx
@@ -10,7 +10,7 @@ import { SwapIcons } from "./SwapIcons";
 
 type Swap = (SomeSwap | RescuableSwap) & { disabled?: boolean };
 
-const getSwapDate = (swap: Swap) => {
+const getSwapDate = <T extends Swap>(swap: T) => {
     if ("date" in swap) {
         return swap.date;
     }
@@ -18,12 +18,28 @@ const getSwapDate = (swap: Swap) => {
     return swap.createdAt * 1_000;
 };
 
+export const sortSwaps = <T extends Swap>(swaps: T[]) => {
+    return swaps.sort((a, b) => {
+        const aDate = getSwapDate(a);
+        const bDate = getSwapDate(b);
+
+        if (a.disabled !== b.disabled) {
+            return a.disabled ? 1 : -1;
+        }
+
+        // Within each group (disabled/enabled), sort by date descending
+        return aDate > bDate ? -1 : aDate === bDate ? 0 : 1;
+    });
+};
+
 const SwapList = (props: {
     swapsSignal: Accessor<Swap[]>;
-    action: string;
+    action: (swap: Swap) => string;
     onDelete?: () => Promise<unknown>;
     onClick?: (swap: Swap) => void;
     surroundingSeparators?: boolean;
+    hideStatusOnMobile?: boolean;
+    hideDateOnMobile?: boolean;
 }) => {
     const navigate = useNavigate();
     const { deleteSwap, t } = useGlobalContext();
@@ -31,17 +47,7 @@ const SwapList = (props: {
     const [lastSwap, setLastSwap] = createSignal();
 
     createEffect(() => {
-        const sorted = props.swapsSignal().sort((a: Swap, b: Swap) => {
-            const aDate = getSwapDate(a);
-            const bDate = getSwapDate(b);
-
-            if (a.disabled !== b.disabled) {
-                return a.disabled ? 1 : -1;
-            }
-
-            // Within each group (disabled/enabled), sort by date descending
-            return aDate > bDate ? -1 : aDate === bDate ? 0 : 1;
-        });
+        const sorted = sortSwaps(props.swapsSignal());
         setSortedSwaps(sorted);
         setLastSwap(sorted[sorted.length - 1]);
     });
@@ -82,15 +88,18 @@ const SwapList = (props: {
                                     navigate(`/swap/${swap.id}`);
                                 }
                             }}>
-                            <a class="btn-small hidden-mobile" href="#">
-                                {props.action}
+                            <a
+                                class={`btn-small ${props.hideStatusOnMobile ? "hidden-mobile" : ""}`}
+                                href="#">
+                                {props.action(swap)}
                             </a>
                             <SwapIcons swap={swap} />
                             <span class="swaplist-asset-id">
                                 {t("id")}:&nbsp;
                                 <span class="monospace">{swap.id}</span>
                             </span>
-                            <span class="swaplist-asset-date">
+                            <span
+                                class={`swaplist-asset-date ${props.hideDateOnMobile ? "hidden-mobile" : ""}`}>
                                 {t("created")}:&nbsp;
                                 <span class="monospace">
                                     {formatDate(getSwapDate(swap))}

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,7 @@ const defaults = {
 
 type Asset = {
     blockExplorerUrl?: Url;
+    blockExplorerApis?: Url[];
 
     rifRelay?: string;
     contracts?: {

--- a/src/configs/beta.json
+++ b/src/configs/beta.json
@@ -12,13 +12,33 @@
             "blockExplorerUrl": {
                 "normal": "https://mempool.space",
                 "tor": "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion"
-            }
+            },
+            "blockExplorerApis": [
+                {
+                    "normal": "https://blockstream.info/api",
+                    "tor": "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/api"
+                },
+                {
+                    "normal": "https://mempool.space/api",
+                    "tor": "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/api"
+                }
+            ]
         },
         "L-BTC": {
             "blockExplorerUrl": {
                 "normal": "https://blockstream.info/liquid",
                 "tor": "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/liquid"
-            }
+            },
+            "blockExplorerApis": [
+                {
+                    "normal": "https://blockstream.info/liquid/api",
+                    "tor": "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/liquid/api"
+                },
+                {
+                    "normal": "https://liquid.network/api",
+                    "tor": "http://liquidmom47f6s3m53ebfxn47p76a6tlnxib3wp6deux7wuzotdr6cyd.onion/api"
+                }
+            ]
         },
         "RBTC": {
             "blockExplorerUrl": {

--- a/src/configs/mainnet.json
+++ b/src/configs/mainnet.json
@@ -11,13 +11,33 @@
             "blockExplorerUrl": {
                 "normal": "https://mempool.space",
                 "tor": "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion"
-            }
+            },
+            "blockExplorerApis": [
+                {
+                    "normal": "https://blockstream.info/api",
+                    "tor": "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/api"
+                },
+                {
+                    "normal": "https://mempool.space/api",
+                    "tor": "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/api"
+                }
+            ]
         },
         "L-BTC": {
             "blockExplorerUrl": {
                 "normal": "https://blockstream.info/liquid",
                 "tor": "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/liquid"
-            }
+            },
+            "blockExplorerApis": [
+                {
+                    "normal": "https://blockstream.info/liquid/api",
+                    "tor": "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/liquid/api"
+                },
+                {
+                    "normal": "https://liquid.network/api",
+                    "tor": "http://liquidmom47f6s3m53ebfxn47p76a6tlnxib3wp6deux7wuzotdr6cyd.onion/api"
+                }
+            ]
         },
         "RBTC": {
             "blockExplorerUrl": {

--- a/src/configs/pro.json
+++ b/src/configs/pro.json
@@ -14,11 +14,31 @@
                 "tor": "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion"
             }
         },
+        "blockExplorerApis": [
+            {
+                "normal": "https://blockstream.info/api",
+                "tor": "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/api"
+            },
+            {
+                "normal": "https://mempool.space/api",
+                "tor": "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/api"
+            }
+        ],
         "L-BTC": {
             "blockExplorerUrl": {
                 "normal": "https://blockstream.info/liquid",
                 "tor": "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/liquid"
-            }
+            },
+            "blockExplorerApis": [
+                {
+                    "normal": "https://blockstream.info/liquid/api",
+                    "tor": "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/liquid/api"
+                },
+                {
+                    "normal": "https://liquid.network/api",
+                    "tor": "http://liquidmom47f6s3m53ebfxn47p76a6tlnxib3wp6deux7wuzotdr6cyd.onion/api"
+                }
+            ]
         },
         "RBTC": {
             "blockExplorerUrl": {

--- a/src/configs/regtest.json
+++ b/src/configs/regtest.json
@@ -8,12 +8,22 @@
         "BTC": {
             "blockExplorerUrl": {
                 "normal": "http://localhost:4002"
-            }
+            },
+            "blockExplorerApis": [
+                {
+                    "normal": "http://localhost:4002/api"
+                }
+            ]
         },
         "L-BTC": {
             "blockExplorerUrl": {
                 "normal": "http://localhost:4003"
-            }
+            },
+            "blockExplorerApis": [
+                {
+                    "normal": "http://localhost:4003/api"
+                }
+            ]
         },
         "RBTC": {
             "blockExplorerUrl": {

--- a/src/configs/testnet.json
+++ b/src/configs/testnet.json
@@ -9,17 +9,42 @@
             "blockExplorerUrl": {
                 "normal": "https://blockstream.info/testnet",
                 "tor": "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/testnet"
-            }
+            },
+            "blockExplorerApis": [
+                {
+                    "normal": "https://blockstream.info/testnet/api",
+                    "tor": "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/api"
+                },
+                {
+                    "normal": "https://mempool.space/testnet/api",
+                    "tor": "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/testnet/api"
+                }
+            ]
         },
         "L-BTC": {
             "blockExplorerUrl": {
                 "normal": "https://blockstream.info/liquidtestnet",
                 "tor": "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/liquidtestnet"
-            }
+            },
+            "blockExplorerApis": [
+                {
+                    "normal": "https://blockstream.info/liquidtestnet/api",
+                    "tor": "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/liquidtestnet/api"
+                },
+                {
+                    "normal": "https://liquid.network/liquidtestnet/api",
+                    "tor": "http://liquidmom47f6s3m53ebfxn47p76a6tlnxib3wp6deux7wuzotdr6cyd.onion/liquidtestnet/api"
+                }
+            ]
         },
         "RBTC": {
             "blockExplorerUrl": {
-                "normal": "https://rootstock-testnet.blockscout.com"
+                "normal": "https://rootstock-testnet.blockscout.com",
+                "tor": "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/testnet"
+            },
+            "apiUrl": {
+                "normal": "https://rootstock-testnet.blockscout.com/api",
+                "tor": "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/api/testnet"
             },
             "network": {
                 "chainName": "Rootstock Testnet",

--- a/src/context/Pay.tsx
+++ b/src/context/Pay.tsx
@@ -7,6 +7,7 @@ import {
 } from "solid-js";
 import type { JSX } from "solid-js";
 
+import { LockupTransaction } from "../utils/boltzClient";
 import { SomeSwap } from "../utils/swapCreator";
 
 export type PayContextType = {
@@ -18,6 +19,12 @@ export type PayContextType = {
     setSwapStatus: Setter<string>;
     swapStatusTransaction: Accessor<SwapStatusTransaction>;
     setSwapStatusTransaction: Setter<SwapStatusTransaction>;
+    refundableUTXOs: Accessor<
+        (Partial<LockupTransaction> & Pick<LockupTransaction, "hex">)[]
+    >;
+    setRefundableUTXOs: Setter<
+        (Partial<LockupTransaction> & Pick<LockupTransaction, "hex">)[]
+    >;
 };
 
 const PayContext = createContext<PayContextType>();
@@ -36,6 +43,9 @@ const PayProvider = (props: { children: JSX.Element }) => {
     const [swapStatus, setSwapStatus] = createSignal<string>("");
     const [swapStatusTransaction, setSwapStatusTransaction] =
         createSignal<SwapStatusTransaction>({});
+    const [refundableUTXOs, setRefundableUTXOs] = createSignal<
+        (Partial<LockupTransaction> & Pick<LockupTransaction, "hex">)[]
+    >([]);
 
     return (
         <PayContext.Provider
@@ -48,6 +58,8 @@ const PayProvider = (props: { children: JSX.Element }) => {
                 setSwapStatus,
                 swapStatusTransaction,
                 setSwapStatusTransaction,
+                refundableUTXOs,
+                setRefundableUTXOs,
             }}>
             {props.children}
         </PayContext.Provider>

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -245,6 +245,10 @@ const dict = {
         no_swaps_found: "No swaps found",
         rif_extra_fee:
             "Wallet doesn't contain enough RBTC, fee adjusted to include RIF Relay fee!",
+        no_refund_due: "No refund due",
+        back: "Back",
+        next: "Next",
+        pagination_info: "Page {{ start }} of {{ end }}",
     },
     de: {
         language: "Deutsch",
@@ -502,6 +506,10 @@ const dict = {
         no_swaps_found: "Keine Swaps gefunden",
         rif_extra_fee:
             "Wallet enthält nicht genug RBTC, Gebühr um RIF-Relay-Gebühr angepasst!",
+        no_refund_due: "Kein Refund fällig",
+        back: "Zurück",
+        next: "Weiter",
+        pagination_info: "Seite {{ start }} von {{ end }}",
     },
     es: {
         language: "Español",
@@ -755,6 +763,10 @@ const dict = {
         no_swaps_found: "No se encontraron swaps",
         rif_extra_fee:
             "El monedero no contiene suficientes RBTC, comisión ajustado para incluir comisión de RIF Relay!",
+        no_refund_due: "Sin reembolso pendiente",
+        back: "Atrás",
+        next: "Siguiente",
+        pagination_info: "Página {{ start }} de {{ end }}",
     },
     zh: {
         language: "中文",
@@ -982,6 +994,10 @@ const dict = {
         rescue_key: "救援钥匙",
         no_swaps_found: "未找到交换",
         rif_extra_fee: "钱包中没有足够的 RBTC，费用已调整为包括 RIF 中继费！",
+        no_refund_due: "暂无退款",
+        back: "回一页",
+        next: "下一页",
+        pagination_info: "{{ start }} 的 {{ end }} 页",
     },
     ja: {
         language: "日本語",
@@ -1233,6 +1249,10 @@ const dict = {
         no_swaps_found: "スワップが見つからない",
         rif_extra_fee:
             "ウォレットに十分なRBTCがないため、RIFリレー手数料を含めて手数料を調整！",
+        no_refund_due: "返金予定なし",
+        back: "戻る",
+        next: "次へ",
+        pagination_info: "{{ end }} ページ中 {{ start }} ページ目",
     },
 };
 

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -153,7 +153,8 @@ const History = () => {
                         onDelete={async () => {
                             setSwaps(await getSwaps());
                         }}
-                        action={t("view")}
+                        action={() => t("view")}
+                        hideStatusOnMobile
                     />
                     <Show when={swaps().length > 0}>
                         <Show when={!isIos()}>

--- a/src/status/SwapExpired.tsx
+++ b/src/status/SwapExpired.tsx
@@ -1,32 +1,15 @@
 import { useNavigate } from "@solidjs/router";
-import log from "loglevel";
-import { Accessor, Show, createResource } from "solid-js";
+import { Accessor } from "solid-js";
 
 import RefundButton from "../components/RefundButton";
 import { useGlobalContext } from "../context/Global";
 import { usePayContext } from "../context/Pay";
-import { getLockupTransaction } from "../utils/boltzClient";
-import { formatError } from "../utils/errors";
 import { ChainSwap, SubmarineSwap } from "../utils/swapCreator";
 
 const SwapExpired = () => {
     const navigate = useNavigate();
     const { failureReason, swap } = usePayContext();
-    const { t, setTransactionToRefund, transactionToRefund } =
-        useGlobalContext();
-
-    createResource(async () => {
-        setTransactionToRefund(null);
-        try {
-            const res = await getLockupTransaction(swap().id, swap().type);
-            log.debug(`got swap transaction for ${swap().id}`);
-            setTransactionToRefund(res.hex);
-        } catch (e) {
-            log.warn(
-                `no swap transaction for: ${swap().id}: ${formatError(e)}`,
-            );
-        }
-    });
+    const { t } = useGlobalContext();
 
     return (
         <div>
@@ -34,12 +17,8 @@ const SwapExpired = () => {
                 {t("failure_reason")}: {failureReason()}
             </p>
             <hr />
-            <Show when={transactionToRefund() !== null}>
-                <RefundButton
-                    swap={swap as Accessor<SubmarineSwap | ChainSwap>}
-                />
-                <hr />
-            </Show>
+            <RefundButton swap={swap as Accessor<SubmarineSwap | ChainSwap>} />
+            <hr />
             <button class="btn" onClick={() => navigate("/swap")}>
                 {t("new_swap")}
             </button>

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -245,6 +245,7 @@ hr.spacer {
 .btn-danger:hover {
     background: vars.$error;
 }
+.center,
 .btns {
     display: flex;
     align-items: center;
@@ -499,6 +500,20 @@ textarea {
     border-left: 0;
     border-right: 0;
     background: #0003;
+}
+.refund {
+    max-width: fit-content;
+
+    p {
+        max-width: 480px;
+        margin: 0 auto;
+    }
+}
+
+@media (max-width: 488px) {
+    .frame {
+        max-width: 480px;
+    }
 }
 
 @media (min-width: 488px) {

--- a/src/style/pagination.scss
+++ b/src/style/pagination.scss
@@ -1,0 +1,36 @@
+.pagination {
+    z-index: 0;
+
+    ul {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 0;
+        gap: 0.5rem;
+    }
+
+    button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+
+    button.active {
+        background-color: rgb(20, 43, 70);
+    }
+
+    li {
+        list-style: none;
+    }
+
+    button {
+        background-color: transparent;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        color: rgb(210, 218, 231);
+        cursor: pointer;
+        padding: 0.5rem 1rem;
+        border-radius: 0.5rem;
+        &:hover {
+            background-color: rgb(20, 43, 70);
+        }
+    }
+}

--- a/src/style/swaplist.scss
+++ b/src/style/swaplist.scss
@@ -16,9 +16,21 @@
         background-color: rgba(0, 0, 0, 0.3);
     }
 
+    .swap-status {
+        white-space: nowrap;
+    }
+
     &.disabled {
         opacity: 0.5;
         cursor: not-allowed;
+
+        .btn-small {
+            background-color: #fff;
+
+            &:hover {
+                cursor: not-allowed;
+            }
+        }
     }
 }
 

--- a/src/utils/blockchain.ts
+++ b/src/utils/blockchain.ts
@@ -1,0 +1,79 @@
+import log from "loglevel";
+
+import { chooseUrl, config } from "../config";
+import { SwapType } from "../consts/Enums";
+import { LockupTransaction } from "./boltzClient";
+import { ChainSwap, SubmarineSwap } from "./swapCreator";
+
+export type UTXO = {
+    txid: string;
+    vout: number;
+};
+
+export const fetchUTXOsWithFailover = async (
+    asset: string,
+    address: string,
+): Promise<UTXO[]> => {
+    for (const url of config.assets[asset].blockExplorerApis) {
+        try {
+            const basePath = chooseUrl(url);
+            const response = await fetch(`${basePath}/address/${address}/utxo`);
+
+            if (!response.ok) {
+                log.error(`Failed to fetch UTXOs for ${address}`);
+                continue;
+            }
+
+            return (await response.json()) as UTXO[];
+        } catch (e) {
+            log.error(`Failed to fetch UTXOs for ${address}: ${e.stack}`);
+            continue;
+        }
+    }
+
+    throw new Error("all block explorer APIs failed");
+};
+
+export const fetchRawTxWithFailover = async (
+    asset: string,
+    txid: string,
+): Promise<Pick<LockupTransaction, "hex">> => {
+    for (const url of config.assets[asset].blockExplorerApis) {
+        try {
+            const basePath = chooseUrl(url);
+            const response = await fetch(`${basePath}/tx/${txid}/hex`);
+
+            if (!response.ok) {
+                log.error(`Failed to fetch raw tx for ${txid}`);
+                continue;
+            }
+
+            return { hex: await response.text() };
+        } catch (e) {
+            log.error(`Failed to fetch raw tx for ${txid}: ${e.stack}`);
+            continue;
+        }
+    }
+
+    throw new Error("all block explorer APIs failed");
+};
+
+export const getSwapUTXOs = async (swap: ChainSwap | SubmarineSwap) => {
+    const address =
+        swap.type === SwapType.Chain
+            ? (swap as ChainSwap).lockupDetails.lockupAddress
+            : (swap as SubmarineSwap).address;
+
+    const utxos = await fetchUTXOsWithFailover(swap.assetSend, address);
+
+    const rawTxs: Pick<LockupTransaction, "hex">[] = [];
+
+    for (const utxo of utxos) {
+        const rawTx = await fetchRawTxWithFailover(swap.assetSend, utxo.txid);
+        rawTxs.push({
+            hex: rawTx.hex,
+        });
+    }
+
+    return rawTxs;
+};

--- a/src/utils/boltzClient.ts
+++ b/src/utils/boltzClient.ts
@@ -180,6 +180,13 @@ export type RescuableSwap = {
     createdAt: number;
 };
 
+export type LockupTransaction = {
+    id: string;
+    hex: string;
+    timeoutBlockHeight: number;
+    timeoutEta?: number;
+};
+
 export const getPairs = async (): Promise<Pairs> => {
     const [submarine, reverse, chain] = await Promise.all([
         fetcher<SubmarinePairsTaproot>("/v2/swap/submarine"),
@@ -400,12 +407,7 @@ export const broadcastTransaction = async (
 export const getLockupTransaction = async (
     id: string,
     type: SwapType,
-): Promise<{
-    id: string;
-    hex: string;
-    timeoutBlockHeight: number;
-    timeoutEta?: number;
-}> => {
+): Promise<LockupTransaction> => {
     switch (type) {
         case SwapType.Submarine:
             return fetcher<{

--- a/src/utils/refund.ts
+++ b/src/utils/refund.ts
@@ -194,7 +194,7 @@ export const refund = async <T extends SubmarineSwap | ChainSwap>(
     deriveKey: deriveKeyFn,
     swap: T,
     refundAddress: string,
-    transactionToRefund: { hex: string; timeoutBlockHeight: number },
+    transactionToRefund: { hex: string; timeoutBlockHeight?: number },
     cooperative: boolean,
     externalBroadcast: boolean,
 ): Promise<T> => {

--- a/src/utils/refund.ts
+++ b/src/utils/refund.ts
@@ -12,12 +12,16 @@ import log from "loglevel";
 
 import { LBTC } from "../consts/Assets";
 import { SwapType } from "../consts/Enums";
+import { swapStatusPending } from "../consts/SwapStatus";
 import { deriveKeyFn } from "../context/Global";
 import secp from "../lazy/secp";
+import { getSwapUTXOs } from "./blockchain";
 import {
+    LockupTransaction,
     TransactionInterface,
     broadcastTransaction,
     getFeeEstimations,
+    getLockupTransaction,
     getPartialRefundSignature,
 } from "./boltzClient";
 import {
@@ -29,7 +33,7 @@ import {
 } from "./compat";
 import { formatError } from "./errors";
 import { parseBlindingKey, parsePrivateKey } from "./helper";
-import { ChainSwap, SubmarineSwap } from "./swapCreator";
+import { ChainSwap, SomeSwap, SubmarineSwap, isRsk } from "./swapCreator";
 import { createMusig, hashForWitnessV1, tweakMusig } from "./taproot/musig";
 
 const refundTaproot = async <T extends TransactionInterface>(
@@ -260,4 +264,73 @@ export const refund = async <T extends SubmarineSwap | ChainSwap>(
     }
 
     return broadcastRefund(swap, refundTransaction, externalBroadcast);
+};
+
+export const isSwapRefundable = (swap: SomeSwap) =>
+    !isRsk(swap) &&
+    [SwapType.Chain, SwapType.Submarine].includes(swap.type) &&
+    ![...Object.values(swapStatusPending)].includes(swap.status);
+
+export const getRefundableUTXOs = async (currentSwap: SomeSwap) => {
+    const mergeLockupWithUTXOs = (
+        lockupTx: LockupTransaction,
+        utxos: Pick<LockupTransaction, "hex">[],
+    ) => {
+        const isLockupTx = (utxo: Pick<LockupTransaction, "hex">) =>
+            utxo.hex === lockupTx.hex;
+
+        if (utxos.some(isLockupTx)) {
+            // If the utxo is also a lockup tx, prefer using it
+            return [lockupTx, ...utxos.filter((tx) => !isLockupTx(tx))];
+        }
+
+        return utxos;
+    };
+
+    if (!isSwapRefundable(currentSwap)) {
+        log.warn(`swap ${currentSwap.id} is not refundable`);
+        return [];
+    }
+
+    const [lockupTxResult, utxosResult] = await Promise.allSettled([
+        getLockupTransaction(currentSwap.id, currentSwap.type),
+        getSwapUTXOs(currentSwap as ChainSwap | SubmarineSwap),
+    ]);
+
+    const lockupTx =
+        lockupTxResult.status === "fulfilled" ? lockupTxResult.value : null;
+    const utxos = utxosResult.status === "fulfilled" ? utxosResult.value : null;
+
+    if (lockupTx && utxos) {
+        return mergeLockupWithUTXOs(lockupTx, utxos);
+    }
+    if (lockupTx && !utxos) {
+        return [lockupTx];
+    }
+    if (!lockupTx && utxos) {
+        return utxos;
+    }
+
+    // if both requests were "rejected"
+    log.error("failed to fetch utxo data for swap: ", currentSwap.id);
+    return [];
+};
+
+export const createRefundList = async (swaps: SomeSwap[]) => {
+    return await Promise.all(
+        swaps.map(async (swap) => {
+            try {
+                const utxos = await getRefundableUTXOs(swap);
+
+                if (utxos.length > 0) {
+                    return swap;
+                }
+
+                return { ...swap, disabled: true };
+            } catch (e) {
+                log.error("error creating refund list: ", e.stack);
+                return { ...swap, disabled: true };
+            }
+        }),
+    );
 };

--- a/src/utils/swapCreator.ts
+++ b/src/utils/swapCreator.ts
@@ -83,6 +83,8 @@ export const getRelevantAssetForSwap = (swap: SwapBase) => {
     }
 };
 
+export const isRsk = (swap: SomeSwap) => getRelevantAssetForSwap(swap) === RBTC;
+
 export const createSubmarine = async (
     pairs: Pairs,
     assetSend: string,

--- a/tests/components/Pagination.spec.tsx
+++ b/tests/components/Pagination.spec.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+
+import Pagination from "../../src/components/Pagination";
+import { BTC } from "../../src/consts/Assets";
+import { SwapType } from "../../src/consts/Enums";
+import { SubmarineSwap } from "../../src/utils/swapCreator";
+import { TestComponent, contextWrapper } from "../helper";
+
+const lockupAddress = "2N4Q5FhU2497BryFfUgbqkAJE87aKHUhXMp";
+const [swaps] = createSignal<SubmarineSwap[]>([
+    {
+        version: 1,
+        date: 1620000000,
+        id: "swap",
+        assetSend: BTC,
+        assetReceive: BTC,
+        sendAmount: 10000,
+        receiveAmount: 10000,
+        type: SwapType.Submarine,
+        address: lockupAddress,
+        bip21: `bitcoin:${lockupAddress}?amount=0.0001`,
+        swapTree: {},
+    },
+] as SubmarineSwap[]);
+
+vi.mock("@solidjs/router", async () => {
+    const actual = await vi.importActual("@solidjs/router");
+    return {
+        ...actual,
+        useSearchParams: () => [{ page: "1" }, vi.fn()],
+    };
+});
+
+describe("Pagination", () => {
+    test("should change page on button click", async () => {
+        const [currentPage, setCurrentPage] = createSignal(1);
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Pagination
+                        items={swaps}
+                        setDisplayedItems={() => null}
+                        totalItems={30}
+                        itemsPerPage={5}
+                        currentPage={currentPage}
+                        setCurrentPage={setCurrentPage}
+                    />
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+
+        const previousButton = (await screen.findByTestId(
+            "previous-page",
+        )) as HTMLButtonElement;
+        const page1 = (await screen.findByTestId("page-1")) as HTMLDivElement;
+        const page2 = (await screen.findByTestId("page-2")) as HTMLDivElement;
+        const nextButton = (await screen.findByTestId(
+            "next-page",
+        )) as HTMLButtonElement;
+
+        expect(page1.classList.contains("active")).toBeTruthy();
+        expect(page2.classList.contains("active")).toBeFalsy();
+
+        // Click on page 2
+        fireEvent.click(page2);
+        expect(page1.classList.contains("active")).toBeFalsy();
+        expect(page2.classList.contains("active")).toBeTruthy();
+
+        // Click on previous button
+        fireEvent.click(previousButton);
+        expect(page1.classList.contains("active")).toBeTruthy();
+        expect(page2.classList.contains("active")).toBeFalsy();
+
+        // Click on next button
+        fireEvent.click(nextButton);
+        expect(page1.classList.contains("active")).toBeFalsy();
+        expect(page2.classList.contains("active")).toBeTruthy();
+    });
+
+    test("should disable previous and next buttons when on first and last page", async () => {
+        const [currentPage, setCurrentPage] = createSignal(1);
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Pagination
+                        items={swaps}
+                        setDisplayedItems={() => null}
+                        totalItems={25}
+                        itemsPerPage={5}
+                        currentPage={currentPage}
+                        setCurrentPage={setCurrentPage}
+                    />
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+
+        const previousButton = (await screen.findByTestId(
+            "previous-page",
+        )) as HTMLButtonElement;
+        const page1 = (await screen.findByTestId("page-1")) as HTMLDivElement;
+        const page5 = (await screen.findByTestId("page-5")) as HTMLDivElement;
+        const nextButton = (await screen.findByTestId(
+            "next-page",
+        )) as HTMLButtonElement;
+
+        // Check if previous button is disabled and page 1 is active
+        expect(previousButton.disabled).toBeTruthy();
+        expect(page1.classList.contains("active")).toBeTruthy();
+
+        // Check if next button is not disabled
+        expect(nextButton.disabled).toBeFalsy();
+
+        // Click on page 5
+        fireEvent.click(page5);
+        expect(nextButton.disabled).toBeTruthy();
+
+        // Check if previous button is not disabled
+        expect(previousButton.disabled).toBeFalsy();
+    });
+});

--- a/tests/components/RefundButton.spec.tsx
+++ b/tests/components/RefundButton.spec.tsx
@@ -6,15 +6,7 @@ import RefundButton from "../../src/components/RefundButton";
 import { BTC, LN } from "../../src/consts/Assets";
 import { SwapType } from "../../src/consts/Enums";
 import { ChainSwap, SubmarineSwap } from "../../src/utils/swapCreator";
-import { contextWrapper } from "../helper";
-
-vi.mock("../../src/utils/boltzClient", () => {
-    return {
-        getLockupTransaction: vi.fn(() => {
-            return { timeoutBlockHeight: 10, timeoutEta: 10 };
-        }),
-    };
-});
+import { TestComponent, contextWrapper, payContext } from "../helper";
 
 describe("RefundButton", () => {
     test("should render RefundButton", () => {
@@ -32,9 +24,18 @@ describe("RefundButton", () => {
             assetReceive: LN,
             type: SwapType.Submarine,
         } as SubmarineSwap);
-        render(() => <RefundButton swap={swap} />, {
-            wrapper: contextWrapper,
-        });
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <RefundButton swap={swap} />,
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+        payContext.setRefundableUTXOs([{ hex: "0x0" }]);
         const input = (await screen.findByTestId(
             "refundAddress",
         )) as HTMLInputElement;
@@ -67,9 +68,18 @@ describe("RefundButton", () => {
             bip21: `bitcoin:${lockupAddress}?amount=0.0001`,
             swapTree: {},
         } as SubmarineSwap);
-        render(() => <RefundButton swap={swap} />, {
-            wrapper: contextWrapper,
-        });
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <RefundButton swap={swap} />,
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+        payContext.setRefundableUTXOs([{ hex: "0x0" }]);
         const input = (await screen.findByTestId(
             "refundAddress",
         )) as HTMLInputElement;
@@ -95,9 +105,18 @@ describe("RefundButton", () => {
             assetReceive: LN,
             type: SwapType.Submarine,
         } as SubmarineSwap);
-        render(() => <RefundButton swap={swap} />, {
-            wrapper: contextWrapper,
-        });
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <RefundButton swap={swap} />,
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+        payContext.setRefundableUTXOs([{ hex: "0x0" }]);
         const input = (await screen.findByTestId(
             "refundAddress",
         )) as HTMLInputElement;

--- a/tests/components/SwapList.spec.tsx
+++ b/tests/components/SwapList.spec.tsx
@@ -19,9 +19,17 @@ describe("SwapList", () => {
 
         const {
             container: { firstChild: firstChild },
-        } = render(() => <SwapList swapsSignal={swapsSignal} action="Test" />, {
-            wrapper: contextWrapper,
-        });
+        } = render(
+            () => (
+                <SwapList
+                    swapsSignal={swapsSignal}
+                    action={(swap) => swap.status}
+                />
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
 
         const childNodes = [];
         firstChild.childNodes.forEach((node) => {

--- a/tests/pages/RefundExternal.spec.tsx
+++ b/tests/pages/RefundExternal.spec.tsx
@@ -3,15 +3,32 @@ import { userEvent } from "@testing-library/user-event";
 
 import i18n from "../../src/i18n/i18n";
 import RefundExternal, { RefundBtcLike } from "../../src/pages/RefundExternal";
-import { TestComponent, contextWrapper, globalSignals } from "../helper";
+import {
+    TestComponent,
+    contextWrapper,
+    globalSignals,
+    payContext,
+} from "../helper";
 
 /* eslint-disable  require-await,@typescript-eslint/require-await,@typescript-eslint/no-explicit-any */
 
 vi.mock("../../src/utils/boltzClient", () => {
     return {
-        getLockupTransaction: vi.fn(() => {
-            return { timeoutBlockHeight: 10, timeoutEta: 10 };
-        }),
+        getLockupTransaction: vi.fn(() =>
+            Promise.resolve({
+                id: "1",
+                hex: "0x",
+                timeoutBlockHeight: 10,
+                timeoutEta: 10,
+            }),
+        ),
+    };
+});
+
+vi.mock("../../src/utils/blockchain", () => {
+    return {
+        fetchUTXOsWithFailover: vi.fn(() => Promise.resolve([])),
+        fetchRawTxWithFailover: vi.fn(() => Promise.resolve([])),
     };
 });
 
@@ -59,6 +76,7 @@ describe("RefundExternal", () => {
                     privateKey: "",
                 });
             await user.upload(uploadInput, swapFile);
+            payContext.setRefundableUTXOs([{ hex: "0x0" }]);
 
             expect(
                 await screen.findAllByText(i18n.en.refund),


### PR DESCRIPTION
Closes #809
Closes #832

I have tested it this way:
1. Created the BTC->LN invoice
2. Made the HTLC expire by mining a bunch of blocks
3. Verified the swap is expired due to HTLC timeout -- not refundable yet
4. Sent sats to the lockup address
5. Verified the swap is now refundable
6. Added a refund address and refunded successfully

Did the above with L-BTC as well.

**Caveats**:
1. At this moment, only one UTXO is refundable through the web app. I will assign myself another issue to improve this.
2. It's also not possible to refund UTXOs of a successfully completed swap. Backend currently doesn't allow it: 
```
POST: http://localhost:9001/v2/swap/submarine/:swapId
Bad Request:
"{"error":"swap not eligible for a cooperative refund: status not eligible"}"
```

I believe these two edge-cases should be addressed on a different PR.