### PR TITLE
fix: properly handle zero-amount invoice error

### DIFF
--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -267,6 +267,7 @@ const CreateButton = () => {
                 amountValid,
                 addressValid,
                 invoiceValid,
+                invoiceError,
                 pairValid,
                 swapType,
                 lnurl,
@@ -285,16 +286,24 @@ const CreateButton = () => {
                     setButtonLabel({ key: "invalid_pair" });
                     return;
                 }
-                if (
+
+                const isChainSwapWithZeroAmount = () =>
+                    swapType() === SwapType.Chain &&
+                    assetSend() !== RBTC &&
+                    sendAmount().isZero();
+
+                const isSubmarineSwapInvoiceValid = () =>
+                    swapType() === SwapType.Submarine && !invoiceError();
+
+                const shouldShowAmountError = () =>
                     !amountValid() &&
                     // Chain swaps with 0-amount that do not have RBTC as sending asset
                     // can skip this check
-                    !(
-                        swapType() === SwapType.Chain &&
-                        assetSend() !== RBTC &&
-                        sendAmount().isZero()
-                    )
-                ) {
+                    !isChainSwapWithZeroAmount() &&
+                    (isSubmarineSwapInvoiceValid() ||
+                        swapType() !== SwapType.Submarine);
+
+                if (shouldShowAmountError()) {
                     const lessThanMin = Number(sendAmount()) < minimum();
                     setButtonLabel({
                         key: lessThanMin ? "minimum_amount" : "maximum_amount",

--- a/src/components/InvoiceInput.tsx
+++ b/src/components/InvoiceInput.tsx
@@ -41,6 +41,18 @@ const InvoiceInput = () => {
         setBolt12Offer,
     } = useCreateContext();
 
+    const clearInputError = (input: HTMLTextAreaElement) => {
+        input.classList.remove("invalid");
+        input.setCustomValidity("");
+        setInvoiceError(undefined);
+    };
+
+    const resetInvoiceState = () => {
+        setBolt12Offer(undefined);
+        setInvoiceValid(false);
+        setLnurl("");
+    };
+
     const validate = async (input: HTMLTextAreaElement) => {
         const val = input.value.trim();
 
@@ -58,10 +70,13 @@ const InvoiceInput = () => {
 
         const inputValue = extractInvoice(val);
 
+        if (inputValue.length === 0) {
+            clearInputError(input);
+            resetInvoiceState();
+            return;
+        }
+
         try {
-            input.setCustomValidity("");
-            setInvoiceError(undefined);
-            input.classList.remove("invalid");
             if (isLnurl(inputValue)) {
                 setLnurl(inputValue);
             } else if (await isBolt12Offer(inputValue)) {
@@ -82,15 +97,12 @@ const InvoiceInput = () => {
                 setLnurl("");
                 setInvoiceValid(true);
             }
+            clearInputError(input);
         } catch (e) {
-            setInvoiceValid(false);
-            setBolt12Offer(undefined);
-            setLnurl("");
+            input.classList.add("invalid");
+            input.setCustomValidity(t(e.message));
+            resetInvoiceState();
             setInvoiceError(e.message);
-            if (inputValue.length !== 0) {
-                input.setCustomValidity(t(e.message));
-                input.classList.add("invalid");
-            }
         }
     };
 

--- a/tests/components/CreateButton.spec.tsx
+++ b/tests/components/CreateButton.spec.tsx
@@ -131,4 +131,34 @@ describe("CreateButton", () => {
         expect(btn.disabled).toBeTruthy();
         expect(btn.textContent).toEqual(i18n.en.invalid_invoice);
     });
+
+    test("should be disabled with invalid_0_amount label", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <CreateButton />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+        globalSignals.setOnline(true);
+        signals.setSendAmount(BigNumber(100_000));
+        signals.setAmountValid(true);
+        signals.setInvoiceValid(true);
+        signals.setAssetSend(LBTC);
+        signals.setAssetReceive(LN);
+        const btn = (await screen.findByText(
+            i18n.en.create_swap,
+        )) as HTMLButtonElement;
+        expect(btn).not.toBeUndefined();
+        expect(btn.disabled).toBeFalsy();
+        signals.setInvoiceValid(false);
+        signals.setInvoiceError("invalid_0_amount");
+        expect(btn.disabled).toBeTruthy();
+        expect(btn.textContent).toEqual(i18n.en.invalid_0_amount);
+        signals.setAmountValid(false);
+        expect(btn.disabled).toBeTruthy();
+        expect(btn.textContent).toEqual(i18n.en.invalid_0_amount);
+    });
 });


### PR DESCRIPTION
Closes #686.

In this PR, amounts are now only validated when there are no invoice errors.