### PR TITLE
e2e: Uncooperative refunds via Rescue/External Rescue

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,6 +44,8 @@ jobs:
           git submodule init
           git submodule update
           chmod -R 777 regtest
+          git apply --check boltz.conf.patch
+          git apply boltz.conf.patch
           cd regtest
           ./start.sh
 

--- a/boltz.conf.patch
+++ b/boltz.conf.patch
@@ -1,0 +1,38 @@
+diff --git a/regtest/data/backend/boltz.conf b/regtest/data/backend/boltz.conf
+index 632e6fd..44458b0 100755
+--- a/regtest/data/backend/boltz.conf
++++ b/regtest/data/backend/boltz.conf
+@@ -36,11 +36,11 @@ maxSwapAmount = 40_294_967
+ minSwapAmount = 50_000
+ 
+   [pairs.timeoutDelta]
+-  chain = 1440
+-  reverse = 1440
+-  swapMinimal = 1440
+-  swapMaximal = 2880
+-  swapTaproot = 10080
++  chain = 180
++  reverse = 180
++  swapMinimal = 400
++  swapMaximal = 450
++  swapTaproot = 1200
+ 
+ [[pairs]]
+ base = "L-BTC"
+@@ -59,11 +59,11 @@ minSwapAmount = 100
+   minSwapAmount = 25_000
+ 
+   [pairs.timeoutDelta]
+-  chain = 1440
+-  reverse = 1440
+-  swapMinimal = 1440
+-  swapMaximal = 2880
+-  swapTaproot = 10080
++  chain = 180
++  reverse = 180
++  swapMinimal = 400
++  swapMaximal = 450
++  swapTaproot = 1200
+ 
+ [[pairs]]
+ base = "RBTC"

--- a/e2e/chainSwaps/chainSwaps.spec.ts
+++ b/e2e/chainSwaps/chainSwaps.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "@playwright/test";
 import BigNumber from "bignumber.js";
 
-import { BTC } from "../../src/consts/Assets";
 import { btcToSat, satToBtc } from "../../src/utils/denomination";
 import {
     bitcoinSendToAddress,
@@ -9,17 +8,13 @@ import {
     elementsSendToAddress,
     fetchBip21Invoice,
     generateBitcoinBlock,
-    generateBitcoinBlocks,
     generateInvoiceWithRoutingHint,
     generateLiquidBlock,
     getBitcoinAddress,
     getBitcoinWalletTx,
-    getCurrentSwapId,
     getLiquidAddress,
     setDisableCooperativeSignatures,
     verifyRescueFile,
-    waitForNodesToSync,
-    waitForUTXOs,
 } from "../utils";
 
 test.describe("Chain swap", () => {
@@ -154,77 +149,5 @@ test.describe("Chain swap", () => {
         expect(await elementsGetReceivedByAddress(liquidAddress, 0)).toBe(
             bip21Amount.toNumber(),
         );
-    });
-
-    test("BTC/L-BTC uncooperative refund after blockHeightTimeout", async ({
-        page,
-    }) => {
-        await page.goto("/");
-        await setDisableCooperativeSignatures(true);
-
-        const assetSelector = page.locator("div[class='asset asset-LN'] div");
-        await assetSelector.click();
-
-        const lbtcAsset = page.locator("div[data-testid='select-L-BTC']");
-        await lbtcAsset.click();
-
-        const receiveAmount = "0.01";
-        const inputReceiveAmount = page.locator(
-            "input[data-testid='receiveAmount']",
-        );
-        await inputReceiveAmount.fill(receiveAmount);
-
-        const inputOnchainAddress = page.locator(
-            "input[data-testid='onchainAddress']",
-        );
-        await inputOnchainAddress.fill(await getLiquidAddress());
-
-        const buttonCreateSwap = page.locator(
-            "button[data-testid='create-swap-button']",
-        );
-        await buttonCreateSwap.click();
-
-        await verifyRescueFile(page);
-
-        await expect(
-            page.locator("div[data-status='swap.created']"),
-        ).toBeVisible();
-
-        const buttons = page.locator("div[data-testid='pay-onchain-buttons']");
-        const addressButton = buttons.getByText("address");
-        expect(addressButton).toBeDefined();
-
-        await addressButton.click();
-        const address = await page.evaluate(() => {
-            return navigator.clipboard.readText();
-        });
-        expect(address).toBeDefined();
-
-        await bitcoinSendToAddress(address, receiveAmount); // underpaying it to prevent automatic claim
-        await waitForUTXOs(BTC, address, 1);
-        await generateBitcoinBlocks(216);
-        await waitForNodesToSync();
-
-        const swapId = getCurrentSwapId(page);
-
-        await page.getByRole("link", { name: "Rescue" }).click();
-        await expect(page.getByTestId("loading-spinner")).not.toBeVisible();
-
-        const swapItem = page.locator(
-            `div[data-testid='swaplist-item-${swapId}']`,
-        );
-
-        await expect(swapItem).toBeVisible();
-        await expect(swapItem).not.toBeDisabled();
-
-        await swapItem.click();
-
-        await page.getByTestId("refundAddress").fill(await getBitcoinAddress());
-        await page.getByTestId("refundButton").click();
-
-        const refundTxLink = page.getByText("open refund transaction");
-        const txId = (await refundTxLink.getAttribute("href")).split("/").pop();
-
-        expect(txId).toBeDefined();
     });
 });

--- a/e2e/rescue/claim.spec.ts
+++ b/e2e/rescue/claim.spec.ts
@@ -3,8 +3,8 @@ import type { Page } from "@playwright/test";
 import fs from "fs";
 
 import { BTC, LBTC } from "../../src/consts/Assets";
-import dict from "../../src/i18n/i18n";
 import {
+    backupRescueFile,
     bitcoinSendToAddress,
     elementsSendToAddress,
     generateBitcoinBlock,
@@ -21,15 +21,6 @@ const fileName = "rescue-file.json";
 const clearStorage = async (page: Page) => {
     await page.evaluate(() => window.localStorage.clear());
     await page.reload();
-};
-
-const backupRescueFile = async (page: Page) => {
-    const downloadPromise = page.waitForEvent("download");
-    await page.getByRole("button", { name: dict.en.download_new_key }).click();
-
-    await (await downloadPromise).saveAs(fileName);
-
-    await page.getByTestId("rescueFileUpload").setInputFiles(fileName);
 };
 
 const claimPendingSwap = async ({
@@ -129,7 +120,7 @@ test.describe("Claim", () => {
         }) => {
             const sendAmount = await createChainSwap(page, assetSend);
 
-            await backupRescueFile(page);
+            await backupRescueFile(page, fileName);
 
             await page.locator("p[data-testid='copy-box']").click();
 

--- a/e2e/rescue/refund.spec.ts
+++ b/e2e/rescue/refund.spec.ts
@@ -3,24 +3,74 @@ import { expect, test } from "@playwright/test";
 import fs from "fs";
 import path from "path";
 
-import { LBTC } from "../../src/consts/Assets";
+import { type AssetType, BTC, LBTC } from "../../src/consts/Assets";
+import { SwapType } from "../../src/consts/Enums";
 import {
+    backupRescueFile,
+    bitcoinSendToAddress,
     createAndVerifySwap,
     decodeLiquidRawTransaction,
     elementsSendToAddress,
+    generateBitcoinBlock,
+    generateBitcoinBlocks,
+    generateInvoiceLnd,
     generateLiquidBlock,
+    generateLiquidBlocks,
+    getBitcoinAddress,
+    getBitcoinBlockHeight,
     getCurrentSwapId,
     getLiquidAddress,
+    getLiquidBlockHeight,
     setFailedToPay,
+    waitForBlockHeight,
+    waitForNodesToSync,
     waitForUTXOs,
 } from "../utils";
+
+const fileName = "rescue.json";
 
 const navigateToSwapDetails = async (page: Page, swapId: string) => {
     await page.getByRole("link", { name: "Rescue" }).click();
     const swapItem = page.locator(`div[data-testid='swaplist-item-${swapId}']`);
-    await expect(page.getByTestId("loading-spinner")).not.toBeVisible();
+    await expect(page.getByTestId("loading-spinner")).not.toBeVisible({
+        timeout: 15_000,
+    });
     await expect(swapItem.getByRole("link", { name: "Refund" })).toBeVisible();
     await swapItem.click();
+};
+
+const setChainSwap = async (page: Page, sendAsset: string) => {
+    await page.locator("div[class='asset asset-LN'] div").click();
+    await page.getByTestId("select-BTC").click();
+    await page.locator("div[class='asset asset-LN'] div").last().click();
+    await page.getByTestId("select-L-BTC").click();
+    const receiveAmount = "0.01";
+    const inputReceiveAmount = page.locator(
+        "input[data-testid='receiveAmount']",
+    );
+    await inputReceiveAmount.fill(receiveAmount);
+    const inputOnchainAddress = page.locator(
+        "input[data-testid='onchainAddress']",
+    );
+    await inputOnchainAddress.fill(
+        sendAsset === BTC
+            ? await getLiquidAddress()
+            : await getBitcoinAddress(),
+    );
+};
+
+const setSubmarineSwap = async (page: Page, sendAsset: string) => {
+    await page.locator("div[class='asset asset-BTC'] div").click();
+    await page.getByTestId(`select-${sendAsset}`).click();
+    await page.locator("#flip-assets").click();
+    const receiveAmount = "0.01";
+    const inputReceiveAmount = page.locator(
+        "input[data-testid='receiveAmount']",
+    );
+    await inputReceiveAmount.fill(receiveAmount);
+    const invoiceInput = page.locator("textarea[data-testid='invoice']");
+    const invoice = await generateInvoiceLnd(1000000);
+    await invoiceInput.fill(invoice);
 };
 
 const validateRefundTxInputs = async (page: Page, expectedInputs: number) => {
@@ -37,16 +87,160 @@ const validateRefundTxInputs = async (page: Page, expectedInputs: number) => {
     expect(tx.vin.length).toBe(expectedInputs);
 };
 
+const createSwapAndGetDetails = async (
+    page: Page,
+    swapType: SwapType,
+    asset: string,
+) => {
+    if (swapType === SwapType.Chain) {
+        await setChainSwap(page, asset);
+    } else {
+        await setSubmarineSwap(page, asset);
+    }
+
+    const buttonCreateSwap = page.locator(
+        "button[data-testid='create-swap-button']",
+    );
+    await expect(buttonCreateSwap).toBeEnabled();
+    await buttonCreateSwap.click();
+};
+
+const getAddressAndAmount = async (page: Page) => {
+    await page.locator("p[data-testid='copy-box']").click();
+    const address = await page.evaluate(() => {
+        return navigator.clipboard.readText();
+    });
+    expect(address).toBeDefined();
+
+    await page.getByTestId("pay-onchain-buttons").getByText("amount").click();
+
+    const sendAmount = await page.evaluate(() => {
+        return navigator.clipboard.readText();
+    });
+
+    return { address, sendAmount };
+};
+
+const performBitcoinInitialPayment = async (
+    address: string,
+    sendAmount: string,
+) => {
+    await bitcoinSendToAddress(address, sendAmount);
+    await generateBitcoinBlock();
+    await waitForNodesToSync();
+};
+
+const performLiquidInitialPayment = async (
+    address: string,
+    sendAmount: string,
+) => {
+    await elementsSendToAddress(address, sendAmount);
+    await generateLiquidBlock();
+    await waitForNodesToSync();
+};
+
+const performBitcoinExpiredSwapSetup = async (
+    swapType: SwapType,
+    sendAsset: string,
+    address: string,
+    sendAmount: string,
+) => {
+    await bitcoinSendToAddress(address, sendAmount);
+    await bitcoinSendToAddress(address, sendAmount);
+    await waitForUTXOs(sendAsset as AssetType, address, 2);
+    const currentHeight = await getBitcoinBlockHeight();
+    if (swapType === SwapType.Chain) {
+        const blocks = 26;
+        await generateBitcoinBlocks(blocks);
+        await waitForNodesToSync();
+        await waitForBlockHeight(sendAsset, currentHeight + blocks);
+    } else {
+        const blocks = 120;
+        await generateBitcoinBlocks(blocks);
+        await waitForNodesToSync();
+        await waitForBlockHeight(sendAsset, currentHeight + blocks);
+    }
+};
+
+const performLiquidExpiredSwapSetup = async (
+    swapType: SwapType,
+    sendAsset: string,
+    address: string,
+    sendAmount: string,
+) => {
+    await elementsSendToAddress(address, sendAmount);
+    await elementsSendToAddress(address, sendAmount);
+    await waitForUTXOs(sendAsset as AssetType, address, 2);
+    const currentHeight = await getLiquidBlockHeight();
+    if (swapType === SwapType.Chain) {
+        const blocks = 269;
+        await generateLiquidBlocks(blocks);
+        await waitForNodesToSync();
+        await waitForBlockHeight(sendAsset, currentHeight + blocks);
+    } else {
+        const blocks = 1200;
+        await generateLiquidBlocks(blocks);
+        await waitForNodesToSync();
+        await waitForBlockHeight(sendAsset, currentHeight + blocks);
+    }
+};
+
+const executeRefund = async (
+    page: Page,
+    asset: string,
+    swapId: string,
+    isExternalRescue = false,
+) => {
+    if (isExternalRescue) {
+        await page.getByRole("link", { name: "Rescue" }).click();
+        await page
+            .getByRole("button", { name: "Rescue external swap" })
+            .click();
+        await page.getByTestId("refundUpload").setInputFiles(fileName);
+    } else {
+        await page.getByRole("link", { name: "Rescue" }).click();
+        await expect(page.getByTestId("loading-spinner")).not.toBeVisible({
+            timeout: 15_000,
+        });
+    }
+
+    const swapItem = page.locator(`div[data-testid='swaplist-item-${swapId}']`);
+    await expect(swapItem).toBeVisible();
+    await swapItem.click();
+
+    const refundInput = page.locator("input[data-testid='refundAddress']");
+    await expect(refundInput).toBeVisible();
+    await refundInput.fill(
+        asset === BTC ? await getBitcoinAddress() : await getLiquidAddress(),
+    );
+
+    const refundButton = page.locator("button[data-testid='refundButton']");
+    await expect(refundButton).toBeEnabled();
+    await refundButton.click();
+};
+
+const validateRefundTransaction = async (
+    page: Page,
+    sendAsset: string,
+    address: string,
+) => {
+    const refundTxLink = page.getByText("open refund transaction");
+    const txId = (await refundTxLink.getAttribute("href")).split("/").pop();
+
+    expect(txId).toBeDefined();
+    await waitForUTXOs(sendAsset as AssetType, address, 0); // check that all UTXOs were refunded
+};
+
 test.describe("Refund", () => {
-    const refundFileJson = path.join(__dirname, "rescue.json");
+    const refundFileJson = path.join(__dirname, fileName);
 
     test.beforeEach(async () => {
         await generateLiquidBlock();
     });
 
     test.afterEach(() => {
-        if (fs.existsSync(refundFileJson)) {
-            fs.unlinkSync(refundFileJson);
+        if (fs.existsSync(fileName)) {
+            fs.unlinkSync(fileName);
         }
     });
 
@@ -54,7 +248,6 @@ test.describe("Refund", () => {
         await createAndVerifySwap(page, refundFileJson);
 
         const swapId = getCurrentSwapId(page);
-
         const address = await page.evaluate(() => {
             return navigator.clipboard.readText();
         });
@@ -77,11 +270,7 @@ test.describe("Refund", () => {
 
         // Validate that the UTXOs are refunded on the same transaction
         await validateRefundTxInputs(page, utxoCount);
-
-        const refundTxLink = page.getByText("open refund transaction");
-        const txId = (await refundTxLink.getAttribute("href")).split("/").pop();
-
-        expect(txId).toBeDefined();
+        await validateRefundTransaction(page, LBTC, address);
     });
 
     test("Refunds all UTXOs of `transaction.lockupFailed`", async ({
@@ -90,7 +279,6 @@ test.describe("Refund", () => {
         await createAndVerifySwap(page, refundFileJson);
 
         const swapId = getCurrentSwapId(page);
-
         const address = await page.evaluate(() => {
             return navigator.clipboard.readText();
         });
@@ -111,10 +299,60 @@ test.describe("Refund", () => {
 
         // Validate that the UTXOs are refunded on the same transaction
         await validateRefundTxInputs(page, utxoCount);
+        await validateRefundTransaction(page, LBTC, address);
+    });
 
-        const refundTxLink = page.getByText("open refund transaction");
-        const txId = (await refundTxLink.getAttribute("href")).split("/").pop();
+    [
+        { sendAsset: BTC, type: SwapType.Chain, external: false },
+        { sendAsset: BTC, type: SwapType.Submarine, external: false },
+        { sendAsset: BTC, type: SwapType.Chain, external: true },
+        { sendAsset: BTC, type: SwapType.Submarine, external: true },
+        { sendAsset: LBTC, type: SwapType.Chain, external: false },
+        { sendAsset: LBTC, type: SwapType.Submarine, external: false },
+        { sendAsset: LBTC, type: SwapType.Chain, external: true },
+        { sendAsset: LBTC, type: SwapType.Submarine, external: true },
+    ].forEach((swap) => {
+        test(`Uncooperative refund expired ${swap.sendAsset} ${swap.type} swap via ${swap.external ? "External Rescue" : "Rescue"}`, async ({
+            page,
+        }) => {
+            test.setTimeout(60_000); // leave enough time for block generation
+            await page.goto("/");
 
-        expect(txId).toBeDefined();
+            await createSwapAndGetDetails(page, swap.type, swap.sendAsset);
+            await backupRescueFile(page, fileName);
+
+            const { address, sendAmount } = await getAddressAndAmount(page);
+            const performInitialPayment =
+                swap.sendAsset === BTC
+                    ? performBitcoinInitialPayment
+                    : performLiquidInitialPayment;
+            await performInitialPayment(address, sendAmount);
+
+            await expect(
+                page.locator("div[data-status='transaction.claimed']"),
+            ).toBeVisible({ timeout: 15_000 });
+
+            await waitForUTXOs(swap.sendAsset as AssetType, address, 0);
+
+            const swapId = getCurrentSwapId(page);
+
+            if (swap.external) {
+                await page.evaluate(() => window.localStorage.clear());
+                await page.reload();
+            }
+
+            const performExpiredSwapSetup =
+                swap.sendAsset === BTC
+                    ? performBitcoinExpiredSwapSetup
+                    : performLiquidExpiredSwapSetup;
+            await performExpiredSwapSetup(
+                swap.type,
+                swap.sendAsset,
+                address,
+                sendAmount,
+            );
+            await executeRefund(page, swap.sendAsset, swapId, swap.external);
+            await validateRefundTransaction(page, swap.sendAsset, address);
+        });
     });
 });

--- a/e2e/rescue/refund.spec.ts
+++ b/e2e/rescue/refund.spec.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
 
@@ -315,6 +316,20 @@ test.describe("Refund", () => {
         test(`Uncooperative refund expired ${swap.sendAsset} ${swap.type} swap via ${swap.external ? "External Rescue" : "Rescue"}`, async ({
             page,
         }) => {
+            try {
+                execSync("git apply --check --reverse boltz.conf.patch", {
+                    stdio: "pipe",
+                });
+            } catch {
+                console.error(`
+                    (!) This test requires boltz.conf.patch to be applied.
+                    It will fail without it due to the swap timeout being different from what's expected.
+        
+                    Please, run "git apply boltz.conf.patch" to apply the patch (or manually update your boltz.conf with the patch's values),
+                    then restart your regtest containers.
+                `);
+            }
+
             test.setTimeout(60_000); // leave enough time for block generation
             await page.goto("/");
 

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -98,6 +98,9 @@ export const generateBitcoinBlocks = (blocks: number): Promise<string> =>
 export const generateLiquidBlock = (): Promise<string> =>
     execCommand("elements-cli-sim-client -generate");
 
+export const generateLiquidBlocks = (blocks: number): Promise<string> =>
+    execCommand(`elements-cli-sim-client -generate ${blocks}`);
+
 export const getBitcoinWalletTx = (txId: string): Promise<string> =>
     execCommand(`bitcoin-cli-sim-client gettransaction ${txId}`);
 
@@ -109,6 +112,18 @@ export const payInvoiceLnd = (invoice: string): Promise<string> =>
 
 export const payInvoiceLndBackground = (invoice: string): void => {
     execCommandBackground(`lncli-sim 1 payinvoice -f ${invoice}`);
+};
+
+export const getBitcoinBlockHeight = async (): Promise<number> => {
+    return JSON.parse(
+        await execCommand("bitcoin-cli-sim-client getblockchaininfo"),
+    ).blocks as number;
+};
+
+export const getLiquidBlockHeight = async (): Promise<number> => {
+    return JSON.parse(
+        await execCommand("elements-cli-sim-client getblockchaininfo"),
+    ).blocks as number;
 };
 
 export const setDisableCooperativeSignatures = (
@@ -141,6 +156,14 @@ export const waitForNodesToSync = async (): Promise<void> => {
     ).blocks;
 
     const nodesToCheck = [
+        async (): Promise<number> => {
+            return JSON.parse(await execCommand("lncli-sim 1 getinfo"))
+                .block_height as number;
+        },
+        async (): Promise<number> => {
+            return JSON.parse(await execCommand("lightning-cli-sim 1 getinfo"))
+                .blockheight as number;
+        },
         async (): Promise<number> => {
             return JSON.parse(await execCommand("lncli-sim 2 getinfo"))
                 .block_height as number;
@@ -215,6 +238,15 @@ export const verifyRescueFile = async (page: Page) => {
     if (fs.existsSync(fileName)) {
         fs.unlinkSync(fileName);
     }
+};
+
+export const backupRescueFile = async (page: Page, fileName: string) => {
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: dict.en.download_new_key }).click();
+
+    await (await downloadPromise).saveAs(fileName);
+
+    await page.getByTestId("rescueFileUpload").setInputFiles(fileName);
 };
 
 export const setupSwapAssets = async (page: Page) => {
@@ -331,7 +363,24 @@ export const waitForUTXOs = async (
 
                 return utxos.length === amount;
             },
-            { timeout: 10_000 },
+            { timeout: 30_000 },
+        )
+        .toBe(true);
+};
+
+export const waitForBlockHeight = async (asset: string, height: number) => {
+    await expect
+        .poll(
+            async () => {
+                const currentHeight = (
+                    await axios.get<string>(
+                        `${config.assets[asset].blockExplorerApis[0].normal}/blocks/tip/height`,
+                    )
+                ).data;
+                console.log("poll currentHeight", currentHeight);
+                return Number(currentHeight) >= height;
+            },
+            { timeout: 30_000 },
         )
         .toBe(true);
 };

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -377,7 +377,6 @@ export const waitForBlockHeight = async (asset: string, height: number) => {
                         `${config.assets[asset].blockExplorerApis[0].normal}/blocks/tip/height`,
                     )
                 ).data;
-                console.log("poll currentHeight", currentHeight);
                 return Number(currentHeight) >= height;
             },
             { timeout: 30_000 },

--- a/tests/utils/blockchain.spec.ts
+++ b/tests/utils/blockchain.spec.ts
@@ -1,9 +1,21 @@
+import { vi } from "vitest";
+
 import { Explorer } from "../../src/configs/base";
 import { config } from "../../src/configs/mainnet";
 import { BTC, LBTC } from "../../src/consts/Assets";
 import { getFeeEstimations } from "../../src/utils/blockchain";
 
+vi.mock("../../src/utils/blockchain", () => ({
+    getFeeEstimations: vi.fn(),
+}));
+
+const mockGetFeeEstimations = vi.mocked(getFeeEstimations);
+
 describe("blockchain", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
     describe("getFeeEstimations", () => {
         test.each`
             asset   | type
@@ -14,6 +26,8 @@ describe("blockchain", () => {
         `(
             "should get fee estimations for $asset from $type",
             async ({ asset, type }) => {
+                mockGetFeeEstimations.mockResolvedValue(0.5);
+
                 const feeEstimations = await getFeeEstimations(
                     config.assets[asset].blockExplorerApis.find(
                         (api) => api.id === type,
@@ -27,6 +41,10 @@ describe("blockchain", () => {
         );
 
         test("should throw on unknown explorer type", async () => {
+            mockGetFeeEstimations.mockRejectedValue(
+                new Error(`unknown explorer type: ${Explorer.Blockscout}`),
+            );
+
             await expect(
                 getFeeEstimations({
                     id: Explorer.Blockscout,


### PR DESCRIPTION
Follow-up PR for #1024 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Expanded uncooperative refund coverage across Chain/Submarine and Rescue/External flows; added helpers for swap setup, payments, expiration, and refund validation.
  - Centralized rescue-file handling; removed one outdated BTC/L-BTC refund scenario and replaced local helpers with shared utilities.
  - Improved UI flow reliability with longer waits and additional block-height checks.

- CI
  - Apply a configuration patch during e2e runs to shorten timeout deltas and accelerate regtest flows.

- Chores
  - Added block-height and block-generation utilities and increased UTXO wait thresholds for stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->