### PR TITLE
docs: enable search detailed view

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -11,6 +11,9 @@ export default defineConfig({
         logo: "/assets/logo.svg",
         search: {
             provider: "local",
+            options: {
+                detailedView: true,
+            },
         },
         nav: [{ text: "🏠 Docs Home", link: docsRoot, target: "_self" }],
         sidebar: [


### PR DESCRIPTION
Changing default search view from:
<img width="1131" height="286" alt="image" src="https://github.com/user-attachments/assets/0f3e880b-47e1-4014-94cc-780b5723ef75" />

To:
<img width="1131" height="435" alt="image" src="https://github.com/user-attachments/assets/21fd712b-8b9a-45a9-b407-bd4e81156b89" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the search functionality in the documentation site to provide a more detailed view of search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->