### PR TITLE
fix: missing timeout block heights for uncooperative refunds

### DIFF
--- a/src/pages/RefundRescue.tsx
+++ b/src/pages/RefundRescue.tsx
@@ -50,6 +50,7 @@ export const mapSwap = (
                 address: swap.refundDetails.lockupAddress,
                 refundPrivateKeyIndex: swap.refundDetails.keyIndex,
                 claimPublicKey: swap.refundDetails.serverPublicKey,
+                timeoutBlockHeight: swap.refundDetails.timeoutBlockHeight,
             };
         case SwapType.Chain:
             return {
@@ -61,6 +62,7 @@ export const mapSwap = (
                 refundPrivateKeyIndex: swap.refundDetails.keyIndex,
                 claimPublicKey: swap.claimDetails.serverPublicKey,
                 claimPrivateKeyIndex: swap.claimDetails.keyIndex,
+                timeoutBlockHeight: swap.refundDetails.timeoutBlockHeight,
                 lockupDetails: {
                     ...swap.refundDetails,
                     swapTree: swap.refundDetails.tree,
@@ -73,6 +75,7 @@ export const mapSwap = (
                 assetReceive: swap.to,
                 version: OutputType.Taproot,
                 address: swap.claimDetails.lockupAddress,
+                timeoutBlockHeight: swap.claimDetails.timeoutBlockHeight,
                 claimPublicKey: swap.claimDetails.serverPublicKey,
                 claimPrivateKeyIndex: swap.claimDetails.keyIndex,
                 sendAmount: swap.claimDetails.amount,


### PR DESCRIPTION
EDIT: closes https://github.com/BoltzExchange/boltz-web-app/issues/1012

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Swap details now include a timeout block height across all swap types (Submarine, Chain, Reverse), improving visibility into refund/claim timing. Users can see the exact block height at which a swap can be refunded or expires, aiding monitoring and planning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->