### PR TITLE
fix: reset last used key for new rescue files

### DIFF
--- a/src/components/settings/ResetRescueKey.tsx
+++ b/src/components/settings/ResetRescueKey.tsx
@@ -18,6 +18,7 @@ const ResetRescueKey = () => {
         setRescueFileBackupDone,
         setSettingsMenu,
         notify,
+        setLastUsedKey,
     } = useGlobalContext();
     const { setSendAmount, setReceiveAmount } = useCreateContext();
 
@@ -38,6 +39,7 @@ const ResetRescueKey = () => {
             await clearSwaps();
             const newRescueFile = generateRescueFile();
             setRescueFile(newRescueFile);
+            setLastUsedKey(0);
             setRescueFileBackupDone(false);
             setSettingsMenu(false);
             setSendAmount(BigNumber(0));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the rescue key reset flow to properly reset key tracking state when generating a new rescue key file.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->