### PR TITLE
fix: allow pasting amountless invoices when swap amounts are set

### DIFF
--- a/src/components/InvoiceInput.tsx
+++ b/src/components/InvoiceInput.tsx
@@ -149,7 +149,7 @@ const InvoiceInput = () => {
             ) {
                 try {
                     const inv = await decodeInvoice(invoice());
-                    if (inv.satoshis !== amount) {
+                    if (inv.satoshis !== 0 && inv.satoshis !== amount) {
                         setInvoice("");
                     }
 


### PR DESCRIPTION
Clearing the input field after pasting ("can't paste!" feeling) doesn't allow the user to see the `Invoices without amount are not supported` error to understand what's even happening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation handling for zero-amount invoices, ensuring they are properly rejected when a receive amount is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->