### PR TITLE
fix: min-relay fee not met

### DIFF
--- a/e2e/bolt12.spec.ts
+++ b/e2e/bolt12.spec.ts
@@ -1,7 +1,10 @@
 import { expect, test } from "@playwright/test";
 
-import dict from "../src/i18n/i18n";
-import { generateBitcoinBlock, getBolt12Offer } from "./utils";
+import {
+    generateBitcoinBlock,
+    getBolt12Offer,
+    verifyRescueFile,
+} from "./utils";
 
 test.describe("BOLT12", () => {
     test.beforeEach(async () => {
@@ -27,7 +30,8 @@ test.describe("BOLT12", () => {
         );
         await buttonCreateSwap.click();
 
-        const downloadButton = page.getByText(dict.en.download_new_key);
-        await expect(downloadButton).toBeVisible();
+        await verifyRescueFile(page);
+
+        await expect(page.getByText("BIP21")).toBeVisible();
     });
 });

--- a/e2e/chainSwaps/zeroAmount.spec.ts
+++ b/e2e/chainSwaps/zeroAmount.spec.ts
@@ -52,7 +52,7 @@ test.describe("Chain Swap 0-amount", () => {
         expect(txId).toBeDefined();
 
         const txInfo = JSON.parse(await getElementsWalletTx(txId));
-        expect(txInfo.amount.bitcoin.toString()).toEqual("0.0099715");
+        expect(txInfo.amount.bitcoin.toString()).toEqual("0.00997147");
     });
 
     test("should allow 0-amount chain swaps", async ({ page }) => {

--- a/tests/pages/Create.spec.tsx
+++ b/tests/pages/Create.spec.tsx
@@ -81,7 +81,7 @@ describe("Create", () => {
 
         signals.setAssetReceive(LBTC);
 
-        expect(signals.receiveAmount()).toEqual(BigNumber(49447));
+        expect(signals.receiveAmount()).toEqual(BigNumber(49441));
     });
 
     test("should update receive amount on miner fee change", () => {


### PR DESCRIPTION
Closes #985

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted miner fee handling for BTC↔LBTC routes; users may see a small increase in estimated/claimed miner fees when fetching pairs and during swaps (applies to both regular and non-regular pair fetches).

* **Tests**
  * Updated expected receive amount and zero-amount BTC/L-BTC expectation to reflect the revised fee calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->