### PR TITLE
fix: Boltz Pro Telegram bot link CSS

### DIFF
--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -960,6 +960,13 @@ header {
     background: var(--color-black-10);
     border-radius: 0.5rem;
 
+    a {
+        color: var(--color-text);
+    }
+    a:hover {
+        color: var(--color-primary);
+    }
+
     th,
     td {
         text-align: center;


### PR DESCRIPTION
Before
<img width="698" height="456" alt="image" src="https://github.com/user-attachments/assets/6a9fc29e-e395-4493-9dea-7aa5945196cf" />

After (orange on hover, just like the Nav links)
<img width="676" height="434" alt="image" src="https://github.com/user-attachments/assets/6676c253-22f4-4d93-b599-30d9a80b5f45" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated link colors in the fee comparison table for improved visual consistency. Links now use the standard text color and change to the primary color on hover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->