### PR TITLE
chore: use prod build for playwright on CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,9 @@ export default defineConfig({
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
         /* Base URL to use in actions like `await page.goto('/')`. */
-        baseURL: "http://localhost:4173",
+        baseURL: process.env.CI
+            ? "http://localhost:4173"
+            : "http://localhost:5173",
         ignoreHTTPSErrors: true,
 
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
@@ -50,8 +52,10 @@ export default defineConfig({
     ],
 
     webServer: {
-        command: "npm run regtest && npm run build && npx vite preview",
-        port: 4173,
+        command: process.env.CI
+            ? "npm run regtest && npm run build && npx vite preview"
+            : "npm run dev",
+        port: process.env.CI ? 4173 : 5173,
         reuseExistingServer: !process.env.CI,
         stdout: "pipe",
         stderr: "pipe",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing configuration to use different ports and commands based on deployment context: port 4173 with preview build for CI environments, and port 5173 with development server for local testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->