### PR TITLE
test(e2e): improve uncooperative refund flakiness

### DIFF
--- a/e2e/rescue/refund.spec.ts
+++ b/e2e/rescue/refund.spec.ts
@@ -161,6 +161,7 @@ const performBitcoinExpiredSwapSetup = async (
         await waitForNodesToSync();
         await waitForBlockHeight(sendAsset, currentHeight + blocks);
     }
+    await waitForUTXOs(sendAsset as AssetType, address, 2);
 };
 
 const performLiquidExpiredSwapSetup = async (
@@ -184,6 +185,7 @@ const performLiquidExpiredSwapSetup = async (
         await waitForNodesToSync();
         await waitForBlockHeight(sendAsset, currentHeight + blocks);
     }
+    await waitForUTXOs(sendAsset as AssetType, address, 2);
 };
 
 const executeRefund = async (
@@ -366,6 +368,7 @@ test.describe("Refund", () => {
                 address,
                 sendAmount,
             );
+            await page.reload();
             await executeRefund(page, swap.sendAsset, swapId, swap.external);
             await validateRefundTransaction(page, swap.sendAsset, address);
         });


### PR DESCRIPTION
Closes #1069 

edit: Still flaky.

--

Reproduced the error locally, applied the fix and re-ran the test 10 times successfully.

Cause:
After mining a bunch of blocks (on `performBitcoinExpiredSwapSetup` or `performLiquidExpiredSwapSetup`) and then trying to perform the refund, sometimes the `/utxo` request was still returning `[]` (I don't know why), so the refund wasn't available when navigating to the Rescue page.

Fix:
Polled for the expected UTXOs again and refreshed the page to (hopefully) have everything correctly updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability for refund flows with enhanced synchronization checks.
  * Added page reload verification in refund test scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->