### PR TITLE
fix: urlParam `receiveAsset` not working

### DIFF
--- a/src/context/Create.tsx
+++ b/src/context/Create.tsx
@@ -23,7 +23,7 @@ const setDestination = (
     setAssetReceive: Setter<string>,
     setInvoice: Setter<string>,
     setOnchainAddress: Setter<string>,
-): { destinationAsset: string | null; destination: string | null } => {
+): { destinationAsset?: string; destination?: string } => {
     const isValidForAsset = (
         asset: typeof BTC | typeof LBTC,
         address: string,
@@ -58,7 +58,7 @@ const setDestination = (
         }
     }
 
-    return { destinationAsset: null, destination: null };
+    return { destinationAsset: undefined, destination: undefined };
 };
 
 const isValidAsset = (asset: string) =>

--- a/tests/context/Create.spec.tsx
+++ b/tests/context/Create.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from "@solidjs/testing-library";
 
-import { BTC, LBTC, LN } from "../../src/consts/Assets";
+import { BTC, LBTC, LN, RBTC } from "../../src/consts/Assets";
 import { SwapType } from "../../src/consts/Enums";
 import { TestComponent, contextWrapper, signals } from "../helper";
 
@@ -37,6 +37,58 @@ describe("signals", () => {
             signals.setAssetSend(assetSend);
             signals.setAssetReceive(assetReceive);
             expect(signals.valid()).toEqual(valid);
+        },
+    );
+
+    test.each`
+        sendAsset | receiveAsset | amount
+        ${BTC}    | ${LBTC}      | ${1000000}
+        ${BTC}    | ${RBTC}      | ${0}
+        ${LN}     | ${RBTC}      | ${1000000}
+        ${LN}     | ${BTC}       | ${0}
+        ${LBTC}   | ${LN}        | ${1000000}
+        ${LBTC}   | ${BTC}       | ${0}
+        ${RBTC}   | ${BTC}       | ${1000000}
+        ${RBTC}   | ${LN}        | ${0}
+    `(
+        "should set assets $sendAsset > $receiveAsset based on urlParams",
+        ({ sendAsset, receiveAsset, amount }) => {
+            vi.spyOn(URLSearchParams.prototype, "get").mockImplementation(
+                (key) => {
+                    if (key === "sendAsset") return sendAsset as string;
+                    if (key === "receiveAsset") return receiveAsset as string;
+                    if (key === "sendAmount") return amount as string;
+                    return null;
+                },
+            );
+
+            render(() => <TestComponent />, { wrapper: contextWrapper });
+
+            expect(signals.assetSend()).toEqual(sendAsset);
+            expect(signals.assetReceive()).toEqual(receiveAsset);
+            expect(Number(signals.sendAmount())).toEqual(amount);
+        },
+    );
+
+    test.each`
+        receiveAsset | destination                                                                                                | expectedReceiveAsset
+        ${BTC}       | ${"test@lnurl.com"}                                                                                        | ${LN}
+        ${LBTC}      | ${"bcrt1qgzzhsnvstqjd5nyr0u6fz706up6ap0jy4ajs3x"}                                                          | ${BTC}
+        ${BTC}       | ${"el1qqd60krw3zqwdg97gs4skuqjf05lgf6jht3w8fsg0hyhtyv203yqnjuhnd96t0an6nz8e35n0ndqh0rvmaq5g7dj999pl26nwr"} | ${LBTC}
+    `(
+        "should have destination taking precedence over receiveAsset",
+        ({ receiveAsset, destination, expectedReceiveAsset }) => {
+            vi.spyOn(URLSearchParams.prototype, "get").mockImplementation(
+                (key) => {
+                    if (key === "receiveAsset") return receiveAsset as string;
+                    if (key === "destination") return destination as string;
+                    return null;
+                },
+            );
+
+            render(() => <TestComponent />, { wrapper: contextWrapper });
+
+            expect(signals.assetReceive()).toEqual(expectedReceiveAsset);
         },
     );
 });


### PR DESCRIPTION
Closes #884

The problem occurred when`setDestination` returned `destinationAsset` as `null`, but the `if` checked if `destinationAsset` was `undefined`.
https://github.com/BoltzExchange/boltz-web-app/blob/cb62f517c97cf35e798922b79feaa8900cd88f16/src/context/Create.tsx#L88-L100

Fixed by returning `destinationAsset` as `undefined` (instead of redefining it as `null`) and added unit tests covering this scenario.