### PR TITLE
chore: do not prevent reload on regtest

### DIFF
--- a/src/components/SwapChecker.tsx
+++ b/src/components/SwapChecker.tsx
@@ -2,6 +2,7 @@ import log from "loglevel";
 import { createEffect, onCleanup, onMount } from "solid-js";
 import { createStore } from "solid-js/store";
 
+import { config } from "../config";
 import { SwapType } from "../consts/Enums";
 import {
     swapStatusFinal,
@@ -236,7 +237,7 @@ export const SwapChecker = () => {
     });
 
     window.onbeforeunload = (event: BeforeUnloadEvent) => {
-        if (pendingSwaps?.length > 0) {
+        if (config.preventReloadOnPendingSwaps && pendingSwaps?.length > 0) {
             event.preventDefault();
             return "";
         }

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -54,6 +54,8 @@ const defaults = {
     // **Should only be enabled for testing purposes**
     cooperativeDisabled: false,
 
+    preventReloadOnPendingSwaps: true,
+
     loglevel: "info" as log.LogLevelDesc,
     defaultLanguage: "en",
     supportUrl: "https://support.boltz.exchange/hc/center",

--- a/src/configs/regtest.ts
+++ b/src/configs/regtest.ts
@@ -5,6 +5,7 @@ const config = {
     ...baseConfig,
     network: "regtest",
     loglevel: "debug",
+    preventReloadOnPendingSwaps: false,
     apiUrl: {
         normal: "http://localhost:9001",
     },


### PR DESCRIPTION
Is endlessly annoying when developing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Page reload prevention when pending swaps are active is now configurable per environment, enabling flexible control over application behavior during swap operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->