### PR TITLE
fix: chatwoot overlap with settings menu 

### DIFF
--- a/src/style/settings.scss
+++ b/src/style/settings.scss
@@ -12,6 +12,9 @@
 }
 
 #settings-menu {
+    top: 0;
+    z-index: 2147483001; // 1 above Chatwoot widget
+
     label {
         display: flex;
         align-items: center;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the settings menu could be hidden behind other interface elements; the menu now reliably displays in front of overlapping components (including support/chat widgets).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->