### PR TITLE
chore: add "do not close this page" to mainchain submarine/chain swap…

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -125,7 +125,7 @@ const dict = {
         tx_in_mempool: "Transaction is in mempool",
         tx_in_mempool_subline: "Waiting for confirmation to complete the swap.",
         tx_in_mempool_warning:
-            "Please keep this tab open until the swap completed!",
+            "Keep this page open, otherwise your swap can't complete!",
         expired: "Swap expired!",
         invoice_pending: "Transaction received, paying invoice.",
         invoice_expired: "Invoice expired, try again!",
@@ -429,7 +429,7 @@ const dict = {
         tx_in_mempool_subline:
             "Warte auf Bestätigung, um den Swap abzuschließen.",
         tx_in_mempool_warning:
-            "Tab nicht schließen, bis der Swap abgeschlossen ist!",
+            "Seite nicht schließen, sonst kann Swap nicht abgeschlossen werden!",
         expired: "Swap ist abgelaufen!",
         invoice_pending: "Transaktion erhalten, Rechnung wird bezahlt.",
         invoice_expired: "Rechnung ist abgelaufen, bitte erneut versuchen!",
@@ -742,7 +742,7 @@ const dict = {
         tx_in_mempool_subline:
             "Esperando confirmación para completar el intercambio.",
         tx_in_mempool_warning:
-            "Por favor, mantenga esta pestaña abierta hasta que se complete el intercambio!",
+            "Mantenga la página abierta, o el intercambio no se completará!",
         expired: "¡El intercambio ha expirado!",
         invoice_pending: "Transacción recibida, pagando la factura...",
         invoice_expired: "La factura ha expirado, ¡intente nuevamente!",
@@ -1053,7 +1053,7 @@ const dict = {
         tx_in_mempool: "Transação na mempool",
         tx_in_mempool_subline: "Aguardando confirmação para concluir a troca.",
         tx_in_mempool_warning:
-            "Por favor, mantenha esta aba aberta até que a troca seja concluída!",
+            "Mantenha esta página aberta, senão a troca não termina!",
         expired: "Troca expirada!",
         invoice_pending: "Transação recebida, a pagar o invoice.",
         invoice_expired: "Invoice expirado, tente novamente!",
@@ -1348,7 +1348,7 @@ const dict = {
         delete_logs: "您确定要删除日志吗？",
         tx_in_mempool: "事务在内存池中",
         tx_in_mempool_subline: "等待确认以完成交换",
-        tx_in_mempool_warning: "请保持打开此选项卡，直至交换完成！",
+        tx_in_mempool_warning: "请保持此页打开，否则兑换无法完成！",
         expired: "交换已过期！",
         invoice_pending: "收到交易，正在支付发票。",
         invoice_expired: "发票已过期，请重试！",
@@ -1638,7 +1638,7 @@ const dict = {
         tx_in_mempool: "トランザクションがメモリプール内にあります",
         tx_in_mempool_subline: "スワップを完了するために確認を待っています",
         tx_in_mempool_warning:
-            "スワップが完了するまでこのタブを開いておいてください！",
+            "ページを開いたままにしないと、スワップは完了しません！",
         expired: "スワップが期限切れです！",
         invoice_pending:
             "トランザクションを受け取りました。インボイスを支払っています",

--- a/src/status/TransactionConfirmed.tsx
+++ b/src/status/TransactionConfirmed.tsx
@@ -88,9 +88,6 @@ const TransactionConfirmed = () => {
                 <div>
                     <h2>{t("tx_confirmed")}</h2>
                     <p>{t("tx_ready_to_claim")}</p>
-                    <Show when={[SwapType.Chain].includes(swap().type)}>
-                        <h3>{t("tx_in_mempool_warning")}</h3>
-                    </Show>
                     <LoadingSpinner />
                 </div>
             }>


### PR DESCRIPTION
Having one or two support cases about this every week. Let's see if this helps at least a lil bit. Also switched 24h-> 12h.

Before and after:
<img width="1714" height="969" alt="image" src="https://github.com/user-attachments/assets/a872eb98-2427-48ce-bf1a-7f66e64c9e1d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated warning messages during swaps to clarify that the page must remain open for the swap to complete, across all supported languages.
  * Improved Portuguese translation for the transaction status message.

* **Refactor**
  * Simplified the swap warning display logic for a more consistent user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->