### PR TITLE
feat: Bitcoin-Only Mode

### DIFF
--- a/src/components/AddressInput.tsx
+++ b/src/components/AddressInput.tsx
@@ -3,7 +3,7 @@ import log from "loglevel";
 import { createEffect, on } from "solid-js";
 import { btcToSat } from "src/utils/denomination";
 
-import { LN, isEvmAsset } from "../consts/Assets";
+import { LN, isBitcoinOnlyAsset, isEvmAsset } from "../consts/Assets";
 import { Side, SwapType } from "../consts/Enums";
 import { useCreateContext } from "../context/Create";
 import { useGlobalContext } from "../context/Global";
@@ -19,7 +19,7 @@ import {
 const AddressInput = () => {
     let inputRef: HTMLInputElement;
 
-    const { t, notify, pairs, regularPairs } = useGlobalContext();
+    const { t, notify, pairs, regularPairs, bitcoinOnly } = useGlobalContext();
     const {
         pair,
         setPair,
@@ -101,6 +101,10 @@ const AddressInput = () => {
                     throw new Error();
 
                 default: {
+                    if (bitcoinOnly() && !isBitcoinOnlyAsset(actualAsset)) {
+                        throw new Error();
+                    }
+
                     if (assetName !== actualAsset) {
                         setPair(
                             new Pair(

--- a/src/components/Asset.tsx
+++ b/src/components/Asset.tsx
@@ -3,10 +3,14 @@ import type { Accessor } from "solid-js";
 import { getNetworkBadge } from "../consts/Assets";
 import type { Side } from "../consts/Enums";
 import { useCreateContext } from "../context/Create";
+import { useGlobalContext } from "../context/Global";
 import "../style/asset.scss";
 
 const Asset = (props: { side: Side; signal: Accessor<string> }) => {
+    const { bitcoinOnly } = useGlobalContext();
+
     const openSelect = () => {
+        if (bitcoinOnly()) return;
         setAssetSelected(props.side);
         setAssetSelect(true);
     };
@@ -14,7 +18,9 @@ const Asset = (props: { side: Side; signal: Accessor<string> }) => {
     const { setAssetSelected, setAssetSelect } = useCreateContext();
 
     return (
-        <div class="asset-wrap" onClick={openSelect}>
+        <div
+            class={`asset-wrap${bitcoinOnly() ? " no-select" : ""}`}
+            onClick={openSelect}>
             <div
                 data-testid={`asset-${props.side}`}
                 class={`asset asset-${props.signal()}`}

--- a/src/components/AssetSelect.tsx
+++ b/src/components/AssetSelect.tsx
@@ -32,7 +32,8 @@ const getAssetNetwork = (asset: string): string | null => {
 const SelectAsset = () => {
     const assets = [...Object.keys(config.assets), LN].sort();
 
-    const { t, fetchPairs, pairs, regularPairs } = useGlobalContext();
+    const { t, fetchPairs, pairs, regularPairs, bitcoinOnly } =
+        useGlobalContext();
 
     const {
         pair,
@@ -87,7 +88,7 @@ const SelectAsset = () => {
     };
 
     return (
-        <Show when={assetSelect()}>
+        <Show when={assetSelect() && !bitcoinOnly()}>
             <div
                 class="asset-select-overlay"
                 onClick={() => setAssetSelect(false)}>

--- a/src/components/FeeComparisonTable.tsx
+++ b/src/components/FeeComparisonTable.tsx
@@ -1,7 +1,7 @@
 import { VsArrowSmallRight } from "solid-icons/vs";
 import { For, Show } from "solid-js";
 
-import { LN } from "../consts/Assets";
+import { LN, isBitcoinOnlyPair } from "../consts/Assets";
 import { SwapType } from "../consts/Enums";
 import { useGlobalContext } from "../context/Global";
 import { type Pairs } from "../utils/boltzClient";
@@ -22,7 +22,7 @@ export const FeeComparisonTable = (props: {
     regularPairs: Pairs;
     onSelect: (opportunity: SwapFees) => void;
 }) => {
-    const { t } = useGlobalContext();
+    const { t, bitcoinOnly } = useGlobalContext();
 
     const getSwapFees = (
         proPairs: Pairs,
@@ -61,7 +61,13 @@ export const FeeComparisonTable = (props: {
         return swapTypes
             .flatMap(({ type, key }) =>
                 getSwapFees(pro[key], regular[key], type).filter(
-                    (swap) => swap.proFee < swap.regularFee,
+                    (swap) =>
+                        swap.proFee < swap.regularFee &&
+                        (!bitcoinOnly() ||
+                            isBitcoinOnlyPair(
+                                swap.assetSend,
+                                swap.assetReceive,
+                            )),
                 ),
             )
             .sort((a, b) => a.proFee - b.proFee);

--- a/src/components/InvoiceInput.tsx
+++ b/src/components/InvoiceInput.tsx
@@ -1,7 +1,7 @@
 import { BigNumber } from "bignumber.js";
 import { createEffect, on } from "solid-js";
 
-import { LN } from "../consts/Assets";
+import { LN, isBitcoinOnlyAsset } from "../consts/Assets";
 import { Side, SwapType } from "../consts/Enums";
 import { useCreateContext } from "../context/Create";
 import { useGlobalContext } from "../context/Global";
@@ -21,7 +21,7 @@ import { validateInvoice } from "../utils/validation";
 const InvoiceInput = () => {
     let inputRef: HTMLTextAreaElement;
 
-    const { t, notify, pairs, regularPairs } = useGlobalContext();
+    const { t, notify, pairs, regularPairs, bitcoinOnly } = useGlobalContext();
     const {
         pair,
         setPair,
@@ -85,7 +85,11 @@ const InvoiceInput = () => {
         }
 
         // Auto switch direction based on address
-        if (actualAsset !== LN && actualAsset !== null) {
+        if (
+            actualAsset !== LN &&
+            actualAsset !== null &&
+            (!bitcoinOnly() || isBitcoinOnlyAsset(actualAsset))
+        ) {
             const fromAsset =
                 pair().fromAsset === actualAsset ? LN : pair().fromAsset;
             setPair(new Pair(pairs(), fromAsset, actualAsset, regularPairs()));

--- a/src/components/settings/BitcoinOnly.tsx
+++ b/src/components/settings/BitcoinOnly.tsx
@@ -1,0 +1,23 @@
+import { useGlobalContext } from "../../context/Global";
+
+const BitcoinOnly = () => {
+    const { bitcoinOnly, setBitcoinOnly, t } = useGlobalContext();
+
+    const toggle = (evt: MouseEvent) => {
+        setBitcoinOnly(!bitcoinOnly());
+        evt.stopPropagation();
+    };
+
+    return (
+        <div
+            class="toggle"
+            data-testid="bitcoin-only-toggle"
+            title={t("bitcoin_only_tooltip")}
+            onClick={toggle}>
+            <span class={bitcoinOnly() ? "active" : ""}>{t("on")}</span>
+            <span class={!bitcoinOnly() ? "active" : ""}>{t("off")}</span>
+        </div>
+    );
+};
+
+export default BitcoinOnly;

--- a/src/components/settings/SettingsMenu.tsx
+++ b/src/components/settings/SettingsMenu.tsx
@@ -8,6 +8,7 @@ import { useGlobalContext } from "../../context/Global";
 import type { DictKey } from "../../i18n/i18n";
 import "../../style/settings.scss";
 import { isMobile } from "../../utils/helper";
+import BitcoinOnly from "./BitcoinOnly";
 import Denomination from "./Denomination";
 import FiatAmountSetting from "./FiatAmountSetting";
 import GasTopUp from "./GasTopUp";
@@ -87,6 +88,11 @@ const SettingsMenuContent = () => {
                 <Section
                     title={t("swap")}
                     icon={<IoSwapHorizontal size={20} />}>
+                    <Entry
+                        label={"bitcoin_only"}
+                        tooltipLabel={"bitcoin_only_tooltip"}
+                        settingElement={<BitcoinOnly />}
+                    />
                     <Entry
                         label={"slippage"}
                         tooltipLabel={"slippage_tooltip"}

--- a/src/consts/Assets.ts
+++ b/src/consts/Assets.ts
@@ -28,6 +28,17 @@ export const btcChains = [BTC, LBTC];
 
 export const evmChains = [RBTC, TBTC, USDT0];
 
+export const isBitcoinOnlyAsset = (asset: string): boolean =>
+    asset === LN || asset === BTC;
+
+export const isBitcoinOnlyPair = (
+    fromAsset: string,
+    toAsset: string,
+): boolean =>
+    isBitcoinOnlyAsset(fromAsset) &&
+    isBitcoinOnlyAsset(toAsset) &&
+    fromAsset !== toAsset;
+
 export const getKindForAsset = (asset: string): AssetKind => {
     const assetConfig = config.assets?.[asset];
     if (!assetConfig) {

--- a/src/context/Create.tsx
+++ b/src/context/Create.tsx
@@ -12,7 +12,14 @@ import {
 import type { Accessor, JSX, Setter } from "solid-js";
 
 import { config } from "../config";
-import { type AssetType, BTC, LBTC, LN, assets } from "../consts/Assets";
+import {
+    type AssetType,
+    BTC,
+    LBTC,
+    LN,
+    assets,
+    isBitcoinOnlyPair,
+} from "../consts/Assets";
 import { Side, UrlParam } from "../consts/Enums";
 import type { DictKey } from "../i18n/i18n";
 import Pair, { RequiredInput } from "../utils/Pair";
@@ -286,7 +293,7 @@ const CreateContext = createContext<CreateContextType>();
 
 const CreateProvider = (props: { children: JSX.Element }) => {
     const navigate = useNavigate();
-    const { pairs, regularPairs } = useGlobalContext();
+    const { pairs, regularPairs, bitcoinOnly } = useGlobalContext();
 
     const [invoice, setInvoice] = createSignal<string>("");
     const [lnurl, setLnurl] = createSignal("");
@@ -327,6 +334,24 @@ const CreateProvider = (props: { children: JSX.Element }) => {
     const [bolt12Loading, setBolt12Loading] = createSignal(false);
     const [quoteLoading, setQuoteLoading] = createSignal(false);
 
+    const resetDestinationState = () => {
+        setInvoice("");
+        setInvoiceValid(false);
+        setInvoiceError(undefined);
+        setLnurl("");
+        setBolt12Offer(undefined);
+        setOnchainAddress("");
+        setAddressValid(false);
+    };
+
+    const normalizeBitcoinOnlyPair = (current: Pair) => {
+        if (isBitcoinOnlyPair(current.fromAsset, current.toAsset)) {
+            return current;
+        }
+
+        return new Pair(pairs(), LN, BTC, regularPairs());
+    };
+
     createEffect(() => {
         if (amountValid() && pair().isRoutable) {
             const requiredInput = pair().requiredInput;
@@ -360,6 +385,25 @@ const CreateProvider = (props: { children: JSX.Element }) => {
         const latest = pair();
         setAssetFrom(latest.fromAsset);
         setAssetTo(latest.toAsset);
+    });
+
+    createEffect(() => {
+        if (!bitcoinOnly()) return;
+
+        const latest = pair();
+        const normalized = normalizeBitcoinOnlyPair(latest);
+        if (
+            latest.fromAsset === normalized.fromAsset &&
+            latest.toAsset === normalized.toAsset
+        ) {
+            return;
+        }
+
+        if (latest.toAsset !== normalized.toAsset) {
+            resetDestinationState();
+        }
+
+        setPair(normalized);
     });
 
     // amounts

--- a/src/context/Global.tsx
+++ b/src/context/Global.tsx
@@ -89,6 +89,8 @@ export type GlobalContextType = {
     setZeroConf: Setter<boolean>;
     showFiatAmount: Accessor<boolean>;
     setShowFiatAmount: Setter<boolean>;
+    bitcoinOnly: Accessor<boolean>;
+    setBitcoinOnly: Setter<boolean>;
     btcPrice: Accessor<BigNumber | Error | null>;
     fetchBtcPrice: () => Promise<void>;
     // functions
@@ -507,6 +509,14 @@ const GlobalProvider = (props: { children: JSX.Element }) => {
         },
     );
 
+    const [bitcoinOnly, setBitcoinOnly] = makePersisted(
+        // eslint-disable-next-line solid/reactivity
+        createSignal<boolean>(false),
+        {
+            name: "bitcoinOnly",
+        },
+    );
+
     const [backupImportTimestamp, setBackupImportTimestamp] = makePersisted(
         // eslint-disable-next-line solid/reactivity
         createSignal<number>(),
@@ -578,6 +588,8 @@ const GlobalProvider = (props: { children: JSX.Element }) => {
                 setZeroConf,
                 showFiatAmount,
                 setShowFiatAmount,
+                bitcoinOnly,
+                setBitcoinOnly,
                 btcPrice,
                 fetchBtcPrice,
                 // functions

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -192,6 +192,9 @@ const dict = {
         hide_wallet_address: "Privacy Mode",
         hide_wallet_address_tooltip:
             "Hides EVM wallet address and Swap ID for privacy in demos/recordings",
+        bitcoin_only: "Bitcoin-Only Mode",
+        bitcoin_only_tooltip:
+            "Only show Bitcoin and Lightning, hide all other pairs",
         slippage: "Slippage",
         slippage_tooltip: "Maximum price slippage tolerance for DEX swaps",
         gas_topup: "Auto gas top-up",
@@ -665,6 +668,9 @@ const dict = {
         hide_wallet_address: "Privatsphäre-Modus",
         hide_wallet_address_tooltip:
             "Blendet EVM Wallet-Adresse und Swap ID aus für besser Privatsphäre in Demos und Bildschirmaufnahmen",
+        bitcoin_only: "Bitcoin-Only Modus",
+        bitcoin_only_tooltip:
+            "Nur Bitcoin und Lightning anzeigen, alle anderen Paare ausblenden",
         slippage: "Slippage",
         slippage_tooltip: "Maximale Slippage-Toleranz bei DEX-Swaps",
         gas_topup: "Auto Gas-Aufladung",
@@ -1145,6 +1151,9 @@ const dict = {
         hide_wallet_address: "Modo de Privacidad",
         hide_wallet_address_tooltip:
             "Oculta la dirección del monedero EVM y el ID de Swap para privacidad en demos y grabaciones",
+        bitcoin_only: "Modo Bitcoin-Only",
+        bitcoin_only_tooltip:
+            "Mostrar solo Bitcoin y Lightning, ocultando todos los demás pares",
         slippage: "Slippage",
         slippage_tooltip: "Tolerancia máxima de slippage para swaps en DEX",
         gas_topup: "Recarga automática de gas",
@@ -1621,6 +1630,9 @@ const dict = {
         hide_wallet_address: "Modo de Privacidade",
         hide_wallet_address_tooltip:
             "Oculta o endereço da carteira EVM e o ID do Swap para privacidade em demos e gravações",
+        bitcoin_only: "Modo Bitcoin-Only",
+        bitcoin_only_tooltip:
+            "Mostrar apenas Bitcoin e Lightning, ocultando todos os outros pares",
         slippage: "Slippage",
         slippage_tooltip: "Tolerância máxima de slippage para trocas em DEX",
         gas_topup: "Recarga automática de gas",
@@ -2075,6 +2087,8 @@ const dict = {
         hide_wallet_address: "隐私模式",
         hide_wallet_address_tooltip:
             "在演示和录屏时隐藏EVM钱包地址和交换ID以保护隐私",
+        bitcoin_only: "仅比特币模式",
+        bitcoin_only_tooltip: "仅显示比特币和闪电网络，隐藏所有其他交易对",
         slippage: "滑点",
         slippage_tooltip: "DEX 交换的最大价格滑点容差",
         gas_topup: "自动补充 Gas",
@@ -2522,6 +2536,9 @@ const dict = {
         hide_wallet_address: "プライバシーモード",
         hide_wallet_address_tooltip:
             "デモや録画時のプライバシー保護のため、EVMウォレットアドレスとスワップIDを非表示にします",
+        bitcoin_only: "ビットコイン専用モード",
+        bitcoin_only_tooltip:
+            "ビットコインとライトニングのみを表示し、他のすべてのペアを非表示にします",
         slippage: "スリッページ",
         slippage_tooltip: "DEXスワップで許容する最大価格スリッページ",
         gas_topup: "ガス自動チャージ",

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -94,6 +94,15 @@ hr.spacer {
     &:hover {
         background: var(--color-secondary-600);
     }
+    &.no-select {
+        cursor: default;
+        &:hover {
+            background-color: var(--color-dark-gray);
+        }
+        .arrow-down {
+            display: none;
+        }
+    }
 }
 
 .asset-selection {

--- a/tests/components/AddressInput.spec.tsx
+++ b/tests/components/AddressInput.spec.tsx
@@ -21,6 +21,10 @@ vi.mock("../../src/utils/invoice", async () => {
     };
 });
 
+afterEach(() => {
+    localStorage.clear();
+});
+
 const setPairAssets = (fromAsset: string, toAsset: string) => {
     signals.setPair(new Pair(globalSignals.pairs(), fromAsset, toAsset));
 };
@@ -186,4 +190,36 @@ describe("AddressInput", () => {
             });
         },
     );
+
+    test("should reject non-bitcoin assets when bitcoinOnly is enabled", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <AddressInput />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        globalSignals.setBitcoinOnly(true);
+        setPairAssets(LN, BTC);
+
+        const input = (await screen.findByTestId(
+            "onchainAddress",
+        )) as HTMLInputElement;
+
+        fireEvent.input(input, {
+            target: {
+                value: "el1qq2yjqfz9evc3c5m0rzw0cdtfcdfl5kmcf9xsskpsgza34zhezxzq7y6y4dnldxhtd935k8dn63n8cywy3jlzuvftycsmytjmu",
+            },
+        });
+
+        await waitFor(() => {
+            expect(signals.pair().fromAsset).toEqual(LN);
+            expect(signals.pair().toAsset).toEqual(BTC);
+            expect(signals.addressValid()).toEqual(false);
+            expect(input.className).toContain("invalid");
+        });
+    });
 });

--- a/tests/components/AssetSelect.spec.tsx
+++ b/tests/components/AssetSelect.spec.tsx
@@ -5,12 +5,21 @@ import { BTC, LBTC, LN } from "../../src/consts/Assets";
 import { Side } from "../../src/consts/Enums";
 import i18n from "../../src/i18n/i18n";
 import Pair from "../../src/utils/Pair";
-import { TestComponent, contextWrapper, signals } from "../helper";
+import {
+    TestComponent,
+    contextWrapper,
+    globalSignals,
+    signals,
+} from "../helper";
 import { pairs } from "../pairs";
 
 vi.mock("../../src/utils/boltzClient", () => ({
     getPairs: vi.fn(() => Promise.resolve(pairs)),
 }));
+
+afterEach(() => {
+    localStorage.clear();
+});
 
 const setPairAssets = (fromAsset: string, toAsset: string) => {
     signals.setPair(new Pair(signals.pair().pairs, fromAsset, toAsset));
@@ -182,5 +191,22 @@ describe("AssetSelect", () => {
 
         expect(signals.pair().toAsset).toEqual(BTC);
         expect(signals.onchainAddress()).toBe("");
+    });
+
+    test("should not render when bitcoinOnly is true", () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <SelectAsset />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        globalSignals.setBitcoinOnly(true);
+        signals.setAssetSelect(true);
+
+        expect(screen.queryByTestId(`select-${BTC}`)).toBeNull();
     });
 });

--- a/tests/components/FeeComparisonTable.spec.tsx
+++ b/tests/components/FeeComparisonTable.spec.tsx
@@ -3,8 +3,12 @@ import "@testing-library/jest-dom";
 import { describe, expect, it, vi } from "vitest";
 
 import FeeComparisonTable from "../../src/components/FeeComparisonTable";
-import { TestComponent, contextWrapper } from "../helper";
+import { TestComponent, contextWrapper, globalSignals } from "../helper";
 import { pairs } from "../pairs";
+
+afterEach(() => {
+    localStorage.clear();
+});
 
 describe("FeeComparisonTable", () => {
     it("should show opportunities where pro fee is lower than regular fee", () => {
@@ -70,5 +74,37 @@ describe("FeeComparisonTable", () => {
         expect(
             screen.getByTestId("no-opportunities-found"),
         ).toBeInTheDocument();
+    });
+
+    it("should hide non-bitcoin opportunities when bitcoinOnly is enabled", () => {
+        const proPairs = structuredClone(pairs);
+        const regularPairs = structuredClone(pairs);
+        proPairs.chain.BTC["L-BTC"].fees.percentage = 0.1;
+        regularPairs.chain.BTC["L-BTC"].fees.percentage = 0.5;
+        proPairs.reverse.BTC.BTC.fees.percentage = 0.1;
+        regularPairs.reverse.BTC.BTC.fees.percentage = 0.5;
+
+        const { container } = render(
+            () => (
+                <>
+                    <TestComponent />
+                    <FeeComparisonTable
+                        proPairs={proPairs}
+                        regularPairs={regularPairs}
+                        onSelect={() => {}}
+                    />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        globalSignals.setBitcoinOnly(true);
+
+        expect(
+            container.querySelectorAll("tbody .fee-comparison-row"),
+        ).toHaveLength(1);
+        expect(container.querySelector('[data-asset="L-BTC"]')).toBeNull();
+        expect(container.querySelector('[data-asset="LN"]')).not.toBeNull();
+        expect(container.querySelector('[data-asset="BTC"]')).not.toBeNull();
     });
 });

--- a/tests/components/InvoiceInput.spec.tsx
+++ b/tests/components/InvoiceInput.spec.tsx
@@ -6,7 +6,12 @@ import InvoiceInput from "../../src/components/InvoiceInput";
 import { BTC, LBTC, LN } from "../../src/consts/Assets";
 import Pair from "../../src/utils/Pair";
 import { extractInvoice, invoicePrefix } from "../../src/utils/invoice";
-import { TestComponent, contextWrapper, signals } from "../helper";
+import {
+    TestComponent,
+    contextWrapper,
+    globalSignals,
+    signals,
+} from "../helper";
 
 vi.mock("../../src/utils/invoice", async () => {
     const actual = await vi.importActual("../../src/utils/invoice");
@@ -72,6 +77,10 @@ vi.mock("../../src/utils/compat", async () => {
             return Promise.resolve(null);
         }),
     };
+});
+
+afterEach(() => {
+    localStorage.clear();
 });
 
 const setPairAssets = (fromAsset: string, toAsset: string) => {
@@ -335,4 +344,37 @@ describe("InvoiceInput", () => {
             });
         },
     );
+
+    test("should keep bitcoin-only mode on bitcoin assets when pasting another chain address", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <InvoiceInput />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        globalSignals.setBitcoinOnly(true);
+        setPairAssets(BTC, LN);
+
+        const input = (await screen.findByTestId(
+            "invoice",
+        )) as HTMLTextAreaElement;
+
+        fireEvent.input(input, {
+            target: {
+                value: "el1qq2yjqfz9evc3c5m0rzw0cdtfcdfl5kmcf9xsskpsgza34zhezxzq7y6y4dnldxhtd935k8dn63n8cywy3jlzuvftycsmytjmu",
+            },
+        });
+
+        await waitFor(() => {
+            expect(signals.pair().fromAsset).toEqual(BTC);
+            expect(signals.pair().toAsset).toEqual(LN);
+            expect(signals.onchainAddress()).toEqual("");
+            expect(signals.invoiceValid()).toEqual(false);
+            expect(input.className).toContain("invalid");
+        });
+    });
 });

--- a/tests/components/SettingsMenu.spec.tsx
+++ b/tests/components/SettingsMenu.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@solidjs/testing-library";
+import { fireEvent, render, screen } from "@solidjs/testing-library";
 
 import SettingsMenu from "../../src/components/settings/SettingsMenu";
 import { TestComponent, contextWrapper, globalSignals } from "../helper";
@@ -20,5 +20,28 @@ describe("SettingsMenu", () => {
         fireEvent.keyDown(document, { key: "Escape" });
 
         expect(globalSignals.settingsMenu()).toBe(false);
+    });
+
+    test("should toggle bitcoinOnly on click", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <SettingsMenu />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        globalSignals.setSettingsMenu(true);
+        globalSignals.setBitcoinOnly(false);
+
+        const toggle = await screen.findByTestId("bitcoin-only-toggle");
+
+        fireEvent.click(toggle);
+        expect(globalSignals.bitcoinOnly()).toBe(true);
+
+        fireEvent.click(toggle);
+        expect(globalSignals.bitcoinOnly()).toBe(false);
     });
 });

--- a/tests/context/Create.spec.tsx
+++ b/tests/context/Create.spec.tsx
@@ -3,7 +3,17 @@ import { render } from "@solidjs/testing-library";
 import { BTC, LBTC, LN, RBTC } from "../../src/consts/Assets";
 import { SwapType } from "../../src/consts/Enums";
 import Pair from "../../src/utils/Pair";
-import { TestComponent, contextWrapper, signals } from "../helper";
+import {
+    TestComponent,
+    contextWrapper,
+    globalSignals,
+    signals,
+} from "../helper";
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+});
 
 const setPairAssets = (fromAsset: string, toAsset: string) => {
     signals.setPair(new Pair(signals.pair().pairs, fromAsset, toAsset));
@@ -99,4 +109,39 @@ describe("signals", () => {
             }
         },
     );
+
+    test.each`
+        fromAsset | toAsset
+        ${LBTC}   | ${RBTC}
+        ${LN}     | ${LBTC}
+        ${RBTC}   | ${LN}
+    `(
+        "should normalize $fromAsset → $toAsset to LN → BTC",
+        ({ fromAsset, toAsset }) => {
+            render(() => <TestComponent />, { wrapper: contextWrapper });
+            setPairAssets(fromAsset, toAsset);
+            globalSignals.setBitcoinOnly(true);
+            expect(signals.pair().fromAsset).toEqual(LN);
+            expect(signals.pair().toAsset).toEqual(BTC);
+        },
+    );
+
+    test("should clear incompatible destination state when bitcoinOnly normalizes the pair", () => {
+        render(() => <TestComponent />, { wrapper: contextWrapper });
+
+        signals.setAmountValid(true);
+        signals.setOnchainAddress("0xdeadbeef");
+        signals.setAddressValid(true);
+        setPairAssets(BTC, RBTC);
+
+        expect(signals.valid()).toEqual(true);
+
+        globalSignals.setBitcoinOnly(true);
+
+        expect(signals.pair().fromAsset).toEqual(LN);
+        expect(signals.pair().toAsset).toEqual(BTC);
+        expect(signals.onchainAddress()).toEqual("");
+        expect(signals.addressValid()).toEqual(false);
+        expect(signals.valid()).toEqual(false);
+    });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Bitcoin-Only Mode toggle in settings that filters the interface to display only Bitcoin and Lightning trading pairs.
  * Address inputs and asset selections now validate against Bitcoin-only constraints when the mode is active.
  * Fee comparisons filter to show only compatible pairs in this mode.

* **Tests**
  * Added comprehensive test coverage for the new Bitcoin-Only Mode functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->