### PR TITLE
feat: add ISO 8601 timestamp to log entries

### DIFF
--- a/src/utils/logs.ts
+++ b/src/utils/logs.ts
@@ -42,20 +42,24 @@ export const deleteOldLogs = async (logsForage: LocalForage) => {
     });
 };
 
-export const formatLogLine = (message: unknown[]) =>
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string
-    message
-        .map((entry: unknown) => {
-            if (entry instanceof Error) {
-                return entry;
-            }
-            if (typeof entry === "object") {
-                return JSON.stringify(entry);
-            }
+export const formatLogLine = (message: unknown[]) => {
+    const timestamp = new Date().toISOString(); // ISO 8601 format with milliseconds (UTC)
+    const formattedMessage =
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
+        message
+            .map((entry: unknown) => {
+                if (entry instanceof Error) {
+                    return entry;
+                }
+                if (typeof entry === "object") {
+                    return JSON.stringify(entry);
+                }
 
-            return entry;
-        })
-        .join(" ");
+                return entry;
+            })
+            .join(" ");
+    return `${timestamp} ${formattedMessage}`;
+};
 
 export const injectLogWriter = (logsForage: LocalForage) => {
     const originalLogFactory = log.methodFactory;

--- a/tests/utils/logs.spec.ts
+++ b/tests/utils/logs.spec.ts
@@ -94,7 +94,10 @@ describe("logs", () => {
         ${["some", "strings"]}           | ${"some strings"}
         ${["some", { data: "objects" }]} | ${'some {"data":"objects"}'}
     `("should format log lines for storage", ({ line, expected }) => {
-        expect(formatLogLine(line)).toEqual(expected);
+        const fixedDate = new Date("2025-10-14T08:14:36.616Z");
+        vi.setSystemTime(fixedDate);
+        const timestamp = fixedDate.toISOString();
+        expect(formatLogLine(line)).toEqual(`${timestamp} ${expected}`);
     });
 
     test.each`
@@ -114,6 +117,8 @@ describe("logs", () => {
             log.setLevel("trace");
 
             const logMessage = "test message";
+            const fixedDate = new Date("2025-10-14T08:14:36.616Z");
+            vi.setSystemTime(fixedDate);
             log.debug(logMessage);
 
             await new Promise((resolve) => {
@@ -123,8 +128,9 @@ describe("logs", () => {
             expect(forage.getItem).toHaveBeenCalledTimes(1);
             expect(forage.getItem).toHaveBeenCalledWith(getDate());
             expect(forage.setItem).toHaveBeenCalledTimes(1);
+            const timestamp = fixedDate.toISOString();
             expect(forage.setItem).toHaveBeenCalledWith(getDate(), [
-                logMessage,
+                `${timestamp} ${logMessage}`,
             ]);
         },
     );
@@ -141,6 +147,8 @@ describe("logs", () => {
         log.setLevel("trace");
 
         const logMessage = "test message";
+        const fixedDate = new Date("2025-10-14T08:14:36.616Z");
+        vi.setSystemTime(fixedDate);
         log.debug(logMessage);
 
         await new Promise((resolve) => {
@@ -150,9 +158,10 @@ describe("logs", () => {
         expect(forage.getItem).toHaveBeenCalledTimes(1);
         expect(forage.getItem).toHaveBeenCalledWith(getDate());
         expect(forage.setItem).toHaveBeenCalledTimes(1);
+        const timestamp = fixedDate.toISOString();
         expect(forage.setItem).toHaveBeenCalledWith(getDate(), [
             ...existingLogs,
-            logMessage,
+            `${timestamp} ${logMessage}`,
         ]);
     });
 


### PR DESCRIPTION
Tested that it doesn't brick anyhting with existing logs:

```
{
  "2025/10/13": [
    "WalletConnect project id not set",
    "Chatwoot URL or token not set",
    "Hot reload",
    "Registration succeeded. Scope is https://localhost:5173/",
    "deleting logs of 2025/8/15",
    "Storage already on latest version: 1",
    "Opening WebSocket",
    "getpairs {\"chain\":{\"BTC\":{\"L-BTC\":{\"hash\":\"9affe2fcb34582f5ae788de379cc4f495dddd92912e11499badd4e85c2243ff4\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":25000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":329,\"user\":{\"claim\":23,\"lockup\":308}}}},\"RBTC\":{\"hash\":\"5871c1d15e8a8bdc9c4a7433abf24c9c40da5ea6fff0434b525bea43dbc1f7fb\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":25000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":423,\"user\":{\"claim\":64,\"lockup\":308}}}}},\"L-BTC\":{\"BTC\":{\"hash\":\"f263627d766fc7b465074c49182357704e1764a18bd687a4238a26250b786f7b\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":25000,\"maximalZeroConf\":500000},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":327,\"user\":{\"claim\":222,\"lockup\":27}}}},\"RBTC\":{\"hash\":\"8315f6ee8da47d7b3ed89a883b4b348f5ec1e4a330860d11c46b40af1a0b1be2\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500,\"maximalZeroConf\":500000},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":140,\"user\":{\"claim\":64,\"lockup\":27}}}}},\"RBTC\":{\"BTC\":{\"hash\":\"7d6ff9322be75e83e374f821c62364d9f4fa0a5eb034e56ee07f25d2461cd4eb\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":25000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":340,\"user\":{\"claim\":222,\"lockup\":121}}}},\"L-BTC\":{\"hash\":\"20c562563175d03aecc3e865a9fbf3727830e6eb36dc2d07e8689ab940f2d9ce\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":59,\"user\":{\"claim\":23,\"lockup\":121}}}}}},\"reverse\":{\"BTC\":{\"BTC\":{\"hash\":\"086a9250fd28cf2e181674ac3ef97302bae3c508a78db233607dde03e8ebf55b\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":25000},\"fees\":{\"percentage\":0.5,\"minerFees\":{\"claim\":222,\"lockup\":308}}},\"L-BTC\":{\"hash\":\"6717d041e27d8b728e7ac9bc6760c130ba7a8cc702c9afb3fabc289d364bba67\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":100},\"fees\":{\"percentage\":0.25,\"minerFees\":{\"claim\":23,\"lockup\":27}}},\"RBTC\":{\"hash\":\"e643fd55d01abefba58c08c662168547f955f706333043442cbeb73b0d5a2fe9\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500},\"fees\":{\"percentage\":0.25,\"minerFees\":{\"claim\":64,\"lockup\":121}}}}},\"submarine\":{\"BTC\":{\"BTC\":{\"hash\":\"52c2397e38d4d6f30ca5896ad32381b0bd0fce0507ef6fb2c6cd39517e043e43\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":1000000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":302,\"maximalRoutingFee\":0.3}}},\"L-BTC\":{\"BTC\":{\"hash\":\"58ef08a576993761ece14f846e4031fdfb838017a18351dd53eb1d6ea980257b\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":1000000,\"maximalZeroConf\":500000,\"minimalBatched\":21},\"fees\":{\"percentage\":0.1,\"minerFees\":19,\"maximalRoutingFee\":0.3}}},\"RBTC\":{\"BTC\":{\"hash\":\"58507b0ccecf7244cfb9a7486029003e64941221f85838a9e420f9e10d00fb16\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":32,\"maximalRoutingFee\":0.35}}}}}",
    "node stats {\"BTC\":{\"LND\":{\"capacity\":6910822894,\"channels\":591,\"peers\":739,\"oldestChannel\":1553900632},\"CLN\":{\"capacity\":2327267467,\"channels\":183,\"peers\":330,\"oldestChannel\":1692971171},\"total\":{\"capacity\":9238090361,\"channels\":774,\"peers\":1069,\"oldestChannel\":1553900632}}}",
    "WebSocket message: {\"event\":\"subscribe\",\"channel\":\"swap.update\",\"args\":[],\"timestamp\":\"1760359337818\"}",
    "WalletConnect project id not set",
    "getpairs {\"chain\":{\"BTC\":{\"L-BTC\":{\"hash\":\"9affe2fcb34582f5ae788de379cc4f495dddd92912e11499badd4e85c2243ff4\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":25000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":329,\"user\":{\"claim\":23,\"lockup\":308}}}},\"RBTC\":{\"hash\":\"5871c1d15e8a8bdc9c4a7433abf24c9c40da5ea6fff0434b525bea43dbc1f7fb\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":25000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":423,\"user\":{\"claim\":64,\"lockup\":308}}}}},\"L-BTC\":{\"BTC\":{\"hash\":\"f263627d766fc7b465074c49182357704e1764a18bd687a4238a26250b786f7b\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":25000,\"maximalZeroConf\":500000},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":327,\"user\":{\"claim\":222,\"lockup\":27}}}},\"RBTC\":{\"hash\":\"8315f6ee8da47d7b3ed89a883b4b348f5ec1e4a330860d11c46b40af1a0b1be2\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500,\"maximalZeroConf\":500000},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":140,\"user\":{\"claim\":64,\"lockup\":27}}}}},\"RBTC\":{\"BTC\":{\"hash\":\"7d6ff9322be75e83e374f821c62364d9f4fa0a5eb034e56ee07f25d2461cd4eb\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":25000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":340,\"user\":{\"claim\":222,\"lockup\":121}}}},\"L-BTC\":{\"hash\":\"20c562563175d03aecc3e865a9fbf3727830e6eb36dc2d07e8689ab940f2d9ce\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":59,\"user\":{\"claim\":23,\"lockup\":121}}}}}},\"reverse\":{\"BTC\":{\"BTC\":{\"hash\":\"086a9250fd28cf2e181674ac3ef97302bae3c508a78db233607dde03e8ebf55b\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":25000},\"fees\":{\"percentage\":0.5,\"minerFees\":{\"claim\":222,\"lockup\":308}}},\"L-BTC\":{\"hash\":\"6717d041e27d8b728e7ac9bc6760c130ba7a8cc702c9afb3fabc289d364bba67\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":100},\"fees\":{\"percentage\":0.25,\"minerFees\":{\"claim\":23,\"lockup\":27}}},\"RBTC\":{\"hash\":\"e643fd55d01abefba58c08c662168547f955f706333043442cbeb73b0d5a2fe9\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500},\"fees\":{\"percentage\":0.25,\"minerFees\":{\"claim\":64,\"lockup\":121}}}}},\"submarine\":{\"BTC\":{\"BTC\":{\"hash\":\"52c2397e38d4d6f30ca5896ad32381b0bd0fce0507ef6fb2c6cd39517e043e43\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":1000000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":302,\"maximalRoutingFee\":0.3}}},\"L-BTC\":{\"BTC\":{\"hash\":\"58ef08a576993761ece14f846e4031fdfb838017a18351dd53eb1d6ea980257b\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":1000000,\"maximalZeroConf\":500000,\"minimalBatched\":21},\"fees\":{\"percentage\":0.1,\"minerFees\":19,\"maximalRoutingFee\":0.3}}},\"RBTC\":{\"BTC\":{\"hash\":\"58507b0ccecf7244cfb9a7486029003e64941221f85838a9e420f9e10d00fb16\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":32,\"maximalRoutingFee\":0.35}}}}}",
    "getpairs {\"chain\":{\"BTC\":{\"L-BTC\":{\"hash\":\"9affe2fcb34582f5ae788de379cc4f495dddd92912e11499badd4e85c2243ff4\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":25000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":329,\"user\":{\"claim\":23,\"lockup\":308}}}},\"RBTC\":{\"hash\":\"5871c1d15e8a8bdc9c4a7433abf24c9c40da5ea6fff0434b525bea43dbc1f7fb\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":25000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":423,\"user\":{\"claim\":64,\"lockup\":308}}}}},\"L-BTC\":{\"BTC\":{\"hash\":\"f263627d766fc7b465074c49182357704e1764a18bd687a4238a26250b786f7b\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":25000,\"maximalZeroConf\":500000},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":327,\"user\":{\"claim\":222,\"lockup\":27}}}},\"RBTC\":{\"hash\":\"8315f6ee8da47d7b3ed89a883b4b348f5ec1e4a330860d11c46b40af1a0b1be2\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500,\"maximalZeroConf\":500000},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":140,\"user\":{\"claim\":64,\"lockup\":27}}}}},\"RBTC\":{\"BTC\":{\"hash\":\"7d6ff9322be75e83e374f821c62364d9f4fa0a5eb034e56ee07f25d2461cd4eb\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":25000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":340,\"user\":{\"claim\":222,\"lockup\":121}}}},\"L-BTC\":{\"hash\":\"20c562563175d03aecc3e865a9fbf3727830e6eb36dc2d07e8689ab940f2d9ce\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":59,\"user\":{\"claim\":23,\"lockup\":121}}}}}},\"reverse\":{\"BTC\":{\"BTC\":{\"hash\":\"086a9250fd28cf2e181674ac3ef97302bae3c508a78db233607dde03e8ebf55b\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":25000},\"fees\":{\"percentage\":0.5,\"minerFees\":{\"claim\":222,\"lockup\":308}}},\"L-BTC\":{\"hash\":\"6717d041e27d8b728e7ac9bc6760c130ba7a8cc702c9afb3fabc289d364bba67\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":100},\"fees\":{\"percentage\":0.25,\"minerFees\":{\"claim\":23,\"lockup\":27}}},\"RBTC\":{\"hash\":\"e643fd55d01abefba58c08c662168547f955f706333043442cbeb73b0d5a2fe9\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500},\"fees\":{\"percentage\":0.25,\"minerFees\":{\"claim\":64,\"lockup\":121}}}}},\"submarine\":{\"BTC\":{\"BTC\":{\"hash\":\"52c2397e38d4d6f30ca5896ad32381b0bd0fce0507ef6fb2c6cd39517e043e43\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":1000000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":302,\"maximalRoutingFee\":0.3}}},\"L-BTC\":{\"BTC\":{\"hash\":\"58ef08a576993761ece14f846e4031fdfb838017a18351dd53eb1d6ea980257b\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":1000000,\"maximalZeroConf\":500000,\"minimalBatched\":21},\"fees\":{\"percentage\":0.1,\"minerFees\":19,\"maximalRoutingFee\":0.3}}},\"RBTC\":{\"BTC\":{\"hash\":\"58507b0ccecf7244cfb9a7486029003e64941221f85838a9e420f9e10d00fb16\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":32,\"maximalRoutingFee\":0.35}}}}}",
    "Found highest index: 46"
  ],
  "2025/10/14": [
    "2025-10-14T08:14:36.616Z Chatwoot URL or token not set",
    "2025-10-14T08:14:36.823Z Hot reload",
    "2025-10-14T08:14:36.823Z Registration succeeded. Scope is https://localhost:5173/",
    "2025-10-14T08:14:36.824Z Storage already on latest version: 1",
    "2025-10-14T08:14:36.824Z Opening WebSocket",
    "2025-10-14T08:14:37.731Z node stats {\"BTC\":{\"LND\":{\"capacity\":6928822894,\"channels\":593,\"peers\":732,\"oldestChannel\":1553900632},\"CLN\":{\"capacity\":2328992698,\"channels\":184,\"peers\":342,\"oldestChannel\":1692971171},\"total\":{\"capacity\":9257815592,\"channels\":777,\"peers\":1074,\"oldestChannel\":1553900632}}}",
    "2025-10-14T08:14:37.777Z getpairs {\"chain\":{\"BTC\":{\"L-BTC\":{\"hash\":\"9affe2fcb34582f5ae788de379cc4f495dddd92912e11499badd4e85c2243ff4\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":25000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":329,\"user\":{\"claim\":23,\"lockup\":308}}}},\"RBTC\":{\"hash\":\"5871c1d15e8a8bdc9c4a7433abf24c9c40da5ea6fff0434b525bea43dbc1f7fb\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":25000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":423,\"user\":{\"claim\":64,\"lockup\":308}}}}},\"L-BTC\":{\"BTC\":{\"hash\":\"f263627d766fc7b465074c49182357704e1764a18bd687a4238a26250b786f7b\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":25000,\"maximalZeroConf\":500000},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":327,\"user\":{\"claim\":222,\"lockup\":27}}}},\"RBTC\":{\"hash\":\"8315f6ee8da47d7b3ed89a883b4b348f5ec1e4a330860d11c46b40af1a0b1be2\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500,\"maximalZeroConf\":500000},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":140,\"user\":{\"claim\":64,\"lockup\":27}}}}},\"RBTC\":{\"BTC\":{\"hash\":\"7d6ff9322be75e83e374f821c62364d9f4fa0a5eb034e56ee07f25d2461cd4eb\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":25000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":340,\"user\":{\"claim\":222,\"lockup\":121}}}},\"L-BTC\":{\"hash\":\"20c562563175d03aecc3e865a9fbf3727830e6eb36dc2d07e8689ab940f2d9ce\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":59,\"user\":{\"claim\":23,\"lockup\":121}}}}}},\"reverse\":{\"BTC\":{\"BTC\":{\"hash\":\"086a9250fd28cf2e181674ac3ef97302bae3c508a78db233607dde03e8ebf55b\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":25000},\"fees\":{\"percentage\":0.5,\"minerFees\":{\"claim\":222,\"lockup\":308}}},\"L-BTC\":{\"hash\":\"6717d041e27d8b728e7ac9bc6760c130ba7a8cc702c9afb3fabc289d364bba67\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":100},\"fees\":{\"percentage\":0.25,\"minerFees\":{\"claim\":23,\"lockup\":27}}},\"RBTC\":{\"hash\":\"e643fd55d01abefba58c08c662168547f955f706333043442cbeb73b0d5a2fe9\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500},\"fees\":{\"percentage\":0.25,\"minerFees\":{\"claim\":64,\"lockup\":121}}}}},\"submarine\":{\"BTC\":{\"BTC\":{\"hash\":\"52c2397e38d4d6f30ca5896ad32381b0bd0fce0507ef6fb2c6cd39517e043e43\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":1000000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":302,\"maximalRoutingFee\":0.3}}},\"L-BTC\":{\"BTC\":{\"hash\":\"58ef08a576993761ece14f846e4031fdfb838017a18351dd53eb1d6ea980257b\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":1000000,\"maximalZeroConf\":500000,\"minimalBatched\":21},\"fees\":{\"percentage\":0.1,\"minerFees\":19,\"maximalRoutingFee\":0.3}}},\"RBTC\":{\"BTC\":{\"hash\":\"58507b0ccecf7244cfb9a7486029003e64941221f85838a9e420f9e10d00fb16\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":32,\"maximalRoutingFee\":0.35}}}}}",
    "2025-10-14T08:14:38.463Z WebSocket message: {\"event\":\"subscribe\",\"channel\":\"swap.update\",\"args\":[\"gVcrZQhy92up\"],\"timestamp\":\"1760429678351\"}",
    "2025-10-14T08:14:38.548Z WebSocket message: {\"event\":\"update\",\"channel\":\"swap.update\",\"args\":[{\"id\":\"gVcrZQhy92up\",\"status\":\"swap.created\"}],\"timestamp\":\"1760429678373\"}",
    "2025-10-14T08:14:44.227Z getpairs {\"chain\":{\"BTC\":{\"L-BTC\":{\"hash\":\"9affe2fcb34582f5ae788de379cc4f495dddd92912e11499badd4e85c2243ff4\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":25000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":329,\"user\":{\"claim\":23,\"lockup\":308}}}},\"RBTC\":{\"hash\":\"5871c1d15e8a8bdc9c4a7433abf24c9c40da5ea6fff0434b525bea43dbc1f7fb\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":25000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":423,\"user\":{\"claim\":64,\"lockup\":308}}}}},\"L-BTC\":{\"BTC\":{\"hash\":\"f263627d766fc7b465074c49182357704e1764a18bd687a4238a26250b786f7b\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":25000,\"maximalZeroConf\":500000},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":327,\"user\":{\"claim\":222,\"lockup\":27}}}},\"RBTC\":{\"hash\":\"8315f6ee8da47d7b3ed89a883b4b348f5ec1e4a330860d11c46b40af1a0b1be2\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500,\"maximalZeroConf\":500000},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":140,\"user\":{\"claim\":64,\"lockup\":27}}}}},\"RBTC\":{\"BTC\":{\"hash\":\"7d6ff9322be75e83e374f821c62364d9f4fa0a5eb034e56ee07f25d2461cd4eb\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":25000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":340,\"user\":{\"claim\":222,\"lockup\":121}}}},\"L-BTC\":{\"hash\":\"20c562563175d03aecc3e865a9fbf3727830e6eb36dc2d07e8689ab940f2d9ce\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":{\"server\":59,\"user\":{\"claim\":23,\"lockup\":121}}}}}},\"reverse\":{\"BTC\":{\"BTC\":{\"hash\":\"086a9250fd28cf2e181674ac3ef97302bae3c508a78db233607dde03e8ebf55b\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":25000},\"fees\":{\"percentage\":0.5,\"minerFees\":{\"claim\":222,\"lockup\":308}}},\"L-BTC\":{\"hash\":\"6717d041e27d8b728e7ac9bc6760c130ba7a8cc702c9afb3fabc289d364bba67\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":100},\"fees\":{\"percentage\":0.25,\"minerFees\":{\"claim\":23,\"lockup\":27}}},\"RBTC\":{\"hash\":\"e643fd55d01abefba58c08c662168547f955f706333043442cbeb73b0d5a2fe9\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500},\"fees\":{\"percentage\":0.25,\"minerFees\":{\"claim\":64,\"lockup\":121}}}}},\"submarine\":{\"BTC\":{\"BTC\":{\"hash\":\"52c2397e38d4d6f30ca5896ad32381b0bd0fce0507ef6fb2c6cd39517e043e43\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":1000000,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":302,\"maximalRoutingFee\":0.3}}},\"L-BTC\":{\"BTC\":{\"hash\":\"58ef08a576993761ece14f846e4031fdfb838017a18351dd53eb1d6ea980257b\",\"rate\":1,\"limits\":{\"maximal\":25000000,\"minimal\":1000000,\"maximalZeroConf\":500000,\"minimalBatched\":21},\"fees\":{\"percentage\":0.1,\"minerFees\":19,\"maximalRoutingFee\":0.3}}},\"RBTC\":{\"BTC\":{\"hash\":\"58507b0ccecf7244cfb9a7486029003e64941221f85838a9e420f9e10d00fb16\",\"rate\":1,\"limits\":{\"maximal\":10000000,\"minimal\":2500,\"maximalZeroConf\":0},\"fees\":{\"percentage\":0.1,\"minerFees\":32,\"maximalRoutingFee\":0.35}}}}}",
    "2025-10-14T08:14:44.603Z Loading BOLT12 modules",
    "2025-10-14T08:14:48.127Z Fetching invoice from LNURL or BIP-353 kilrau@breez.fun",
    "2025-10-14T08:14:48.133Z Fetching LNURL: https://breez.fun/.well-known/lnurlp/kilrau",
    "2025-10-14T08:14:48.134Z Fetching BIP-353: kilrau@breez.fun",
    "2025-10-14T08:14:48.396Z amount check: (x, min, max) \"980000\" 100000 25000000000",
    "2025-10-14T08:14:48.397Z fetching invoice https://breez.fun/lnurlpay/kilrau/invoice?amount=980000",
    "2025-10-14T08:14:48.903Z Resolved offer for BIP-353:"
  ]
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Log messages now include a UTC ISO 8601 timestamp prefix for clearer traceability; message content and public behavior remain unchanged.

* **Tests**
  * Tests updated to assert the timestamped log format using deterministic fixed-time expectations so results are stable and reproducible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->