### PR TITLE
feat: show originally entered ln destination on funding screen instead of resolved invoice

### DIFF
--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -148,6 +148,9 @@ const CreateButton = () => {
     const [buttonLabel, setButtonLabel] = createSignal<ButtonLabelParams>({
         key: "create_swap",
     });
+    const [originalDestination, setOriginalDestination] = createSignal<
+        string | undefined
+    >(undefined);
 
     createEffect(() => {
         setButtonClass(!online() ? "btn btn-danger" : "btn");
@@ -349,6 +352,7 @@ const CreateButton = () => {
                     ].map((p) => promiseWithTimeout(p, invoiceFetchTimeout)),
                 );
 
+                setOriginalDestination(lnurl());
                 setInvoice(fetched);
                 setLnurl("");
                 setInvoiceValid(true);
@@ -363,6 +367,7 @@ const CreateButton = () => {
                     bolt12Offer(),
                     Number(receiveAmount()),
                 );
+                setOriginalDestination(bolt12Offer());
                 setInvoice(res.invoice);
                 setBolt12Offer(undefined);
                 setInvoiceValid(true);
@@ -402,6 +407,7 @@ const CreateButton = () => {
                             ref(),
                             useRif,
                             newKey,
+                            originalDestination(),
                         );
                     };
 
@@ -508,6 +514,7 @@ const CreateButton = () => {
                             useRif,
                             rescueFile(),
                             newKey,
+                            originalDestination(),
                         );
 
                         data = {
@@ -589,6 +596,7 @@ const CreateButton = () => {
             setInvoiceValid(false);
             setOnchainAddress("");
             setAddressValid(false);
+            setOriginalDestination(undefined);
 
             clearBackupDoneState();
 

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -209,7 +209,13 @@ export const getDestinationAddress = (swap: SomeSwap) => {
     }
 
     if (swap.type === SwapType.Submarine) {
-        return (swap as SubmarineSwap).invoice;
+        const submarineSwap = swap as SubmarineSwap;
+        return submarineSwap.originalDestination || submarineSwap.invoice;
+    }
+
+    if (swap.type === SwapType.Reverse || swap.type === SwapType.Chain) {
+        const chainSwap = swap as ReverseSwap | ChainSwap;
+        return chainSwap.originalDestination || chainSwap.claimAddress;
     }
 
     return swap.claimAddress;

--- a/src/utils/swapCreator.ts
+++ b/src/utils/swapCreator.ts
@@ -41,6 +41,9 @@ export type SwapBase = {
     signer?: string;
     // Set for hardware wallet signers
     derivationPath?: string;
+
+    // Original user input (Lightning address/LNURL/BIP353/BOLT12) before resolution
+    originalDestination?: string;
 };
 
 export type SubmarineSwap = SwapBase &
@@ -115,6 +118,7 @@ export const createSubmarine = async (
     referralId: string,
     useRif: boolean,
     newKey: newKeyFn,
+    originalDestination?: string,
 ): Promise<SubmarineSwap> => {
     const isRsk = assetReceive === RBTC;
     const key = !isRsk ? newKey() : undefined;
@@ -140,6 +144,7 @@ export const createSubmarine = async (
             useRif,
         ),
         invoice,
+        originalDestination,
         refundPrivateKeyIndex: key?.index,
     };
 };
@@ -155,6 +160,7 @@ export const createReverse = async (
     useRif: boolean,
     rescueFile: RescueFile,
     newKey: newKeyFn,
+    originalDestination?: string,
 ): Promise<ReverseSwap> => {
     const isRsk = assetReceive === RBTC;
 
@@ -189,6 +195,7 @@ export const createReverse = async (
             useRif,
         ),
         claimAddress,
+        originalDestination,
         preimage: preimage.toString("hex"),
         claimPrivateKeyIndex: key?.index,
     };
@@ -205,6 +212,7 @@ export const createChain = async (
     useRif: boolean,
     rescueFile: RescueFile,
     newKey: newKeyFn,
+    originalDestination?: string,
 ): Promise<ChainSwap> => {
     const claimKey = assetReceive !== RBTC ? newKey() : undefined;
     const refundKey = assetSend !== RBTC ? newKey() : undefined;
@@ -243,6 +251,7 @@ export const createChain = async (
             useRif,
         ),
         claimAddress,
+        originalDestination,
         preimage: preimage.toString("hex"),
         claimPrivateKeyIndex: claimKey?.index,
         refundPrivateKeyIndex: refundKey?.index,

--- a/tests/utils/helper.spec.ts
+++ b/tests/utils/helper.spec.ts
@@ -1,10 +1,13 @@
+import { SwapType } from "../../src/consts/Enums";
 import type { Pairs } from "../../src/utils/boltzClient";
 import { ECPair } from "../../src/utils/ecpair";
 import {
     formatAddress,
+    getDestinationAddress,
     getPair,
     parsePrivateKey,
 } from "../../src/utils/helper";
+import type { ChainSwap, SubmarineSwap } from "../../src/utils/swapCreator";
 
 vi.mock("../../src/utils/ecpair", () => {
     return {
@@ -117,6 +120,54 @@ describe("helper", () => {
         test("should handle null or undefined gracefully", () => {
             expect(formatAddress(null)).toEqual([]);
             expect(formatAddress(undefined)).toEqual([]);
+        });
+    });
+
+    describe("getDestinationAddress", () => {
+        test("should return originalDestination for submarine swap (Lightning address/LNURL)", () => {
+            const swap = {
+                type: SwapType.Submarine,
+                assetReceive: "BTC",
+                invoice: "lnbc1234567890abcdefghijklmnopqrstuvwxyz1234567890",
+                originalDestination: "user@getalby.com",
+            } as SubmarineSwap;
+
+            expect(getDestinationAddress(swap)).toBe("user@getalby.com");
+        });
+
+        test("should fallback to invoice for submarine swap without originalDestination", () => {
+            const swap = {
+                type: SwapType.Submarine,
+                assetReceive: "BTC",
+                invoice: "lnbc1234567890abcdefghijklmnopqrstuvwxyz1234567890",
+            } as SubmarineSwap;
+
+            expect(getDestinationAddress(swap)).toBe(
+                "lnbc1234567890abcdefghijklmnopqrstuvwxyz1234567890",
+            );
+        });
+
+        test("should return originalDestination for chain swap (MRH case)", () => {
+            const swap = {
+                type: SwapType.Chain,
+                assetReceive: "L-BTC",
+                claimAddress: "liquid1qabcdefghijklmnopqrstuvwxyz",
+                originalDestination: "user@getalby.com",
+            } as ChainSwap;
+
+            expect(getDestinationAddress(swap)).toBe("user@getalby.com");
+        });
+
+        test("should fallback to claimAddress for chain swap without originalDestination", () => {
+            const swap = {
+                type: SwapType.Chain,
+                assetReceive: "L-BTC",
+                claimAddress: "liquid1qabcdefghijklmnopqrstuvwxyz",
+            } as ChainSwap;
+
+            expect(getDestinationAddress(swap)).toBe(
+                "liquid1qabcdefghijklmnopqrstuvwxyz",
+            );
         });
     });
 });


### PR DESCRIPTION
Closes #1086. Added to Chain swaps for MRH resolution and to Reverse Swap just because it doesn't hurt and to be future proof, who knows what we'll come up with.

<img width="519" height="177" alt="image" src="https://github.com/user-attachments/assets/78b87a45-1fca-44a5-b4f9-ddd9398c13a8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserve and prefer the original payment destination across submarine, reverse, and chain swap flows to improve payment traceability and reduce misrouting; original destination is cleared during swap cleanup/reset.

* **Tests**
  * Added tests validating destination selection and fallback behavior across swap and invoice scenarios to ensure reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->