### PR TITLE
Chain Swaps: Rename transaction.refunded state in Web App

### DIFF
--- a/src/pages/Pay.tsx
+++ b/src/pages/Pay.tsx
@@ -121,7 +121,20 @@ const Pay = () => {
         string | undefined
     >(undefined);
 
-    const status = createMemo(() => statusOverride() || swapStatus());
+    const renameSwapStatus = (status: string) => {
+        if (
+            swap()?.type === SwapType.Chain &&
+            status === swapStatusFailed.TransactionRefunded
+        ) {
+            // Rename because the previous name was confusing users
+            return "swap.waitingForRefund";
+        }
+        return status;
+    };
+
+    const status = createMemo(
+        () => statusOverride() || renameSwapStatus(swapStatus()),
+    );
 
     return (
         <div data-status={status()} class="frame">

--- a/src/pages/Pay.tsx
+++ b/src/pages/Pay.tsx
@@ -1,6 +1,7 @@
 import { useParams } from "@solidjs/router";
 import log from "loglevel";
 import {
+    Accessor,
     Match,
     Show,
     Switch,
@@ -13,6 +14,7 @@ import {
 
 import BlockExplorerLink from "../components/BlockExplorerLink";
 import LoadingSpinner from "../components/LoadingSpinner";
+import RefundButton from "../components/RefundButton";
 import { SwapIcons } from "../components/SwapIcons";
 import SettingsCog from "../components/settings/SettingsCog";
 import SettingsMenu from "../components/settings/SettingsMenu";
@@ -195,6 +197,14 @@ const Pay = () => {
                             <TransactionLockupFailed
                                 setStatusOverride={setStatusOverride}
                             />
+                        </Match>
+                        <Match
+                            when={
+                                swap().type === SwapType.Chain &&
+                                swapStatus() ===
+                                    swapStatusFailed.TransactionRefunded
+                            }>
+                            <RefundButton swap={swap as Accessor<ChainSwap>} />
                         </Match>
                         <Match
                             when={

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -171,6 +171,7 @@ hr.spacer {
 }
 
 [data-status="swap.expired"],
+[data-status="swap.waitingForRefund"],
 [data-status="invoice.expired"],
 [data-status="transaction.refunded"],
 [data-status="invoice.failedToPay"],

--- a/tests/pages/Pay.spec.tsx
+++ b/tests/pages/Pay.spec.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from "@solidjs/testing-library";
+
+import { BTC, LBTC } from "../../src/consts/Assets";
+import { SwapType } from "../../src/consts/Enums";
+import { swapStatusFailed } from "../../src/consts/SwapStatus";
+import Pay from "../../src/pages/Pay";
+import { ChainSwap, ReverseSwap } from "../../src/utils/swapCreator";
+import { TestComponent } from "../helper";
+import { contextWrapper, payContext } from "../helper";
+
+vi.mock("../../src/utils/boltzClient", () => ({
+    getSwapStatus: vi.fn().mockResolvedValue({
+        status: swapStatusFailed.TransactionRefunded,
+    }),
+}));
+
+vi.mock("@solidjs/router", async () => {
+    const actual =
+        await vi.importActual<typeof import("@solidjs/router")>(
+            "@solidjs/router",
+        );
+    return {
+        ...actual,
+        useParams: vi.fn(() => ({ id: "123" })), // Mock params.id
+    };
+});
+
+describe("Pay", () => {
+    test("should rename `transaction.refunded` to `swap.waitingForRefund` on ChainSwap", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Pay />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+        payContext.setSwap({
+            type: SwapType.Chain,
+            assetReceive: BTC,
+            assetSend: LBTC,
+            lockupDetails: {},
+        } as ChainSwap);
+        payContext.setSwapStatus(swapStatusFailed.TransactionRefunded);
+
+        const status = await screen.findByText("swap.waitingForRefund");
+        expect(status).not.toBeUndefined();
+    });
+
+    test("should allow to refund `transaction.refunded` on ChainSwap", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Pay />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+        payContext.setSwap({
+            type: SwapType.Chain,
+            assetReceive: BTC,
+            assetSend: LBTC,
+            lockupDetails: {},
+        } as ChainSwap);
+        payContext.setSwapStatus(swapStatusFailed.TransactionRefunded);
+
+        const button = (await screen.findByTestId(
+            "refundButton",
+        )) as HTMLButtonElement;
+        expect(button).toBeTruthy();
+    });
+
+    test("should not rename `transaction.refunded` status on ReverseSwap", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Pay />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+        payContext.setSwap({
+            type: SwapType.Reverse,
+            assetReceive: LBTC,
+            assetSend: BTC,
+            lockupDetails: {},
+        } as unknown as ReverseSwap);
+        payContext.setSwapStatus(swapStatusFailed.TransactionRefunded);
+
+        const status = await screen.findByText("transaction.refunded");
+        expect(status).not.toBeUndefined();
+    });
+
+    test("should not allow to refund `transaction.refunded` on ReverseSwap", () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Pay />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+        payContext.setSwap({
+            type: SwapType.Reverse,
+            assetReceive: LBTC,
+            assetSend: BTC,
+            lockupDetails: {},
+        } as unknown as ReverseSwap);
+        payContext.setSwapStatus(swapStatusFailed.TransactionRefunded);
+
+        const button = screen.queryByTestId(
+            "refundButton",
+        ) as HTMLButtonElement;
+        expect(button).not.toBeTruthy();
+    });
+});


### PR DESCRIPTION
Closes #813 

Also added the `RefundButton` for a swap with the state `swap.waitingForRefund`:

![image](https://github.com/user-attachments/assets/6fafa0d0-8716-4c63-8f39-89d9be931179)

