### PR TITLE
fix: Improve flip assets button's UX

### DIFF
--- a/src/components/Reverse.tsx
+++ b/src/components/Reverse.tsx
@@ -18,9 +18,9 @@ const Reverse = () => {
     };
 
     return (
-        <div id="flip-assets" onClick={() => setDirection()}>
+        <button id="flip-assets" onClick={() => setDirection()}>
             <ImArrowDown size={14} />
-        </div>
+        </button>
     );
 };
 

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -584,6 +584,11 @@ textarea.invalid {
     cursor: pointer;
     z-index: 1;
     box-shadow: 0 0 7px var(--color-black-40);
+    color: var(--color-secondary-100);
+    position: absolute;
+    display: inline-block;
+    left: 50%;
+    transform: translateX(-50%);
 }
 @media (hover: hover) {
     #flip-assets:hover {


### PR DESCRIPTION
Closes #850 

Using a `div` was making this button harder to press on mobile, because touch event was getting triggered on the `input` below. Switching to `button` fixed the problem.

Easily reproducible with 200% zoom on devtools, mobile mode and then touching the upper part of the button.
<img width="847" height="595" alt="image" src="https://github.com/user-attachments/assets/d219ddb0-58d4-40a4-abdc-74480d73a741" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual appearance and positioning of the flip assets element for better alignment and color consistency.

* **Refactor**
  * Enhanced accessibility and semantics by changing the interactive element for reversing direction from a div to a button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->