### PR TITLE
fix: creation data off by one

### DIFF
--- a/src/utils/Pair.ts
+++ b/src/utils/Pair.ts
@@ -601,11 +601,13 @@ export default class Pair {
         const firstHop = this.route[0];
         let boltzSendAmount = sendAmount;
         if (firstHop.type === SwapType.Dex) {
-            boltzSendAmount = await this.calculateReceiveAmount(
-                sendAmount,
-                minerFees,
-                [firstHop],
-            );
+            // Reuse the exact Boltz input from the latest reverse quote when available.
+            // Requoting the DEX hop forward can round down by 1 and drift from swap creation.
+            boltzSendAmount =
+                this.boltzSwapSendAmountFromLatestQuote(sendAmount) ??
+                (await this.calculateReceiveAmount(sendAmount, minerFees, [
+                    firstHop,
+                ]));
         }
 
         const receiveAmount = await this.calculateReceiveAmount(

--- a/tests/utils/Pair.spec.ts
+++ b/tests/utils/Pair.spec.ts
@@ -1,0 +1,83 @@
+import { BigNumber } from "bignumber.js";
+
+import { LN, USDT0 } from "../../src/consts/Assets";
+import Pair from "../../src/utils/Pair";
+import type * as BoltzClientModule from "../../src/utils/boltzClient";
+import type { Pairs, QuoteData } from "../../src/utils/boltzClient";
+
+const { quoteDexAmountInMock, quoteDexAmountOutMock } = vi.hoisted(() => ({
+    quoteDexAmountInMock: vi.fn<() => Promise<QuoteData[]>>(),
+    quoteDexAmountOutMock: vi.fn<() => Promise<QuoteData[]>>(),
+}));
+
+vi.mock("../../src/utils/boltzClient", async () => {
+    const actual = await vi.importActual<typeof BoltzClientModule>(
+        "../../src/utils/boltzClient",
+    );
+
+    return {
+        ...actual,
+        quoteDexAmountIn: quoteDexAmountInMock,
+        quoteDexAmountOut: quoteDexAmountOutMock,
+    };
+});
+
+const tbtcAssetAmount = (sats: number) =>
+    (BigInt(sats) * 10_000_000_000n).toString();
+
+const pairs: Pairs = {
+    submarine: {
+        TBTC: {
+            BTC: {
+                hash: "tbtc-ln-pair-hash",
+                rate: 1,
+                limits: {
+                    maximal: 1_000_000,
+                    minimal: 1,
+                    maximalZeroConf: 0,
+                },
+                fees: {
+                    percentage: 0,
+                    minerFees: 0,
+                },
+            },
+        },
+    },
+    reverse: {},
+    chain: {},
+};
+
+describe("Pair", () => {
+    beforeEach(() => {
+        quoteDexAmountInMock.mockReset();
+        quoteDexAmountOutMock.mockReset();
+    });
+
+    test("should keep the cached Boltz send amount for routed submarine creation", async () => {
+        quoteDexAmountOutMock.mockResolvedValue([
+            {
+                quote: "1000000",
+                data: { route: "exact-out" },
+            },
+        ]);
+        quoteDexAmountInMock.mockResolvedValue([
+            {
+                quote: tbtcAssetAmount(1479),
+                data: { route: "exact-in" },
+            },
+        ]);
+
+        const pair = new Pair(pairs, USDT0, LN);
+
+        const sendAmount = await pair.calculateSendAmount(BigNumber(1480), 0);
+        expect(sendAmount.toNumber()).toBe(1_000_000);
+        expect(
+            pair.boltzSwapSendAmountFromLatestQuote(sendAmount)?.toNumber(),
+        ).toBe(1480);
+
+        const creationData = await pair.creationData(sendAmount, 0);
+
+        expect(creationData?.sendAmount.toNumber()).toBe(1480);
+        expect(creationData?.receiveAmount.toNumber()).toBe(1480);
+    });
+});


### PR DESCRIPTION
EDIT: closes https://github.com/BoltzExchange/boltz-web-app/issues/1219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Swap amount calculation for routed transactions now prefers cached quote data for first-hop DEX routes, improving consistency and efficiency while retaining previous fallback behavior.

* **Tests**
  * Added unit tests covering routed swap scenarios, cached quote usage, and send/receive amount calculations to ensure correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->