### PR TITLE
feat: prompt on tab close with pending swaps

### DIFF
--- a/src/components/SwapChecker.tsx
+++ b/src/components/SwapChecker.tsx
@@ -1,6 +1,7 @@
 import { OutputType } from "boltz-core";
 import log from "loglevel";
 import { createEffect, onCleanup, onMount } from "solid-js";
+import { createStore } from "solid-js/store";
 
 import { BTC, LBTC, RBTC } from "../consts/Assets";
 import { SwapType } from "../consts/Enums";
@@ -27,6 +28,7 @@ import { getApiUrl } from "../utils/helper";
 import type {
     ChainSwap,
     ReverseSwap,
+    SomeSwap,
     SubmarineSwap,
 } from "../utils/swapCreator";
 import { getRelevantAssetForSwap } from "../utils/swapCreator";
@@ -178,6 +180,28 @@ export const SwapChecker = () => {
 
     let ws: BoltzWebSocket | undefined = undefined;
 
+    const [pendingSwaps, setPendingSwaps] = createStore<string[]>([]);
+
+    const updatePendingSwaps = (swap: SomeSwap, data: SwapStatus) => {
+        if (![SwapType.Chain, SwapType.Reverse].includes(swap.type)) {
+            return;
+        }
+
+        if (
+            Object.values(swapStatusPending).includes(data.status) &&
+            data.status !== swapStatusPending.SwapCreated &&
+            !pendingSwaps.includes(swap.id)
+        ) {
+            setPendingSwaps((pendingSwaps) => [...pendingSwaps, swap.id]);
+        }
+
+        if (Object.values(swapStatusFinal).includes(data.status)) {
+            setPendingSwaps((pendingSwaps) =>
+                pendingSwaps.filter((id: string) => id !== swap.id),
+            );
+        }
+    };
+
     const prepareSwap = async (swapId: string, data: SwapStatus) => {
         const currentSwap = await getSwap(swapId);
         if (currentSwap === null) {
@@ -194,6 +218,7 @@ export const SwapChecker = () => {
             }
         }
         if (data.status) {
+            updatePendingSwaps(currentSwap, data);
             await updateSwapStatus(currentSwap.id, data.status);
         }
     };
@@ -373,6 +398,14 @@ export const SwapChecker = () => {
             ws.subscribeUpdates([activeSwap.id]);
         }
     });
+
+    window.onbeforeunload = (event: BeforeUnloadEvent) => {
+        if (pendingSwaps?.length > 0) {
+            event.preventDefault();
+            return "";
+        }
+        return undefined;
+    };
 
     return "";
 };

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -121,7 +121,9 @@ const dict = {
             "Are you sure you want to clear Swap {{ id }} from your storage?\nYour swap information and you refund / claim private keys will be lost.",
         delete_logs: "Are you sure you want to clear your logs?",
         tx_in_mempool: "Transaction is in mempool",
-        tx_in_mempool_subline: "Waiting for confirmation to complete the swap",
+        tx_in_mempool_subline: "Waiting for confirmation to complete the swap.",
+        tx_in_mempool_warning:
+            "Please keep this tab open until the swap completed!",
         expired: "Swap expired!",
         invoice_pending: "Transaction received, paying invoice.",
         invoice_expired: "Invoice expired, try again!",
@@ -378,6 +380,8 @@ const dict = {
         tx_in_mempool: "Transaktion befindet sich im Mempool.",
         tx_in_mempool_subline:
             "Warte auf Bestätigung, um den Swap abzuschließen.",
+        tx_in_mempool_warning:
+            "Tab nicht schließen, bis der Swap abgeschlossen ist!",
         expired: "Swap ist abgelaufen!",
         invoice_pending: "Transaktion erhalten, Rechnung wird bezahlt.",
         invoice_expired: "Rechnung ist abgelaufen, bitte erneut versuchen!",
@@ -638,7 +642,9 @@ const dict = {
         delete_logs: "¿Estás seguro de que deseas borrar tus registros?",
         tx_in_mempool: "La transacción está en el mempool.",
         tx_in_mempool_subline:
-            "Esperando confirmación para completar el intercambio",
+            "Esperando confirmación para completar el intercambio.",
+        tx_in_mempool_warning:
+            "Por favor, mantenga esta pestaña abierta hasta que se complete el intercambio!",
         expired: "¡El intercambio ha expirado!",
         invoice_pending: "Transacción recibida, pagando la factura...",
         invoice_expired: "La factura ha expirado, ¡intente nuevamente!",
@@ -898,7 +904,9 @@ const dict = {
             "Tem certeza de que deseja remover a troca {{ id }} do armazenamento?\nAs informações da troca e as chaves privadas de reembolso/recebimento serão perdidas.",
         delete_logs: "Tem certeza que deseja limpar seus logs?",
         tx_in_mempool: "Transação na mempool",
-        tx_in_mempool_subline: "Aguardando confirmação para concluir a troca",
+        tx_in_mempool_subline: "Aguardando confirmação para concluir a troca.",
+        tx_in_mempool_warning:
+            "Por favor, mantenha esta aba aberta até que a troca seja concluída!",
         expired: "Troca expirada!",
         invoice_pending: "Transação recebida, a pagar o invoice.",
         invoice_expired: "Invoice expirado, tente novamente!",
@@ -1145,6 +1153,7 @@ const dict = {
         delete_logs: "您确定要删除日志吗？",
         tx_in_mempool: "事务在内存池中",
         tx_in_mempool_subline: "等待确认以完成交换",
+        tx_in_mempool_warning: "请保持打开此选项卡，直至交换完成！",
         expired: "交换已过期！",
         invoice_pending: "收到交易，正在支付发票。",
         invoice_expired: "发票已过期，请重试！",
@@ -1390,6 +1399,8 @@ const dict = {
         delete_logs: "ログを削除しても本当にいいですか？",
         tx_in_mempool: "トランザクションがメモリプール内にあります",
         tx_in_mempool_subline: "スワップを完了するために確認を待っています",
+        tx_in_mempool_warning:
+            "スワップが完了するまでこのタブを開いておいてください！",
         expired: "スワップが期限切れです！",
         invoice_pending:
             "トランザクションを受け取りました。インボイスを支払っています",

--- a/src/pages/Pay.tsx
+++ b/src/pages/Pay.tsx
@@ -236,7 +236,7 @@ const Pay = () => {
                                 swapStatus() ===
                                     swapStatusPending.TransactionServerMempool
                             }>
-                            <TransactionMempool />
+                            <TransactionMempool swap={swap} />
                         </Match>
                         <Match
                             when={

--- a/src/status/TransactionMempool.tsx
+++ b/src/status/TransactionMempool.tsx
@@ -1,12 +1,28 @@
-import LoadingSpinner from "../components/LoadingSpinner";
-import { useGlobalContext } from "../context/Global";
+import { Show } from "solid-js";
+import type { Accessor } from "solid-js";
 
-const TransactionMempool = () => {
+import LoadingSpinner from "../components/LoadingSpinner";
+import { SwapType } from "../consts/Enums";
+import { useGlobalContext } from "../context/Global";
+import { isMobile } from "../utils/helper";
+import type { SomeSwap } from "../utils/swapCreator";
+
+const TransactionMempool = (props: { swap: Accessor<SomeSwap> }) => {
     const { t } = useGlobalContext();
+
     return (
         <div>
             <h2>{t("tx_in_mempool")}</h2>
             <p>{t("tx_in_mempool_subline")}</p>
+            <Show
+                when={
+                    isMobile() &&
+                    [SwapType.Chain, SwapType.Reverse].includes(
+                        props.swap().type,
+                    )
+                }>
+                <h3>{t("tx_in_mempool_warning")}</h3>
+            </Show>
             <LoadingSpinner />
         </div>
     );


### PR DESCRIPTION
Closes #815 

Displays generic prompt when user has Reverse or Chain swap pending and is on desktop.
Tested on Tor browser:
![image](https://github.com/user-attachments/assets/f0ad76c5-180c-4592-b6ec-966730e88b98)

Also displays this warning (mobile AND BTC -> x only):
![image](https://github.com/user-attachments/assets/a4b01465-7b0b-49ea-82dd-852c62e5e959)