### PR TITLE
fix: parse query params when destination is an LN address

### DIFF
--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -341,7 +341,8 @@ const CreateButton = () => {
             swapType() === SwapType.Submarine &&
             (lnurl() !== "" || bolt12Offer() !== undefined) &&
             amountValid() &&
-            sendAmount().isGreaterThan(0)
+            sendAmount().isGreaterThan(0) &&
+            assetReceive() !== assetSend()
         );
     };
 

--- a/src/utils/invoice.ts
+++ b/src/utils/invoice.ts
@@ -244,7 +244,9 @@ const isValidBech32 = (data: string) => {
 const emailRegex =
     /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
-export const isLnurl = (data: string) => {
+export const isLnurl = (data: string | null | undefined) => {
+    if (typeof data !== "string") return false;
+
     data = data.toLowerCase().replace(invoicePrefix, "");
     return (
         (data.includes("@") && emailRegex.test(data)) ||


### PR DESCRIPTION
This PR adds a function `isLightningAddress` to more accurately determine if we should handle a given `destination` as eligible for parsing the `sendAmount` query parameter.

Previously the logic dictated that any `LN` type destination should defer to the invoice's embedded amount -- but this did not work for LN addresses.