### PR TITLE
fix: don't show routing fee limit for invalid pairs

### DIFF
--- a/src/utils/Pair.ts
+++ b/src/utils/Pair.ts
@@ -293,7 +293,7 @@ export default class Pair {
 
     public get maxRoutingFee() {
         if (!this.isRoutable) {
-            return 0;
+            return undefined;
         }
 
         const maxFee = this.route

--- a/tests/utils/Pair.spec.ts
+++ b/tests/utils/Pair.spec.ts
@@ -53,6 +53,12 @@ describe("Pair", () => {
         quoteDexAmountOutMock.mockReset();
     });
 
+    test("should return undefined maxRoutingFee for invalid pairs", () => {
+        const pair = new Pair(undefined, "NONEXISTENT", LN);
+        expect(pair.isRoutable).toBe(false);
+        expect(pair.maxRoutingFee).toBeUndefined();
+    });
+
     test("should keep the cached Boltz send amount for routed submarine creation", async () => {
         quoteDexAmountOutMock.mockResolvedValue([
             {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed routing fee calculations to properly handle invalid pair configurations by returning undefined instead of a placeholder value, improving correctness for edge case scenarios.

* **Tests**
  * Added test coverage validating expected behavior when pairs are initialized with invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->