### PR TITLE
Get python3 location from env in shebang

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#! /bin/python3
+#!/usr/bin/env python3
 
 import sys
 import json

--- a/build_dnssec_prover.py
+++ b/build_dnssec_prover.py
@@ -1,4 +1,4 @@
-#! /bin/python3
+#!/usr/bin/env python3
 
 import os
 import shutil


### PR DESCRIPTION
Rather than require python3 be installed exactly at /bin/python3