### PR TITLE
fix: invoice millisatoshi conversion

### DIFF
--- a/src/utils/invoice.ts
+++ b/src/utils/invoice.ts
@@ -50,7 +50,7 @@ export const decodeInvoice = async (
         const decoded = bolt11.decode(invoice);
         const sats = BigNumber(decoded.millisatoshis || 0)
             .dividedBy(1000)
-            .integerValue(BigNumber.ROUND_CEIL)
+            .integerValue(BigNumber.ROUND_HALF_UP)
             .toNumber();
         return {
             satoshis: sats,


### PR DESCRIPTION
Aligns client invoice rounding with server's Math.round() behavior to fix submarine swap validation failures when invoices contain fractional millisatoshis (1-499 msat remainder).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rounding behavior for invoice amounts to ensure more accurate satoshi values when converting fractional amounts.

* **New Features**
  * Invoice decoding is now publicly available for integration and use.

* **Tests**
  * Added comprehensive tests covering rounding scenarios and edge cases for invoice amount conversion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->