### PR TITLE
fix: browser's navigation buttons on paginated pages

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -66,7 +66,7 @@ const Pagination = <T,>(initialProps: {
 
         if (isNaN(page) || page < 1 || page > numberOfPages.length) {
             page = 1;
-            setSearchParams({ page });
+            setSearchParams({ page }, { replace: true });
         }
 
         props.setCurrentPage(page);


### PR DESCRIPTION
When navigating from any non-paginated page to any paginated page then pressing the browser's back button, the browser would not go back. This PR fixes this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser history handling when pagination resets to the first page due to invalid page parameters, providing better back-button behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->