### PR TITLE
docs: add secure context section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,9 @@ next:
 We encourage our technical users to check the code and run the web app locally
 from source following the instructions below.
 
-## Dependencies
+## Native Build
+
+### Dependencies
 
 Make sure to have the latest
 [Node.js LTS and NPM](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
@@ -26,7 +28,9 @@ install all dependencies. Then `npm run mainnet && npm run build` and
 Open [http://localhost:3000](http://localhost:3000) in your browser and start
 swapping!
 
-## With Docker
+## Docker
+
+In your local `boltz-web-app` repository, run:
 
 ```bash
 docker build -t boltz-webapp .
@@ -35,3 +39,17 @@ docker run -d --rm -p 3000:80 --name my-boltz-webapp boltz-webapp
 
 Just like the native build, the Docker container will serve the web app on
 [http://localhost:3000](http://localhost:3000).
+
+## Secure Context
+
+To access your local Boltz Web App build from another machine, ensure the page
+is served in a
+[secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts).
+Otherwise, the site will not work and the browser console will show an error
+like: `Window is not in a secure context`.
+
+Ways to get a secure context:
+
+- access the site via `localhost` (for remote hosts, use SSH port forwarding:
+  `ssh -N -L 3000:localhost:3000 user@server`)
+- or serve the app over `https://` (self‑signed certificates are fine).

--- a/src/utils/logs.ts
+++ b/src/utils/logs.ts
@@ -68,6 +68,10 @@ export const injectLogWriter = (logsForage: LocalForage) => {
 
             const currentDate = getDate();
 
+            if (navigator.locks === undefined) {
+                throw new Error("Window is not in a secure context");
+            }
+
             void navigator.locks
                 .request("logLock", async () => {
                     await logsForage.setItem(


### PR DESCRIPTION
Came up twice in our TG group in the past couple of days

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced “Dependencies” with “Native Build” and added a detailed “Dependencies” subsection (Node.js LTS/NPM, nvm); clarified run flow to include environment setup and an explicit npm install before build; renamed “With Docker” to “Docker,” added prefatory guidance and build/run commands, and added a “Secure Context” guide with troubleshooting and tunneling/HTTPS options.

* **Bug Fixes**
  * Added a preflight check that surfaces a clear “Window is not in a secure context” error when secure APIs are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->