### PR TITLE
feat: improve UX for copying address/invoice on click

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,10 +36,7 @@ export default [
     {
         rules: {
             "no-async-promise-executor": "off",
-        },
-    },
-    {
-        rules: {
+            "no-console": 1,
             "no-restricted-imports": [
                 "error",
                 {
@@ -84,6 +81,12 @@ export default [
             "@typescript-eslint/no-unsafe-enum-comparison": "off",
             "@typescript-eslint/prefer-promise-reject-errors": "off",
             "@typescript-eslint/no-unnecessary-type-assertion": "off",
+        },
+    },
+    {
+        files: ["tests/**/*.ts", "e2e/**/*.ts"],
+        rules: {
+            "no-console": "off",
         },
     },
 ];

--- a/src/components/CopyBox.tsx
+++ b/src/components/CopyBox.tsx
@@ -1,0 +1,33 @@
+import { BiRegularCopy } from "solid-icons/bi";
+import { IoCheckmark } from "solid-icons/io";
+import { Show, createSignal } from "solid-js";
+
+import { copyIconTimeout } from "../consts/CopyContent";
+import { clipboard, cropString, isMobile } from "../utils/helper";
+
+const CopyBox = (props: { value: string }) => {
+    const [copyBoxActive, setCopyBoxActive] = createSignal(false);
+    const baseStrLength = isMobile() ? 8 : 13;
+    const maxStrLength = baseStrLength + 3; // 3 is the length of the ellipsis
+
+    const copyBoxText = () => {
+        clipboard(props.value);
+        setCopyBoxActive(true);
+        setTimeout(() => {
+            setCopyBoxActive(false);
+        }, copyIconTimeout);
+    };
+
+    return (
+        <p onClick={copyBoxText} class="copy-box break-word">
+            <Show
+                when={copyBoxActive()}
+                fallback={<BiRegularCopy size={23} data-testid="copy-icon" />}>
+                <IoCheckmark size={23} data-testid="checkmark-icon" />
+            </Show>
+            {cropString(props.value, baseStrLength, maxStrLength)}
+        </p>
+    );
+};
+
+export default CopyBox;

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -3,6 +3,7 @@ import { IoCheckmark } from "solid-icons/io";
 import type { Accessor } from "solid-js";
 import { Show, createEffect, createSignal, mergeProps } from "solid-js";
 
+import { copyIconTimeout } from "../consts/CopyContent";
 import { useGlobalContext } from "../context/Global";
 import type { DictKey } from "../i18n/i18n";
 import { clipboard } from "../utils/helper";
@@ -32,7 +33,7 @@ const CopyButton = (props: {
         setTimeout(() => {
             setButtonClass(merged.btnClass);
             setButtonActive(false);
-        }, 600);
+        }, copyIconTimeout);
     };
 
     return (

--- a/src/components/PayInvoice.tsx
+++ b/src/components/PayInvoice.tsx
@@ -7,12 +7,14 @@ import QrCode from "../components/QrCode";
 import { BTC } from "../consts/Assets";
 import { useGlobalContext } from "../context/Global";
 import { formatAmount, formatDenomination } from "../utils/denomination";
-import { clipboard, cropString, isMobile } from "../utils/helper";
+import { isMobile } from "../utils/helper";
 import { invoicePrefix } from "../utils/invoice";
 import { enableWebln } from "../utils/webln";
+import CopyBox from "./CopyBox";
 
 const PayInvoice = (props: { sendAmount: number; invoice: string }) => {
     const { t, denomination, separator, webln } = useGlobalContext();
+
     const payWeblnInvoice = async (pr: string) => {
         await enableWebln(async () => {
             const result = await window.webln.sendPayment(pr);
@@ -37,11 +39,7 @@ const PayInvoice = (props: { sendAmount: number; invoice: string }) => {
                 <QrCode data={props.invoice} />
             </a>
             <hr />
-            <p
-                onClick={() => clipboard(props.invoice)}
-                class="address-box break-word">
-                {cropString(props.invoice)}
-            </p>
+            <CopyBox value={props.invoice} />
             <hr />
             <Show when={isMobile()}>
                 <h3>{t("warning_return")}</h3>

--- a/src/components/PayOnchain.tsx
+++ b/src/components/PayOnchain.tsx
@@ -8,7 +8,8 @@ import type { SwapType } from "../consts/Enums";
 import { useGlobalContext } from "../context/Global";
 import { getPairs } from "../utils/boltzClient";
 import { formatAmount, formatDenomination } from "../utils/denomination";
-import { clipboard, cropString, getPair, isMobile } from "../utils/helper";
+import { getPair, isMobile } from "../utils/helper";
+import CopyBox from "./CopyBox";
 import LoadingSpinner from "./LoadingSpinner";
 
 const PayOnchain = (props: {
@@ -81,11 +82,7 @@ const PayOnchain = (props: {
                     <QrCode asset={props.assetSend} data={props.bip21} />
                 </a>
                 <hr />
-                <p
-                    onClick={() => clipboard(props.address)}
-                    class="address-box break-word">
-                    {cropString(props.address)}
-                </p>
+                <CopyBox value={props.address} />
                 <Show when={props.assetSend === BTC}>
                     <hr class="spacer" />
                     <h3>{t("warning_expiry")}</h3>

--- a/src/consts/CopyContent.ts
+++ b/src/consts/CopyContent.ts
@@ -1,0 +1,1 @@
+export const copyIconTimeout = 600;

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -694,12 +694,17 @@ textarea {
     word-break: break-all;
 }
 
-.address-box {
-    font-size: 18px;
+.copy-box {
+    display: flex;
+    align-items: end;
+    justify-content: center;
+    gap: 0.63rem;
+    user-select: none;
+    font-size: 1.13rem;
     background-color: #545c65;
     background-color: rgba(0, 0, 0, 0.2);
-    border-radius: 7px;
-    padding: 10px;
+    border-radius: 0.43rem;
+    padding: 0.63rem;
     border: 1px solid rgba(255, 255, 255, 0.1);
     color: rgba(255, 255, 255, 0.5);
     margin: 0;

--- a/src/utils/compat.ts
+++ b/src/utils/compat.ts
@@ -222,7 +222,6 @@ const getOutputAmount = async (
 
     if (output.rangeProof?.length !== 0) {
         const { confidential } = await secp.get();
-        console.log(output);
         const unblinded = confidential.unblindOutputWithKey(
             output,
             output.blindingPrivateKey,

--- a/tests/components/CopyBox.spec.tsx
+++ b/tests/components/CopyBox.spec.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+
+import CopyBox from "../../src/components/CopyBox";
+import { contextWrapper } from "../helper";
+
+/* eslint-disable @typescript-eslint/unbound-method */
+
+const writeText = vi.fn();
+
+Object.defineProperty(navigator, "clipboard", {
+    value: {
+        writeText,
+    },
+});
+
+describe("CopyBox", () => {
+    beforeEach(() => {
+        writeText.mockClear();
+    });
+
+    test("should stay active for 600ms and copy into clipboard", async () => {
+        const address = "bcrt1qhgpdl988atca59fv2hgh87kcs9td082aucra3d";
+
+        const {
+            container: { firstChild },
+        } = render(() => <CopyBox value={address} />, {
+            wrapper: contextWrapper,
+        });
+
+        const copyBox = firstChild as HTMLParagraphElement;
+
+        expect(copyBox).not.toBeUndefined();
+        expect(screen.getByTestId("copy-icon")).toBeTruthy();
+
+        fireEvent.click(copyBox);
+
+        expect(screen.getByTestId("checkmark-icon")).toBeTruthy();
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(address);
+
+        // should still show checkmark
+        await new Promise((resolve) => setTimeout(resolve, 400));
+        expect(screen.getByTestId("checkmark-icon")).toBeTruthy();
+
+        // should show copy icon again
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        expect(screen.getByTestId("copy-icon")).toBeTruthy();
+    });
+});


### PR DESCRIPTION
Closes #875

The issue was about adding a "copy on click" functionality to the address/invoice "input", however the functionality was already there, it just wasn't clear due to lack of clues about it.

This PR adds to the "input" the same icon aspect & behavior we already had in other buttons:
![image](https://github.com/user-attachments/assets/00b90ea4-b7b1-4be1-bdeb-626d6ad4be78)
![image](https://github.com/user-attachments/assets/cd1029e8-ec13-4ea7-a011-654cb97c7583)

