### PR TITLE
fix: `AddressInput` filled with incorrect RBTC address

### DIFF
--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -1,7 +1,14 @@
 import log from "loglevel";
 import { IoClose } from "solid-icons/io";
 import type { Accessor, Setter } from "solid-js";
-import { For, Show, createEffect, createMemo, createSignal } from "solid-js";
+import {
+    For,
+    Show,
+    createEffect,
+    createMemo,
+    createSignal,
+    onCleanup,
+} from "solid-js";
 
 import type { EIP6963ProviderInfo } from "../consts/Types";
 import { useCreateContext } from "../context/Create";
@@ -261,6 +268,11 @@ const ConnectWallet = (props: {
         const addr = address();
         setAddressValid(addr !== undefined);
         setOnchainAddress(addr || "");
+    });
+
+    onCleanup(() => {
+        setAddressValid(false);
+        setOnchainAddress("");
     });
 
     return (


### PR DESCRIPTION
RSK address should be cleared when `ConnectWallet` unmount, otherwise `AddressInput` will be filled with wrong data when navigating back to `/swap`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet connection stability by ensuring address validity and on-chain address are properly reset when disconnecting or leaving the wallet connection screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->