### PR TITLE
fix: Don't attempt to get UTXOs during initial swap phase

### DIFF
--- a/src/pages/Pay.tsx
+++ b/src/pages/Pay.tsx
@@ -95,11 +95,15 @@ const Pay = () => {
     });
 
     createResource(swapStatus, async () => {
+        const emptyPrevSwapStatus =
+            prevSwapStatus.value === undefined ||
+            prevSwapStatus.value === null ||
+            prevSwapStatus.value === "";
+
         const isInitialSwapState =
-            (swapStatus() === swapStatusPending.SwapCreated &&
-                prevSwapStatus.value === "") ||
-            (swapStatus() === swapStatusPending.InvoiceSet &&
-                prevSwapStatus.value === "");
+            emptyPrevSwapStatus &&
+            (swapStatus() === swapStatusPending.SwapCreated ||
+                swapStatus() === swapStatusPending.InvoiceSet);
 
         // No need to fetch UTXO data for a swap just created
         if (isInitialSwapState) {

--- a/src/pages/Pay.tsx
+++ b/src/pages/Pay.tsx
@@ -105,8 +105,8 @@ const Pay = () => {
             (swapStatus() === swapStatusPending.SwapCreated ||
                 swapStatus() === swapStatusPending.InvoiceSet);
 
-        // No need to fetch UTXO data for a swap just created
-        if (isInitialSwapState) {
+        // No need to fetch UTXO data for a reverse swap or a swap just created
+        if (isInitialSwapState || swap().type === SwapType.Reverse) {
             return;
         }
 


### PR DESCRIPTION
If swap was just created or is a reverse swap, there is no need to attempt to fetch UTXOs or lockup tx.

<img width="1280" height="738" alt="image" src="https://github.com/user-attachments/assets/e01ef0f0-e364-4705-a85e-9dc235e40ef0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Optimized Pay screen to skip unnecessary background checks during initial and reverse swaps, reducing load times and improving responsiveness.
- Tests
  - Added scenarios to verify no UTXO lookups occur during early swap states across swap types, strengthening reliability and preventing regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->