### PR TITLE
fix: Restore previous `SwapChecker` behavior

### DIFF
--- a/src/components/SwapChecker.tsx
+++ b/src/components/SwapChecker.tsx
@@ -271,7 +271,11 @@ export const SwapChecker = () => {
         if (
             currentSwap.claimTx === undefined &&
             data.transaction !== undefined &&
-            isSwapClaimable(data.status, currentSwap.type)
+            isSwapClaimable({
+                status: data.status,
+                type: currentSwap.type,
+                includeSuccess: true,
+            })
         ) {
             try {
                 const res = await claim(

--- a/src/utils/blockchain.ts
+++ b/src/utils/blockchain.ts
@@ -10,6 +10,10 @@ export type UTXO = {
     vout: number;
 };
 
+const requestTimeout = () => ({
+    signal: AbortSignal.timeout(10_000),
+});
+
 export const fetchUTXOsWithFailover = async (
     asset: string,
     address: string,
@@ -17,7 +21,10 @@ export const fetchUTXOsWithFailover = async (
     for (const url of config.assets[asset].blockExplorerApis) {
         try {
             const basePath = chooseUrl(url);
-            const response = await fetch(`${basePath}/address/${address}/utxo`);
+            const response = await fetch(
+                `${basePath}/address/${address}/utxo`,
+                requestTimeout(),
+            );
 
             if (!response.ok) {
                 log.error(`Failed to fetch UTXOs for ${address}`);
@@ -41,7 +48,10 @@ export const fetchRawTxWithFailover = async (
     for (const url of config.assets[asset].blockExplorerApis) {
         try {
             const basePath = chooseUrl(url);
-            const response = await fetch(`${basePath}/tx/${txid}/hex`);
+            const response = await fetch(
+                `${basePath}/tx/${txid}/hex`,
+                requestTimeout(),
+            );
 
             if (!response.ok) {
                 log.error(`Failed to fetch raw tx for ${txid}`);

--- a/tests/utils/rescue.spec.ts
+++ b/tests/utils/rescue.spec.ts
@@ -1,0 +1,131 @@
+import { SwapType } from "../../src/consts/Enums";
+import {
+    swapStatusPending,
+    swapStatusSuccess,
+} from "../../src/consts/SwapStatus";
+import { isSwapClaimable } from "../../src/utils/rescue";
+
+describe("rescue", () => {
+    describe("isSwapClaimable", () => {
+        test.each([
+            {
+                name: "Reverse: confirmed -> true",
+                type: SwapType.Reverse,
+                status: swapStatusPending.TransactionConfirmed,
+                includeSuccess: undefined,
+                expected: true,
+            },
+            {
+                name: "Reverse: mempool -> true",
+                type: SwapType.Reverse,
+                status: swapStatusPending.TransactionMempool,
+                includeSuccess: undefined,
+                expected: true,
+            },
+            {
+                name: "Reverse: success not included by default -> false",
+                type: SwapType.Reverse,
+                status: swapStatusSuccess.InvoiceSettled,
+                includeSuccess: undefined,
+                expected: false,
+            },
+            {
+                name: "Reverse: irrelevant status -> false",
+                type: SwapType.Reverse,
+                status: swapStatusPending.TransactionServerMempool,
+                includeSuccess: undefined,
+                expected: false,
+            },
+            {
+                name: "Reverse: include success -> true",
+                type: SwapType.Reverse,
+                status: swapStatusSuccess.InvoiceSettled,
+                includeSuccess: true,
+                expected: true,
+            },
+        ])("$name", ({ type, status, includeSuccess, expected }) => {
+            expect(isSwapClaimable({ status, type, includeSuccess })).toEqual(
+                expected,
+            );
+        });
+
+        test.each([
+            {
+                name: "Chain: server confirmed -> true",
+                type: SwapType.Chain,
+                status: swapStatusPending.TransactionServerConfirmed,
+                includeSuccess: undefined,
+                expected: true,
+            },
+            {
+                name: "Chain: server mempool -> true",
+                type: SwapType.Chain,
+                status: swapStatusPending.TransactionServerMempool,
+                includeSuccess: undefined,
+                expected: true,
+            },
+            {
+                name: "Chain: success not included by default -> false",
+                type: SwapType.Chain,
+                status: swapStatusSuccess.TransactionClaimed,
+                includeSuccess: undefined,
+                expected: false,
+            },
+            {
+                name: "Chain: include success -> true",
+                type: SwapType.Chain,
+                status: swapStatusSuccess.TransactionClaimed,
+                includeSuccess: true,
+                expected: true,
+            },
+        ])("$name", ({ type, status, includeSuccess, expected }) => {
+            expect(isSwapClaimable({ status, type, includeSuccess })).toEqual(
+                expected,
+            );
+        });
+
+        test.each([
+            {
+                name: "Submarine: confirmed -> false",
+                type: SwapType.Submarine,
+                status: swapStatusPending.TransactionConfirmed,
+                includeSuccess: undefined,
+                expected: false,
+            },
+            {
+                name: "Submarine: success (includeSuccess=true) -> false",
+                type: SwapType.Submarine,
+                status: swapStatusSuccess.InvoiceSettled,
+                includeSuccess: true,
+                expected: false,
+            },
+        ])("$name", ({ type, status, includeSuccess, expected }) => {
+            expect(isSwapClaimable({ status, type, includeSuccess })).toEqual(
+                expected,
+            );
+        });
+
+        test.each([
+            { type: SwapType.Chain, includeSuccess: undefined },
+            { type: SwapType.Chain, includeSuccess: false },
+            { type: SwapType.Chain, includeSuccess: true },
+            { type: SwapType.Reverse, includeSuccess: undefined },
+            { type: SwapType.Reverse, includeSuccess: false },
+            { type: SwapType.Reverse, includeSuccess: true },
+            { type: SwapType.Submarine, includeSuccess: undefined },
+            { type: SwapType.Submarine, includeSuccess: false },
+            { type: SwapType.Submarine, includeSuccess: true },
+        ])(
+            "should return false for unknown statuses (type: $type, includeSuccess: $includeSuccess)",
+            ({ type, includeSuccess }) => {
+                expect(
+                    isSwapClaimable({
+                        status: "unknown.status",
+                        type,
+                        includeSuccess,
+                    }),
+                ).toEqual(false);
+            },
+        );
+    });
+});


### PR DESCRIPTION
A regression was introduced in #973, replacing an existing condition in `SwapChecker` with `isSwapClaimable`, but `isSwapClaimable` did not include all swap status which were prevoiusly defined in `SwapChecker`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded swap claim eligibility so reverse swaps become claimable after invoice settlement and chain swaps after transaction claim, reducing stuck swaps and incorrect "not claimable" states.

* **Reliability**
  * Improved blockchain request timeout handling to reduce hangs and speed up responses.

* **Tests**
  * Added tests covering claim eligibility across swap types and statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->