### PR TITLE
fix: Consider swaps created before backup as claimed if status is final

### DIFF
--- a/src/components/SwapChecker.tsx
+++ b/src/components/SwapChecker.tsx
@@ -178,6 +178,7 @@ export const SwapChecker = () => {
         t,
         deriveKey,
         pairs,
+        backupImportTimestamp,
     } = useGlobalContext();
 
     let ws: BoltzWebSocket | undefined = undefined;
@@ -278,6 +279,8 @@ export const SwapChecker = () => {
                 status: data.status,
                 type: currentSwap.type,
                 includeSuccess: true,
+                swapDate: currentSwap.date,
+                backupImportTimestamp: backupImportTimestamp(),
             })
         ) {
             try {

--- a/src/context/Global.tsx
+++ b/src/context/Global.tsx
@@ -116,6 +116,11 @@ export type GlobalContextType = {
     setRescueFile: Setter<RescueFile | null>;
     rescueFileBackupDone: Accessor<boolean>;
     setRescueFileBackupDone: Setter<boolean>;
+
+    // UNIX timestamp when a backup file was last imported
+    // Used to prevent auto-claiming swaps that were created before the backup
+    backupImportTimestamp: Accessor<number | undefined>;
+    setBackupImportTimestamp: Setter<number | undefined>;
 };
 
 const regularReferral = () =>
@@ -407,7 +412,10 @@ const GlobalProvider = (props: { children: JSX.Element }) => {
         return false;
     };
 
-    const clearSwaps = () => swapsForage.clear();
+    const clearSwaps = async () => {
+        await swapsForage.clear();
+        setBackupImportTimestamp(undefined);
+    };
 
     const rdnsForage = localforage.createInstance({
         name: "rdns",
@@ -457,6 +465,14 @@ const GlobalProvider = (props: { children: JSX.Element }) => {
         createSignal<string>(""),
         {
             name: "hardwareDerivationPath",
+        },
+    );
+
+    const [backupImportTimestamp, setBackupImportTimestamp] = makePersisted(
+        // eslint-disable-next-line solid/reactivity
+        createSignal<number>(),
+        {
+            name: "backupImportTimestamp",
         },
     );
 
@@ -543,6 +559,9 @@ const GlobalProvider = (props: { children: JSX.Element }) => {
 
                 rescueFileBackupDone,
                 setRescueFileBackupDone,
+
+                backupImportTimestamp,
+                setBackupImportTimestamp,
             }}>
             {props.children}
         </GlobalContext.Provider>

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -52,6 +52,7 @@ const History = () => {
         setSwapStorage,
         setNotification,
         setNotificationType,
+        setBackupImportTimestamp,
         t,
         setRdns,
     } = useGlobalContext();
@@ -96,6 +97,7 @@ const History = () => {
             setSwaps(swaps);
             setRescueFile({ mnemonic: parsedFile.mnemonic });
             setRescueFileBackupDone(true);
+            setBackupImportTimestamp(new Date().getTime());
 
             if (result.rdns !== undefined) {
                 log.debug(`Importing ${result.rdns.length} RDNS records`);

--- a/src/utils/rescue.ts
+++ b/src/utils/rescue.ts
@@ -63,11 +63,22 @@ export const isSwapClaimable = ({
     status,
     type,
     includeSuccess = false,
+    swapDate = undefined,
+    backupImportTimestamp = undefined,
 }: {
     status: string;
     type: SwapType;
     includeSuccess?: boolean;
+    swapDate?: number;
+    backupImportTimestamp?: number;
 }) => {
+    // When a backup is imported, we only auto-claim successful swaps that were created
+    // after the import timestamp. This prevents attempting to claim swaps that may have
+    // already been completed before the backup was created
+    const swapCreatedAfterBackup: boolean =
+        backupImportTimestamp === undefined ||
+        (swapDate !== undefined && swapDate >= backupImportTimestamp);
+
     switch (type) {
         case SwapType.Reverse: {
             const statuses = [
@@ -75,7 +86,7 @@ export const isSwapClaimable = ({
                 swapStatusPending.TransactionMempool,
             ];
 
-            if (includeSuccess) {
+            if (includeSuccess && swapCreatedAfterBackup) {
                 statuses.push(swapStatusSuccess.InvoiceSettled);
             }
 
@@ -87,7 +98,7 @@ export const isSwapClaimable = ({
                 swapStatusPending.TransactionServerMempool,
             ];
 
-            if (includeSuccess) {
+            if (includeSuccess && swapCreatedAfterBackup) {
                 statuses.push(swapStatusSuccess.TransactionClaimed);
             }
 


### PR DESCRIPTION
Closes #1060 

If user creates a swap, backups the swap history, claims the swap and then imports the backup history on another browser, another claim attempt would be performed

`SwapChecker` should only try to autoclaim final swaps created *after* swap backup history import date

`Rescue` and `RescueExternal` behaviors were not altered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Swap claim eligibility now considers when a backup was imported—swaps created after a backup are evaluated differently for success status.
  * Import flow records a backup import timestamp and resets it when swaps are cleared.

* **Tests**
  * Added tests covering timestamp interactions with swap claimability across swap types and statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->