### PR TITLE
test: Add e2e tests for refunding multiple UTXOs

### DIFF
--- a/e2e/refund/refund.spec.ts
+++ b/e2e/refund/refund.spec.ts
@@ -1,0 +1,139 @@
+import { Page, expect, request, test } from "@playwright/test";
+import fs from "fs";
+import path from "path";
+
+import { UTXO } from "../../src/utils/blockchain";
+import {
+    createAndVerifySwap,
+    decodeLiquidRawTransaction,
+    elementsSendToAddress,
+    generateLiquidBlock,
+    getLiquidAddress,
+    setFailedToPay,
+} from "../utils";
+
+const getCurrentSwapId = (page: Page) => {
+    const url = new URL(page.url());
+    return url.pathname.split("/").pop();
+};
+
+const waitForUTXOsInMempool = async (address: string, amount: number) => {
+    const requestContext = request.newContext();
+    await expect
+        .poll(
+            async () => {
+                const res = await (
+                    await requestContext
+                ).get(`http://localhost:4003/api/address/${address}/utxo`);
+
+                const utxos = (await res.json()) as UTXO[];
+                return utxos.length === amount;
+            },
+            { timeout: 10_000 },
+        )
+        .toBe(true);
+};
+
+const navigateToSwapDetails = async (page: Page, swapId: string) => {
+    await page.getByRole("link", { name: "Refund" }).click();
+    const swapItem = page.locator(`div[data-testid='swaplist-item-${swapId}']`);
+    await expect(page.getByTestId("loading-spinner")).not.toBeVisible();
+    await expect(swapItem.getByRole("link", { name: "Refund" })).toBeVisible();
+    await swapItem.click();
+};
+
+const validateRefundTxInputs = async (page: Page, expectedInputs: number) => {
+    const refundRequest = await page.waitForRequest((req) =>
+        req.url().includes("/refund"),
+    );
+    const broadcastedTx = JSON.parse(refundRequest.postData() || "{}");
+
+    const decodedTx = await decodeLiquidRawTransaction(
+        broadcastedTx.transaction,
+    );
+    const tx = JSON.parse(decodedTx);
+
+    expect(tx.vin.length).toBe(expectedInputs);
+};
+
+test.describe("Refund", () => {
+    const refundFileJson = path.join(__dirname, "rescue.json");
+
+    test.beforeEach(async () => {
+        await generateLiquidBlock();
+    });
+
+    test.afterEach(() => {
+        if (fs.existsSync(refundFileJson)) {
+            fs.unlinkSync(refundFileJson);
+        }
+    });
+
+    test("Refunds all UTXOs of `invoice.failedToPay`", async ({ page }) => {
+        await createAndVerifySwap(page, refundFileJson);
+
+        const swapId = getCurrentSwapId(page);
+
+        const address = await page.evaluate(() => {
+            return navigator.clipboard.readText();
+        });
+        const amount = 0.005;
+        const utxoCount = 3;
+
+        await setFailedToPay(swapId);
+
+        await elementsSendToAddress(address, amount);
+        await elementsSendToAddress(address, amount);
+        await elementsSendToAddress(address, amount);
+
+        await waitForUTXOsInMempool(address, utxoCount);
+
+        await navigateToSwapDetails(page, swapId);
+
+        await expect(page.getByText("invoice.failedToPay")).toBeVisible();
+        await page.getByTestId("refundAddress").fill(await getLiquidAddress());
+        await page.getByTestId("refundButton").click();
+
+        // Validate that the UTXOs are refunded on the same transaction
+        await validateRefundTxInputs(page, utxoCount);
+
+        const refundTxLink = page.getByText("open refund transaction");
+        const txId = (await refundTxLink.getAttribute("href")).split("/").pop();
+
+        expect(txId).toBeDefined();
+    });
+
+    test("Refunds all UTXOs of `transaction.lockupFailed`", async ({
+        page,
+    }) => {
+        await createAndVerifySwap(page, refundFileJson);
+
+        const swapId = getCurrentSwapId(page);
+
+        const address = await page.evaluate(() => {
+            return navigator.clipboard.readText();
+        });
+        const amount = 0.01;
+        const utxoCount = 2;
+
+        // Pay swap with incorrect amount & pay additional UTXO
+        await elementsSendToAddress(address, amount);
+        await elementsSendToAddress(address, amount);
+
+        await waitForUTXOsInMempool(address, utxoCount);
+
+        await navigateToSwapDetails(page, swapId);
+
+        await expect(page.getByText("transaction.lockupFailed")).toBeVisible();
+        await page.getByTestId("refundAddress").fill(await getLiquidAddress());
+        await page.getByTestId("refundButton").click();
+
+        // Validate that the UTXOs are refunded on the same transaction
+        await validateRefundTxInputs(page, utxoCount);
+
+        const refundTxLink = page.getByText("open refund transaction");
+        const txId = (await refundTxLink.getAttribute("href")).split("/").pop();
+
+        expect(txId).toBeDefined();
+    });
+});

--- a/e2e/refund/rescueFile.spec.ts
+++ b/e2e/refund/rescueFile.spec.ts
@@ -1,4 +1,4 @@
-import { Page, expect, request, test } from "@playwright/test";
+import { expect, request, test } from "@playwright/test";
 import fs from "fs";
 import path from "path";
 
@@ -6,42 +6,14 @@ import dict from "../../src/i18n/i18n";
 import { UTXO } from "../../src/utils/blockchain";
 import { getRescuableSwaps } from "../boltzClient";
 import {
+    createAndVerifySwap,
     elementsSendToAddress,
+    fillSwapDetails,
     generateLiquidBlock,
-    getBolt12Offer,
     getElementsWalletTx,
     getLiquidAddress,
+    setupSwapAssets,
 } from "../utils";
-
-const setupSwapAssets = async (page: Page) => {
-    await page.locator(".arrow-down").first().click();
-    await page.getByTestId("select-L-BTC").click();
-    await page
-        .locator(
-            "div:nth-child(3) > .asset-wrap > .asset > .asset-selection > .arrow-down",
-        )
-        .click();
-    await page.getByTestId("select-LN").click();
-};
-
-const fillSwapDetails = async (page: Page) => {
-    await page.getByTestId("invoice").fill(await getBolt12Offer());
-    await page.getByTestId("sendAmount").fill("0.005");
-    await page.getByTestId("create-swap-button").click();
-};
-
-const createAndVerifySwap = async (page: Page, rescueFile: string) => {
-    await page.goto("/");
-    await setupSwapAssets(page);
-    await fillSwapDetails(page);
-
-    const downloadPromise = page.waitForEvent("download");
-    await page.getByRole("button", { name: dict.en.download_new_key }).click();
-    await (await downloadPromise).saveAs(rescueFile);
-
-    await page.getByTestId("rescueFileUpload").setInputFiles(rescueFile);
-    await page.getByText("address").click();
-};
 
 test.describe("Rescue file", () => {
     const rescueFileJson = path.join(__dirname, "rescue.json");

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -2,7 +2,7 @@ import "../style/loadingSpinner.scss";
 
 const LoadingSpinner = () => {
     return (
-        <div class="spinner">
+        <div class="spinner" data-testid="loading-spinner">
             <div class="bounce1" />
             <div class="bounce2" />
             <div class="bounce3" />

--- a/src/components/SwapList.tsx
+++ b/src/components/SwapList.tsx
@@ -76,6 +76,7 @@ const SwapList = (props: {
                 {(swap) => (
                     <>
                         <div
+                            data-testid={`swaplist-item-${swap.id}`}
                             class={`swaplist-item ${swap.disabled ? "disabled" : ""}`}
                             onClick={() => {
                                 if (swap.disabled) {


### PR DESCRIPTION
Closes #856

Refunding multiple UTXOs on the following scenarios:
`transaction.lockupFailed`: has 1 UTXO known by both Boltz and the block explorer, and 2 known only by the block explorer (3 total).
`invoice.failedToPay`: has both UTXOs known only by the block explorer.