### PR TITLE
Refactor fetch mechanism for 3rd party explorers

### DIFF
--- a/src/utils/blockchain.ts
+++ b/src/utils/blockchain.ts
@@ -78,6 +78,24 @@ const getRawTransaction = async (asset: string, txid: string) => {
     });
 };
 
+export const broadcastToExplorer = async (
+    asset: string,
+    txHex: string,
+): Promise<{ id: string }> => {
+    const txId = await fetchBlockExplorer<string>({
+        asset,
+        endpoint: "/tx",
+        options: {
+            method: "POST",
+            body: txHex,
+        },
+    });
+
+    return {
+        id: txId,
+    };
+};
+
 export const getSwapUTXOs = async (swap: ChainSwap | SubmarineSwap) => {
     const address =
         swap.type === SwapType.Chain

--- a/src/utils/blockchain.ts
+++ b/src/utils/blockchain.ts
@@ -10,52 +10,69 @@ export type UTXO = {
     vout: number;
 };
 
-const fetchBlockExplorer = async <T>({
-    asset,
-    endpoint,
-    options = {},
-}: {
-    asset: string;
-    endpoint: string;
-    options?: RequestInit;
-}) => {
+const processResponse = async <T>(response: Response): Promise<T> => {
+    const contentType = response.headers.get("content-type");
+    if (contentType?.includes("application/json")) {
+        return (await response.json()) as T;
+    }
+    return (await response.text()) as T;
+};
+
+const constructRequestOptions = (options: RequestInit) => {
+    const controller = new AbortController();
+    const requestTimeout = setTimeout(() => controller.abort(), 10_000);
+
+    const opts: RequestInit = {
+        signal: controller.signal, // Default abort signal, can be overridden by options.signal
+        ...options,
+    };
+
+    return { opts, requestTimeout };
+};
+
+/**
+ * Sequentially fetches resources from block explorers APIs and returns the response
+ */
+const fetchBlockExplorer = async <T>(
+    asset: string,
+    endpoint: string,
+    options: RequestInit = {},
+): Promise<T> => {
     for (const url of config.assets[asset].blockExplorerApis) {
+        const { opts, requestTimeout } = constructRequestOptions(options);
+
         try {
             const basePath = chooseUrl(url);
 
-            const controller = new AbortController();
-            const requestTimeout = setTimeout(() => controller.abort(), 10_000);
-            const opts: RequestInit = {
-                ...options,
-                signal: controller.signal,
-            };
+            const res = await fetch(`${basePath}${endpoint}`, opts);
 
-            const response = await fetch(`${basePath}${endpoint}`, opts);
-
-            clearTimeout(requestTimeout);
-
-            if (!response.ok) {
+            if (!res.ok) {
                 try {
-                    const body = await response.json();
-                    log.error(`failed to fetch ${endpoint}`, formatError(body));
+                    const body = await res.json();
+                    log.error(
+                        `block explorer fetch ${endpoint} for asset ${asset} failed`,
+                        formatError(body),
+                    );
                     continue;
                 } catch {
                     // If parsing JSON fails, throw a generic error with status text
-                    log.error(response.statusText);
+                    log.error(
+                        `block explorer fetch ${endpoint} for asset ${asset} failed`,
+                        res.statusText,
+                    );
                     continue;
                 }
             }
 
-            const contentType = response.headers.get("content-type");
-
-            if (contentType?.includes("application/json")) {
-                return (await response.json()) as T;
-            }
-
-            return (await response.text()) as T;
+            return await processResponse<T>(res);
         } catch (e) {
-            log.error(`failed to fetch ${endpoint} for asset ${asset}`, e);
+            log.error(
+                `block explorer fetch ${endpoint} for asset ${asset} failed`,
+                e,
+            );
             continue;
+        } finally {
+            clearTimeout(requestTimeout);
         }
     }
 
@@ -64,36 +81,69 @@ const fetchBlockExplorer = async <T>({
     );
 };
 
+/**
+ * Fetches resources from multiple block explorer APIs in parallel and returns the first successful response
+ */
+const fetchBlockExplorerParallel = async <T>(
+    asset: string,
+    endpoint: string,
+    options: RequestInit = {},
+): Promise<T> => {
+    const urls = config.assets[asset].blockExplorerApis;
+
+    try {
+        const broadcastPromises = urls.map(async (url) => {
+            const { opts, requestTimeout } = constructRequestOptions(options);
+            try {
+                const basePath = chooseUrl(url);
+
+                const res = await fetch(`${basePath}${endpoint}`, opts);
+
+                if (!res.ok) {
+                    throw new Error(
+                        `HTTP ${res.status} from ${basePath}${endpoint}`,
+                    );
+                }
+
+                return res;
+            } finally {
+                clearTimeout(requestTimeout);
+            }
+        });
+
+        const response = await Promise.any(broadcastPromises);
+
+        return await processResponse<T>(response);
+    } catch (err) {
+        if (err instanceof AggregateError) {
+            err.errors.forEach((e, i) => {
+                log.error(`Broadcast to ${chooseUrl(urls[i])} failed: ${e}`);
+            });
+        }
+        throw new Error(`all ${asset} transaction broadcast attempts failed`, {
+            cause: err,
+        });
+    }
+};
+
 const getAddressUTXOs = async (asset: string, address: string) => {
-    return await fetchBlockExplorer<UTXO[]>({
-        asset,
-        endpoint: `/address/${address}/utxo`,
-    });
+    return await fetchBlockExplorer<UTXO[]>(asset, `/address/${address}/utxo`);
 };
 
 const getRawTransaction = async (asset: string, txid: string) => {
-    return await fetchBlockExplorer<string>({
-        asset,
-        endpoint: `/tx/${txid}/hex`,
-    });
+    return await fetchBlockExplorer<string>(asset, `/tx/${txid}/hex`);
 };
 
 export const broadcastToExplorer = async (
     asset: string,
     txHex: string,
 ): Promise<{ id: string }> => {
-    const txId = await fetchBlockExplorer<string>({
-        asset,
-        endpoint: "/tx",
-        options: {
-            method: "POST",
-            body: txHex,
-        },
+    const txId = await fetchBlockExplorerParallel<string>(asset, "/tx", {
+        method: "POST",
+        body: txHex,
     });
 
-    return {
-        id: txId,
-    };
+    return { id: txId };
 };
 
 export const getSwapUTXOs = async (swap: ChainSwap | SubmarineSwap) => {

--- a/src/utils/boltzClient.ts
+++ b/src/utils/boltzClient.ts
@@ -6,7 +6,8 @@ import log from "loglevel";
 
 import { config } from "../config";
 import { SwapType } from "../consts/Enums";
-import { broadcastToExplorer, fetcher } from "./helper";
+import { broadcastToExplorer } from "./blockchain";
+import { fetcher } from "./helper";
 import { validateInvoiceForOffer } from "./invoice";
 
 const cooperativeErrorMessage = "cooperative signatures for swaps are disabled";

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -146,29 +146,3 @@ export const parsePrivateKey = (
         return ECPair.fromWIF(privateKeyHex);
     }
 };
-
-// posts transaction to a block explorer
-export const broadcastToExplorer = async (
-    asset: string,
-    txHex: string,
-): Promise<{ id: string }> => {
-    const basePath = chooseUrl(config.assets[asset].blockExplorerUrl);
-    const response = await fetch(`${basePath}/api/tx`, {
-        method: "POST",
-        body: txHex,
-    });
-
-    if (!response.ok) {
-        try {
-            const body = await response.json();
-            throw formatError(body);
-        } catch {
-            // If parsing JSON fails, throw a generic error with status text
-            throw response.statusText;
-        }
-    }
-
-    return {
-        id: await response.text(),
-    };
-};


### PR DESCRIPTION
Refactors `blockchain.ts`'s fetching mechanism to a more scalable design

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API to broadcast raw transactions to block explorers, returning the broadcast identifier and using parallel requests to obtain the first successful response.

* **Refactor**
  * Centralized block-explorer requests into a single, content-type aware fetcher with timeouts and improved error handling.
  * Removed legacy per-endpoint failover helpers and updated callers and imports to use the new unified helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->