### PR TITLE
fix: Dockerfile builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:24 AS builder
 
-RUN npm i -g npm
-
 WORKDIR /app
 
 COPY package.json package-lock.json ./

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:24 AS builder
 
-RUN npm i -g npm
-
 WORKDIR /app
 
 COPY package.json package-lock.json ./


### PR DESCRIPTION
For some reason NPM is acting really weird with our current package-lock.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build configuration by removing an unnecessary global npm installation step. The build process remains functionally equivalent with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->