### PR TITLE
chore: improve i18n pt translations

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1096,8 +1096,8 @@ const dict = {
             "Informe um endereço para receber seu reembolso:",
         refund_backup: "Backup",
         refund_import: "Importar backup",
-        refund_clear: "Excluir armazenamento",
-        delete_swap: "Excluir troca do armazenamento",
+        refund_clear: "Apagar armazenamento",
+        delete_swap: "Apagar troca do armazenamento",
         delete_storage:
             "Tem certeza de que deseja limpar seu armazenamento?\nAs informações das suas trocas e as chaves privadas de reembolso/recebimento serão perdidas.",
         delete_storage_single_swap:
@@ -1153,14 +1153,14 @@ const dict = {
         warning_expiry:
             "Certifique-se de que sua transação seja confirmada em até 24h após a criação da troca!",
         not_found: "404 - Página não encontrada",
-        not_found_subline: "A página que procuras não existe.",
+        not_found_subline: "A página solicitada não existe.",
         back_to_home: "Voltar à página inicial",
         transaction_prompt:
             'Pressione "{{ button }}" para abrir sua carteira conectada e confirmar a transação exibida.',
         transaction_prompt_receive:
             'Pressione "{{ button }}" para abrir sua carteira conectada e confirmar a transação para receber {{ asset }}.',
         invalid_address: "Endereço {{ asset }} inválido",
-        scan_qr_code: "Escanear QR Code",
+        scan_qr_code: "Ler QR Code",
         version: "Versão",
         commithash: "Hash do Commit",
         open_in_wallet: "Abrir na carteira",
@@ -1248,8 +1248,7 @@ const dict = {
             "Esta nova chave funciona em qualquer dispositivo e funciona para todas as trocas criadas com ela.",
         backup_boltz_rescue_key_subline_third:
             "Por favor, escreva ou copie esta chave e armazene-a em um local seguro e permanente.",
-        backup_boltz_rescue_key_reminder:
-            "Guarde com segurança. Não compartilhe.",
+        backup_boltz_rescue_key_reminder: "Guarde com segurança. Não partilhe.",
         copy_rescue_key: "Copiar chave de resgate",
         user_saved_key: "Eu guardei a chave de resgate",
         verify_mnemonic_word: {
@@ -1277,9 +1276,9 @@ const dict = {
             telegram_bot: "Bot do Telegram",
         },
         refresh_for_refund:
-            "Se enviou Bitcoin para esta troca, recarregue a página para verificar se existe um reembolso.",
+            "Se enviou Bitcoin para esta troca, atualize a página para verificar se existe um reembolso.",
         applied_routing_hint:
-            "O teu destinatário suporta a receção direta de {{ asset }}. Assim, poupas em taxas e ele continua a receber o valor total.",
+            "O seu destinatário suporta o recebimento direto de {{ asset }}. Assim, você poupa em taxas e ele continua a receber o valor total.",
         optimized_route_amount:
             "Rota de troca otimizada, poupando-te ~{{ amount }} {{ denomination }}",
         claim_address_prompt: "Digite um endereço para reivindicar a troca:",
@@ -1292,9 +1291,9 @@ const dict = {
         failed_get_swap_subline:
             "Por favor, re-insira a chave de resgate e tente novamente.",
         in_progress: "Em curso",
-        completed: "Completado",
+        completed: "Finalizada",
         get_refundable_error:
-            "Não foi possível carregar os dados de UTXO. Recarregue a página para voltar a tentar ou verifique sua conexão com a Internet se o problema persistir.",
+            "Não foi possível carregar os dados de UTXO. Atualize a página para voltar a tentar ou verifique sua conexão com a Internet se o problema persistir.",
         min_amount_destination:
             "O valor mínimo para o endereço de destino é {{ amount }} {{ denomination }}",
         max_amount_destination:


### PR DESCRIPTION
Just some nitpicking adjustments 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Localization
  - Updated translations across all supported languages for 404 messaging, QR scan prompts, refund actions, completion status, and rescue-key reminders to improve clarity and consistency.
  - Standardized "Refresh/Reload" wording in refund-related prompts across locales.
  - Harmonized terminology for branding, testnet references, and common UI labels.
  - Removed obsolete "View Lightning Nodes" text from all locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->