### PR TITLE
fix: Trezor's tx value's NaN

### DIFF
--- a/src/utils/hardware/TrezorSigner.ts
+++ b/src/utils/hardware/TrezorSigner.ts
@@ -114,7 +114,7 @@ class TrezorSigner implements EIP1193Provider, HardwareSigner {
                     nonce: nonce.toString(16),
                     chainId: Number(network.chainId),
                     gasPrice: feeData.gasPrice.toString(16),
-                    value: value.toString(16),
+                    value: "0x" + value.toString(16),
                     gasLimit: (txParams as unknown as { gas: number }).gas,
                 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction signing issues with Trezor hardware wallets by properly hex-prefixing the transaction value. This improves compatibility with Trezor Connect and prevents “invalid value” errors during signing.
  * No changes to gas, nonce, or final on-chain amounts; this is a formatting correction to ensure successful signing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->