### PR TITLE
fix: always have zeroConf enabled on mobile

### DIFF
--- a/src/components/settings/SettingsMenu.tsx
+++ b/src/components/settings/SettingsMenu.tsx
@@ -2,11 +2,12 @@ import { BiSolidHelpCircle } from "solid-icons/bi";
 import { BsCardText } from "solid-icons/bs";
 import { ImDisplay } from "solid-icons/im";
 import { IoClose, IoShield } from "solid-icons/io";
-import type { JSXElement } from "solid-js";
+import { type JSXElement, Show } from "solid-js";
 
 import { useGlobalContext } from "../../context/Global";
 import type { DictKey } from "../../i18n/i18n";
 import "../../style/settings.scss";
+import { isMobile } from "../../utils/helper";
 import Denomination from "./Denomination";
 import FiatAmountSetting from "./FiatAmountSetting";
 import Logs from "./Logs";
@@ -93,11 +94,13 @@ const SettingsMenu = () => {
                         tooltipLabel={"hide_wallet_address_tooltip"}
                         settingElement={<PrivacyMode />}
                     />
-                    <Entry
-                        label={"zero_conf"}
-                        tooltipLabel={"zero_conf_tooltip"}
-                        settingElement={<ZeroConf />}
-                    />
+                    <Show when={!isMobile()}>
+                        <Entry
+                            label={"zero_conf"}
+                            tooltipLabel={"zero_conf_tooltip"}
+                            settingElement={<ZeroConf />}
+                        />
+                    </Show>
                     <Entry
                         label={"rescue_key"}
                         tooltipLabel={"download_boltz_rescue_key"}

--- a/src/context/Global.tsx
+++ b/src/context/Global.tsx
@@ -489,6 +489,12 @@ const GlobalProvider = (props: { children: JSX.Element }) => {
         },
     );
 
+    createEffect(() => {
+        if (isMobile()) {
+            setZeroConf(true);
+        }
+    });
+
     // i18n
     createEffect(() => {
         setI18n(detectLanguage(i18nConfigured() || i18nUrl()));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated zero-configuration settings handling for mobile devices by hiding the settings menu option on mobile and automatically enabling the feature when running on mobile platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->