### PR TITLE
fix: Claim pending swaps

### DIFF
--- a/src/components/Fees.tsx
+++ b/src/components/Fees.tsx
@@ -1,5 +1,4 @@
 import { BigNumber } from "bignumber.js";
-import type { Accessor } from "solid-js";
 import {
     Show,
     createEffect,
@@ -10,7 +9,6 @@ import {
 } from "solid-js";
 
 import { config } from "../config";
-import { LBTC } from "../consts/Assets";
 import { SwapType } from "../consts/Enums";
 import { useCreateContext } from "../context/Create";
 import { useGlobalContext } from "../context/Global";
@@ -24,18 +22,14 @@ import {
     calculateBoltzFeeOnSend,
     calculateSendAmount,
 } from "../utils/calculate";
-import { isConfidentialAddress } from "../utils/compat";
 import { formatAmount } from "../utils/denomination";
+import { isToUnconfidentialLiquid, unconfidentialExtra } from "../utils/fees";
 import { getPair } from "../utils/helper";
 import { weiToSatoshi } from "../utils/rootstock";
 import { getClaimAddress } from "./CreateButton";
 import Denomination from "./settings/Denomination";
 
 const ppmFactor = 10_000;
-
-// When sending to an unconfidential address, we need to add an extra
-// confidential OP_RETURN output with 1 sat inside
-export const unconfidentialExtra = 5;
 
 const rifExtraGasCost = 157_000n;
 
@@ -50,19 +44,6 @@ export const getFeeHighlightClass = (fee: number, regularFee: number) => {
 
     return "";
 };
-
-export const isToUnconfidentialLiquid = ({
-    assetReceive,
-    addressValid,
-    onchainAddress,
-}: {
-    assetReceive: Accessor<string>;
-    addressValid: Accessor<boolean>;
-    onchainAddress: Accessor<string>;
-}) =>
-    assetReceive() === LBTC &&
-    addressValid() &&
-    !isConfidentialAddress(onchainAddress());
 
 const Fees = () => {
     const {

--- a/src/components/OptimizedRoute.tsx
+++ b/src/components/OptimizedRoute.tsx
@@ -16,12 +16,12 @@ import type {
 } from "../utils/boltzClient";
 import { calculateBoltzFeeOnSend } from "../utils/calculate";
 import { formatAmount, formatDenomination } from "../utils/denomination";
-import { getPair, isMobile } from "../utils/helper";
-import type { ChainSwap } from "../utils/swapCreator";
 import {
     unconfidentialExtra as extraFee,
     isToUnconfidentialLiquid,
-} from "./Fees";
+} from "../utils/fees";
+import { getPair, isMobile } from "../utils/helper";
+import type { ChainSwap } from "../utils/swapCreator";
 import Tooltip from "./settings/Tooltip";
 
 const getTotalChainFees = ({

--- a/src/components/SwapChecker.tsx
+++ b/src/components/SwapChecker.tsx
@@ -25,7 +25,7 @@ import {
 } from "../utils/claim";
 import { formatError } from "../utils/errors";
 import { getApiUrl, getPair } from "../utils/helper";
-import { isSwapClaimable } from "../utils/rescue";
+import { isSwapStatusClaimable } from "../utils/rescue";
 import type {
     ChainSwap,
     ReverseSwap,
@@ -271,7 +271,7 @@ export const SwapChecker = () => {
         if (
             currentSwap.claimTx === undefined &&
             data.transaction !== undefined &&
-            isSwapClaimable(data.status, currentSwap.type)
+            isSwapStatusClaimable(data.status, currentSwap.type)
         ) {
             try {
                 const res = await claim(

--- a/src/context/Global.tsx
+++ b/src/context/Global.tsx
@@ -16,7 +16,6 @@ import type { Accessor, JSX, Setter } from "solid-js";
 import { config } from "../config";
 import { Denomination, UrlParam } from "../consts/Enums";
 import { referralIdKey } from "../consts/LocalStorage";
-import { swapStatusFinal } from "../consts/SwapStatus";
 import { detectLanguage } from "../i18n/detect";
 import type { DictKey } from "../i18n/i18n";
 import dict from "../i18n/i18n";
@@ -374,14 +373,12 @@ const GlobalProvider = (props: { children: JSX.Element }) => {
     };
 
     const updateSwapStatus = async (id: string, newStatus: string) => {
-        if (swapStatusFinal.includes(newStatus)) {
-            const swap = await getSwap<SubmarineSwap & { status: string }>(id);
+        const swap = await getSwap<SubmarineSwap & { status: string }>(id);
 
-            if (swap.status !== newStatus) {
-                swap.status = newStatus;
-                await setSwapStorage(swap);
-                return true;
-            }
+        if (swap.status !== newStatus) {
+            swap.status = newStatus;
+            await setSwapStorage(swap);
+            return true;
         }
 
         return false;

--- a/src/context/Rescue.tsx
+++ b/src/context/Rescue.tsx
@@ -2,16 +2,16 @@ import type { ECPairInterface } from "ecpair";
 import type { Accessor, JSX, Setter } from "solid-js";
 import { createContext, createSignal, useContext } from "solid-js";
 
-import type { RestorableSwap } from "../utils/boltzClient";
 import { ECPair } from "../utils/ecpair";
 import { type RescueFile, deriveKey } from "../utils/rescueFile";
+import type { SomeSwap } from "../utils/swapCreator";
 
 export type RescueContextType = {
     rescueFile: Accessor<RescueFile>;
     setRescueFile: Setter<RescueFile>;
 
-    rescuableSwaps: Accessor<RestorableSwap[]>;
-    setRescuableSwaps: Setter<RestorableSwap[]>;
+    rescuableSwaps: Accessor<SomeSwap[]>;
+    setRescuableSwaps: Setter<SomeSwap[]>;
 
     deriveKey: (index: number) => ECPairInterface;
 };
@@ -20,9 +20,7 @@ const RescueContext = createContext<RescueContextType>();
 
 export const RescueProvider = (props: { children: JSX.Element }) => {
     const [rescueFile, setRescueFile] = createSignal<RescueFile>();
-    const [rescuableSwaps, setRescuableSwaps] = createSignal<RestorableSwap[]>(
-        [],
-    );
+    const [rescuableSwaps, setRescuableSwaps] = createSignal<SomeSwap[]>([]);
 
     const deriveKeyWrapper = (index: number) => {
         return ECPair.fromPrivateKey(

--- a/src/utils/fees.ts
+++ b/src/utils/fees.ts
@@ -1,0 +1,21 @@
+import type { Accessor } from "solid-js";
+
+import { LBTC } from "../consts/Assets";
+import { isConfidentialAddress } from "./compat";
+
+export const isToUnconfidentialLiquid = ({
+    assetReceive,
+    addressValid,
+    onchainAddress,
+}: {
+    assetReceive: Accessor<string>;
+    addressValid: Accessor<boolean>;
+    onchainAddress: Accessor<string>;
+}) =>
+    assetReceive() === LBTC &&
+    addressValid() &&
+    !isConfidentialAddress(onchainAddress());
+
+// When sending to an unconfidential address, we need to add an extra
+// confidential OP_RETURN output with 1 sat inside
+export const unconfidentialExtra = 5;

--- a/src/utils/rescue.ts
+++ b/src/utils/rescue.ts
@@ -8,7 +8,7 @@ import log from "loglevel";
 
 import { LBTC } from "../consts/Assets";
 import { SwapType } from "../consts/Enums";
-import { swapStatusPending } from "../consts/SwapStatus";
+import { swapStatusPending, swapStatusSuccess } from "../consts/SwapStatus";
 import type { deriveKeyFn } from "../context/Global";
 import secp from "../lazy/secp";
 import { getSwapUTXOs } from "./blockchain";
@@ -41,14 +41,17 @@ export enum RescueAction {
 
 export const RescueNoAction = [RescueAction.None, RescueAction.Pending];
 
+// Shared with SwapChecker.tsx. All these statuses are necessary to ensure consistent claimability
 export const isSwapClaimable = (status: string, type: SwapType) =>
     (type === SwapType.Reverse &&
         [
+            swapStatusSuccess.InvoiceSettled,
             swapStatusPending.TransactionConfirmed,
             swapStatusPending.TransactionMempool,
         ].includes(status)) ||
     (type === SwapType.Chain &&
         [
+            swapStatusSuccess.TransactionClaimed,
             swapStatusPending.TransactionServerConfirmed,
             swapStatusPending.TransactionServerMempool,
         ].includes(status));

--- a/src/utils/rescue.ts
+++ b/src/utils/rescue.ts
@@ -47,7 +47,7 @@ export enum RescueAction {
 export const RescueNoAction = [RescueAction.None, RescueAction.Pending];
 
 // Shared with SwapChecker.tsx. All these statuses are necessary to ensure consistent claimability
-export const isSwapClaimable = (status: string, type: SwapType) =>
+export const isSwapStatusClaimable = (status: string, type: SwapType) =>
     (type === SwapType.Reverse &&
         [
             swapStatusSuccess.InvoiceSettled,
@@ -365,7 +365,7 @@ export const createRescueList = async (swaps: SomeSwap[]) => {
         swaps.map(async (swap) => {
             try {
                 if (
-                    isSwapClaimable(swap.status, swap.type) &&
+                    isSwapStatusClaimable(swap.status, swap.type) &&
                     (await getClaimableUTXOs(swap as ChainSwap | ReverseSwap))
                         .length > 0
                 ) {

--- a/tests/pages/RescueExternal.spec.tsx
+++ b/tests/pages/RescueExternal.spec.tsx
@@ -9,6 +9,7 @@ import {
     globalSignals,
     payContext,
 } from "../helper";
+import { pairs } from "../pairs";
 
 /* eslint-disable  require-await,@typescript-eslint/require-await,@typescript-eslint/no-explicit-any */
 
@@ -22,6 +23,7 @@ vi.mock("../../src/utils/boltzClient", () => {
                 timeoutEta: 10,
             }),
         ),
+        getPairs: vi.fn(() => Promise.resolve(pairs)),
     };
 });
 


### PR DESCRIPTION
Had a support case in which a user couldn't claim his pending reverse swap because it had the `invoice.settled` status, which wasn't covered by the existing `isSwapClaimable` function.

This was a regression introduced in https://github.com/BoltzExchange/boltz-web-app/pull/973:
`isSwapClaimable` replaced a condition which existed in `SwapChecker`, but didn't include all status which were previously defined in `SwapChecker`.

This PR fixes the issue by adding the missing statuses (which were previously in `SwapChecker`) to `isSwapClaimable` (also renamed it to `isSwapStatusClaimable`, for a more accurate name).

Also refactored the code to ensure data consistency by unifying the `RestorableSwap` -> `SomeSwap` maps which were defined in different files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Waits for pending transactions in mempool before proceeding to improve claim reliability.
  * Auto-loads pair data on mount to populate rescue options.

* **Refactor**
  * Unified swap representation across rescue flows; simplified claim/refund data paths.
  * Adds claimable-UTXO checks and centralizes unconfidential-fee logic for more accurate receive amounts.

* **Tests**
  * Stabilized e2e and component tests with mempool polling and deterministic pair fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->