### PR TITLE
fix: Support RSK refund via External Rescue

### DIFF
--- a/src/pages/RefundRescue.tsx
+++ b/src/pages/RefundRescue.tsx
@@ -58,10 +58,10 @@ export const mapSwap = (
                 assetSend: swap.from,
                 assetReceive: swap.to,
                 version: OutputType.Taproot,
-                address: swap.claimDetails.lockupAddress,
+                address: swap.claimDetails?.lockupAddress, // RSK doesn't have claimDetails yet
                 refundPrivateKeyIndex: swap.refundDetails.keyIndex,
-                claimPublicKey: swap.claimDetails.serverPublicKey,
-                claimPrivateKeyIndex: swap.claimDetails.keyIndex,
+                claimPublicKey: swap.claimDetails?.serverPublicKey,
+                claimPrivateKeyIndex: swap.claimDetails?.keyIndex,
                 timeoutBlockHeight: swap.refundDetails.timeoutBlockHeight,
                 lockupDetails: {
                     ...swap.refundDetails,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness in refund/claim flows by safely handling missing claim-related data so refunds don't fail when details are absent.
  * Expanded refund eligibility logic to include additional swap types that were previously excluded, ensuring more swaps are considered refundable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->