### PR TITLE
fix: Allow pasting amounts with white space on `Create`

### DIFF
--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -176,7 +176,10 @@ const Create = () => {
 
     const validatePaste = (evt: ClipboardEvent) => {
         const clipboardData = evt.clipboardData || globalThis.clipboardData;
-        const pastedData = clipboardData.getData("Text").trim();
+        const pastedData = clipboardData
+            .getData("Text")
+            .replace(/\s+/g, "")
+            .trim();
         if (!getValidationRegex(maximum()).test(pastedData)) {
             evt.stopPropagation();
             evt.preventDefault();


### PR DESCRIPTION
Closes #950 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation when pasting text by removing all whitespace, ensuring only valid, space-free entries are accepted.
* **Tests**
  * Added tests to confirm correct handling of pasted amounts containing spaces and commas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->