### PR TITLE
feat: Export rescue key in backup

### DIFF
--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -9,47 +9,33 @@ import { useGlobalContext } from "../context/Global";
 import { downloadJson, getBackupFileName } from "../utils/download";
 import { isIos } from "../utils/helper";
 import { latestStorageVersion, migrateBackupFile } from "../utils/migration";
+import { Errors, validateRescueFile } from "../utils/rescueFile";
 import { SomeSwap } from "../utils/swapCreator";
 
-export enum Errors {
-    InvalidBackupFile = "invalid file",
-    NotAllElementsHaveAnId = "not all elements have an id",
-}
-
-type BackupFileType = { version: number; swaps: SomeSwap[] };
+type BackupFileType = { version: number; mnemonic: string; swaps: SomeSwap[] };
 
 // Throws when the file is invalid
 // Returns the version of the backup file
-const validateBackupFile = (
-    file: BackupFileType | unknown[] | SomeSwap,
-): BackupFileType => {
+const validateBackupFile = (file: BackupFileType): BackupFileType => {
     const allSwapsHaveId = (swaps: { id: string }[]) => {
         if (swaps.some((swap) => swap.id === undefined || swap.id === null)) {
             throw Errors.NotAllElementsHaveAnId;
         }
     };
 
-    if (file instanceof Array) {
-        allSwapsHaveId(file as { id: string }[]);
-        return { version: 0, swaps: file as SomeSwap[] };
-    } else if (typeof file === "object") {
-        // A single refund file was uploaded
-        if (["id", "type"].every((key) => key in file)) {
-            return {
-                version: latestStorageVersion,
-                swaps: [file as unknown as SomeSwap],
-            };
-        }
-
-        if (!["version", "swaps"].every((key) => key in file)) {
-            throw Errors.InvalidBackupFile;
-        }
-
-        allSwapsHaveId((file as BackupFileType).swaps);
-        return file as BackupFileType;
-    } else {
-        throw Errors.InvalidBackupFile;
+    if (typeof file !== "object") {
+        throw Errors.InvalidFile;
     }
+
+    if (!["version", "swaps", "mnemonic"].every((key) => key in file)) {
+        throw Errors.InvalidFile;
+    }
+
+    validateRescueFile(file);
+
+    allSwapsHaveId((file as BackupFileType).swaps);
+
+    return file as BackupFileType;
 };
 
 const History = () => {
@@ -58,6 +44,9 @@ const History = () => {
     let importRef: HTMLInputElement;
 
     const {
+        rescueFile,
+        setRescueFile,
+        setRescueFileBackupDone,
         getSwaps,
         clearSwaps,
         setSwapStorage,
@@ -78,6 +67,7 @@ const History = () => {
     const backupLocalStorage = async () => {
         downloadJson(getBackupFileName(), {
             version: latestStorageVersion,
+            mnemonic: rescueFile().mnemonic,
             swaps: await getSwaps(),
         });
     };
@@ -104,6 +94,8 @@ const History = () => {
                     await setSwapStorage(swap);
                 }
                 setSwaps(swaps);
+                setRescueFile({ mnemonic: parsedFile.mnemonic });
+                setRescueFileBackupDone(true);
             })
             .catch((e) => {
                 log.error("invalid file upload", e);

--- a/src/utils/rescueFile.ts
+++ b/src/utils/rescueFile.ts
@@ -6,6 +6,12 @@ import {
 } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english";
 
+export enum Errors {
+    InvalidFile = "invalid file",
+    NotAllElementsHaveAnId = "not all elements have an id",
+    InvalidMnemonic = "invalid mnemonic",
+}
+
 export type RescueFile = {
     mnemonic: string;
 };
@@ -35,11 +41,11 @@ export const validateRescueFile = (
     data: Record<string, string | object | number | boolean>,
 ): RescueFile => {
     if (!("mnemonic" in data)) {
-        throw "invalid rescue file";
+        throw Errors.InvalidFile;
     }
 
     if (!validateMnemonic(data.mnemonic as string, wordlist)) {
-        throw "invalid mnemonic";
+        throw Errors.InvalidMnemonic;
     }
 
     getXpub(data as RescueFile);

--- a/tests/pages/History.spec.tsx
+++ b/tests/pages/History.spec.tsx
@@ -1,50 +1,34 @@
-import { SwapType } from "../../src/consts/Enums";
-import { Errors, validateBackupFile } from "../../src/pages/History";
-import { latestStorageVersion } from "../../src/utils/migration";
-import { SomeSwap } from "../../src/utils/swapCreator";
+import { validateBackupFile } from "../../src/pages/History";
+import { Errors } from "../../src/utils/rescueFile";
+
+const mnemonic =
+    "path follow autumn enough napkin manual warrior vote skate feel during humor";
 
 describe("History", () => {
     test.each`
         data
-        ${[]}
-        ${[{ id: "1" }]}
-        ${[{ id: "1" }, { id: "2" }]}
-    `("should validate legacy backup files", ({ data }) => {
-        expect(validateBackupFile(data)).toEqual({
-            version: 0,
-            swaps: data,
-        });
-    });
-
-    test.each`
-        data
-        ${{ version: 1, swaps: [] }}
-        ${{ version: 1, swaps: [{ id: "taproot" }] }}
+        ${{ version: 1, swaps: [], mnemonic }}
+        ${{ version: 1, swaps: [{ id: "taproot" }], mnemonic }}
     `("should validate new backup files", ({ data }) => {
         expect(validateBackupFile(data)).toEqual(data);
     });
 
-    test("should validate single swap refund files", () => {
-        const file = { id: "asdf", type: SwapType.Chain };
-        expect(validateBackupFile(file as SomeSwap)).toEqual({
-            version: latestStorageVersion,
-            swaps: [file],
-        });
-    });
-
     test.each`
         error                            | data
-        ${Errors.InvalidBackupFile}      | ${{}}
-        ${Errors.InvalidBackupFile}      | ${"test"}
-        ${Errors.InvalidBackupFile}      | ${1}
-        ${Errors.InvalidBackupFile}      | ${{ version: 1 }}
-        ${Errors.InvalidBackupFile}      | ${{ swaps: [] }}
-        ${Errors.InvalidBackupFile}      | ${{ id: "asdf" }}
-        ${Errors.NotAllElementsHaveAnId} | ${{ version: 1, swaps: [{ id: null }] }}
-        ${Errors.NotAllElementsHaveAnId} | ${[{}]}
-        ${Errors.NotAllElementsHaveAnId} | ${[{ id: undefined }]}
-        ${Errors.NotAllElementsHaveAnId} | ${[{ id: null }]}
-        ${Errors.NotAllElementsHaveAnId} | ${[{ id: "1" }, { noId: "2" }]}
+        ${Errors.InvalidFile}            | ${{}}
+        ${Errors.InvalidFile}            | ${"test"}
+        ${Errors.InvalidFile}            | ${1}
+        ${Errors.InvalidFile}            | ${{ version: 1 }}
+        ${Errors.InvalidFile}            | ${{ swaps: [] }}
+        ${Errors.InvalidFile}            | ${{ id: "asdf" }}
+        ${Errors.InvalidFile}            | ${[{}]}
+        ${Errors.InvalidFile}            | ${{ version: 1, id: "asdf", swaps: [{ id: "asdf" }] }}
+        ${Errors.NotAllElementsHaveAnId} | ${{ version: 1, swaps: [{ id: null }], mnemonic }}
+        ${Errors.NotAllElementsHaveAnId} | ${{ version: 1, id: null, swaps: [{ id: null }], mnemonic }}
+        ${Errors.NotAllElementsHaveAnId} | ${{ version: 1, id: undefined, swaps: [{ id: null }], mnemonic }}
+        ${Errors.NotAllElementsHaveAnId} | ${{ version: 1, id: "", swaps: [{ id: null }], mnemonic }}
+        ${Errors.InvalidMnemonic}        | ${{ version: 1, id: "asdf", swaps: [{ id: "asdf" }], mnemonic: "hello" }}
+        ${Errors.InvalidMnemonic}        | ${{ version: 1, id: "asdf", swaps: [{ id: "asdf" }], mnemonic: "" }}
     `("should throw for invalid backup file: $data", ({ data, error }) => {
         expect(() => validateBackupFile(data)).toThrow(error);
     });

--- a/tests/utils/rescueFile.spec.ts
+++ b/tests/utils/rescueFile.spec.ts
@@ -1,4 +1,5 @@
 import {
+    Errors,
     deriveKey,
     generateRescueFile,
     getXpub,
@@ -71,9 +72,7 @@ describe("rescueFile", () => {
                     "def0a13214538650fb84a7545c9b81128a639f55147cdd61c46d5ea0f70045a3",
             };
 
-            expect(() => validateRescueFile(data)).toThrow(
-                "invalid rescue file",
-            );
+            expect(() => validateRescueFile(data)).toThrow(Errors.InvalidFile);
         });
 
         test("should throw error if mnemonic is invalid", () => {
@@ -81,7 +80,9 @@ describe("rescueFile", () => {
                 mnemonic: "invalid",
             };
 
-            expect(() => validateRescueFile(data)).toThrow("invalid mnemonic");
+            expect(() => validateRescueFile(data)).toThrow(
+                Errors.InvalidMnemonic,
+            );
         });
     });
 });


### PR DESCRIPTION
Closes #867

Rescue key should be included on backup of multiple swaps (Backup button on `History` page), so that users can refund these swaps later on, if needed.

Old refund files don't need to include the mnemonic since they use `refundPrivateKey` for the refunds.