### PR TITLE
fix: WalletConnect multiple inits

### DIFF
--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -20,7 +20,6 @@ import "../style/web3.scss";
 import { formatError } from "../utils/errors";
 import { cropString, isMobile } from "../utils/helper";
 import HardwareDerivationPaths, { connect } from "./HardwareDerivationPaths";
-import { WalletConnect } from "./WalletConnect";
 import { hiddenInformation } from "./settings/PrivacyMode";
 
 const Modal = (props: {
@@ -225,7 +224,6 @@ export const ConnectAddress = (props: {
                     );
                 }
             }}>
-            <WalletConnect />
             {t("connect_to_address")}
         </button>
     );
@@ -305,7 +303,6 @@ const ConnectWallet = (props: {
                     {t("no_wallet")}
                 </button>
             }>
-            <WalletConnect />
             <Show
                 when={address() !== undefined}
                 fallback={

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ import Footer from "./components/Footer";
 import Nav from "./components/Nav";
 import Notification from "./components/Notification";
 import { SwapChecker } from "./components/SwapChecker";
+import { WalletConnect } from "./components/WalletConnect";
 import { config } from "./config";
 import { CreateProvider } from "./context/Create";
 import { GlobalProvider } from "./context/Global";
@@ -62,6 +63,7 @@ const App = (props: RouteSectionProps) => {
     return (
         <GlobalProvider>
             <Web3SignerProvider>
+                <WalletConnect />
                 <CreateProvider>
                     <PayProvider>
                         <RescueProvider>


### PR DESCRIPTION
Fixes

> WalletConnect Core is already initialized. This is probably a mistake and can lead to unexpected behavior. Init() was called 3 times

And the errors that follow it when WalletConnect is actually being used