### PR TITLE
chore: reorder header menu

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -72,7 +72,7 @@ const Nav = (props: { network: string; isPro?: boolean }) => {
                         {t("history")}
                     </A>
 
-                    <Show when={config.discordUrl}>
+                    <Show when={config.supportUrl}>
                         <a
                             class="external"
                             target="_blank"

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -72,21 +72,21 @@ const Nav = (props: { network: string; isPro?: boolean }) => {
                         {t("history")}
                     </A>
 
-                    <Show when={config.docsUrl}>
-                        <a
-                            class="external"
-                            target="_blank"
-                            href={config.docsUrl}>
-                            {t("documentation")}
-                            <OcLinkexternal2 size={23} />
-                        </a>
-                    </Show>
                     <Show when={config.discordUrl}>
                         <a
                             class="external"
                             target="_blank"
                             href={config.supportUrl}>
                             {t("help")}
+                            <OcLinkexternal2 size={23} />
+                        </a>
+                    </Show>
+                    <Show when={config.docsUrl}>
+                        <a
+                            class="external"
+                            target="_blank"
+                            href={config.docsUrl}>
+                            {t("documentation")}
                             <OcLinkexternal2 size={23} />
                         </a>
                     </Show>


### PR DESCRIPTION
moved "help" one position to the left to have it even more visible

![image](https://github.com/user-attachments/assets/859d1ba7-d3f6-4d28-a3a5-1c3c8e66bfdc)
