### PR TITLE
chore: pretty print logs

### DIFF
--- a/src/components/settings/Logs.tsx
+++ b/src/components/settings/Logs.tsx
@@ -22,12 +22,12 @@ const Logs = () => {
     const copy = async (evt: MouseEvent) => {
         evt.stopPropagation();
         const logs = await getLogs();
-        clipboard(JSON.stringify(logs));
+        clipboard(JSON.stringify(logs, null, 2));
     };
 
     const download = async (evt: MouseEvent) => {
         evt.stopPropagation();
-        downloadJson("boltz-logs", await getLogs());
+        downloadJson("boltz-logs", await getLogs(), true);
     };
 
     return (

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -16,11 +16,12 @@ export const download = (file: string, content: string) => {
 export const downloadJson = <T>(
     file: string,
     content: T extends Promise<T> ? never : T,
+    pretty: boolean = false,
 ) => {
     download(
         `${file}.json`,
         `data:application/json;charset=utf-8,${encodeURI(
-            JSON.stringify(content),
+            JSON.stringify(content, null, pretty ? 2 : 0),
         )}`,
     );
 };


### PR DESCRIPTION
Makes reading them possible without running them through a formatter first

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Copying logs now places human-readable, formatted JSON in your clipboard for easier review and sharing.
  - Downloaded logs can be saved as neatly formatted JSON, improving readability in editors and diffs.
- Improvements
  - Enhanced log export options provide clearer structure and indentation, making large log files simpler to scan and troubleshoot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->