### PR TITLE
feat: close settings with escape key

### DIFF
--- a/src/components/settings/SettingsMenu.tsx
+++ b/src/components/settings/SettingsMenu.tsx
@@ -2,7 +2,7 @@ import { BiSolidHelpCircle } from "solid-icons/bi";
 import { BsCardText } from "solid-icons/bs";
 import { ImDisplay } from "solid-icons/im";
 import { IoClose, IoShield } from "solid-icons/io";
-import { type JSXElement, Show } from "solid-js";
+import { type JSXElement, Show, onCleanup, onMount } from "solid-js";
 
 import { useGlobalContext } from "../../context/Global";
 import type { DictKey } from "../../i18n/i18n";
@@ -54,15 +54,28 @@ const Entry = (props: {
     );
 };
 
-const SettingsMenu = () => {
+const SettingsMenuContent = () => {
     const { t, settingsMenu, setSettingsMenu } = useGlobalContext();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key === "Escape" && settingsMenu()) {
+            setSettingsMenu(false);
+        }
+    };
+
+    onMount(() => {
+        document.addEventListener("keydown", handleKeyDown);
+    });
+
+    onCleanup(() => {
+        document.removeEventListener("keydown", handleKeyDown);
+    });
 
     return (
         <div
             id="settings-menu"
             class="frame assets-select"
-            onClick={() => setSettingsMenu(false)}
-            style={settingsMenu() ? "display: block;" : "display: none;"}>
+            onClick={() => setSettingsMenu(false)}>
             <div onClick={(e) => e.stopPropagation()}>
                 <h2>{t("settings")}</h2>
                 <span class="close" onClick={() => setSettingsMenu(false)}>
@@ -116,6 +129,16 @@ const SettingsMenu = () => {
                 </Section>
             </div>
         </div>
+    );
+};
+
+const SettingsMenu = () => {
+    const { settingsMenu } = useGlobalContext();
+
+    return (
+        <Show when={settingsMenu()}>
+            <SettingsMenuContent />
+        </Show>
     );
 };
 

--- a/src/style/settings.scss
+++ b/src/style/settings.scss
@@ -13,6 +13,7 @@
 
 #settings-menu {
     top: 0;
+    display: block;
     z-index: 2147483001; // 1 above Chatwoot widget
 
     label {

--- a/tests/components/SettingsMenu.spec.tsx
+++ b/tests/components/SettingsMenu.spec.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render } from "@solidjs/testing-library";
+
+import SettingsMenu from "../../src/components/settings/SettingsMenu";
+import { TestComponent, contextWrapper, globalSignals } from "../helper";
+
+describe("SettingsMenu", () => {
+    test("should close when Escape key is pressed", () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <SettingsMenu />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        globalSignals.setSettingsMenu(true);
+
+        fireEvent.keyDown(document, { key: "Escape" });
+
+        expect(globalSignals.settingsMenu()).toBe(false);
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard support to close the settings menu by pressing the Escape key.

* **Style**
  * Improved settings menu display rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->