### PR TITLE
chore: clarify Docker build port

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,5 +30,8 @@ swapping!
 
 ```bash
 docker build -t boltz-webapp .
-docker run -d --rm -p 4173:80 --name my-boltz-webapp boltz-webapp
+docker run -d --rm -p 3000:80 --name my-boltz-webapp boltz-webapp
 ```
+
+Just like the native build, the Docker container will serve the web app on
+[http://localhost:3000](http://localhost:3000).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker run example to map host port 3000 (replacing 4173) using -p 3000:80 in the code block within the documentation.
  * Added an explicit note stating the app is served at http://localhost:3000, including a clickable link.
  * Inserted a blank line between the code block and the note in the docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->