### PR TITLE
fix: oft send amount fee calc

### DIFF
--- a/src/components/Fees.tsx
+++ b/src/components/Fees.tsx
@@ -11,7 +11,7 @@ import {
 import { gasTokenToGetUsdCents } from "src/utils/qouter";
 
 import { config } from "../config";
-import { AssetKind, BTC, LBTC } from "../consts/Assets";
+import { BTC, LBTC } from "../consts/Assets";
 import { SwapType } from "../consts/Enums";
 import { useCreateContext } from "../context/Create";
 import { useGlobalContext } from "../context/Global";
@@ -88,27 +88,12 @@ const Fees = () => {
     const assetSend = () => pair().fromAsset;
     const assetReceive = () => pair().toAsset;
 
-    const needsBoltzSwapSendAmount = createMemo(() => {
-        if (!pair().isRoutable) return false;
-
-        const from = assetSend();
-        const fromAsset = config.assets[from];
-        return (
-            fromAsset?.type === AssetKind.ERC20 &&
-            fromAsset.token?.routeVia !== undefined
-        );
-    });
-
     const boltzFeeAmount = createMemo(() => {
         if (!pair().isRoutable) {
             return BigNumber(0);
         }
 
         receiveAmount();
-
-        if (!needsBoltzSwapSendAmount()) {
-            return pair().feeOnSend(sendAmount());
-        }
 
         const boltzSwapSendAmount =
             pair().boltzSwapSendAmountFromLatestQuote(sendAmount());

--- a/src/utils/Pair.ts
+++ b/src/utils/Pair.ts
@@ -933,6 +933,10 @@ export default class Pair {
     };
 
     public boltzSwapSendAmountFromLatestQuote = (sendAmount: BigNumber) => {
+        if (this.preOft === undefined && this.dexHopBeforeBoltz === undefined) {
+            return sendAmount;
+        }
+
         const key = sendAmount.toFixed();
 
         if (this.latestBoltzSwapSendAmount?.sendAmount !== key) {

--- a/tests/components/Fees.spec.tsx
+++ b/tests/components/Fees.spec.tsx
@@ -10,6 +10,7 @@ import * as rifSigner from "../../src/rif/Signer";
 import Pair from "../../src/utils/Pair";
 import { getPairs } from "../../src/utils/boltzClient";
 import {
+    calculateBoltzFeeOnSend,
     calculateReceiveAmount,
     calculateSendAmount,
 } from "../../src/utils/calculate";
@@ -270,6 +271,55 @@ describe("Fees component", () => {
             expect(signals.minerFee()).toEqual(baseMinerFee);
         });
         expect(globalSignals.notification()).toEqual("");
+    });
+
+    test("should use the quoted Boltz input for OFT-routed service fees", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Fees />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        globalSignals.setPairs(pairs);
+        globalSignals.setDenomination(Denomination.Btc);
+
+        const feeOnSend = vi.fn((amount: BigNumber) =>
+            calculateBoltzFeeOnSend(amount, 1, 0, SwapType.Submarine),
+        );
+        const mockPair = {
+            isRoutable: true,
+            fromAsset: "USDT0-POL",
+            toAsset: LN,
+            swapToCreate: {
+                type: SwapType.Submarine,
+            },
+            preOft: null,
+            dexHopBeforeBoltz: null,
+            feePercentage: 1,
+            minerFees: 0,
+            maxRoutingFee: undefined,
+            oftMessagingFeeToken: undefined,
+            feeOnSend,
+            boltzSwapSendAmountFromLatestQuote: vi.fn(() => BigNumber(1480)),
+            oftMessagingFeeFromLatestQuote: vi.fn(() => undefined),
+            getMinimum: vi.fn().mockResolvedValue(1),
+            getMaximum: vi.fn().mockResolvedValue(10_000),
+        } as unknown as Pair;
+
+        signals.setPair(mockPair);
+        signals.setSendAmount(BigNumber(2000));
+
+        await waitFor(() => {
+            expect(screen.getByTestId("boltz-fee").textContent).toEqual(
+                "0.00000015",
+            );
+        });
+        expect(feeOnSend).toHaveBeenCalled();
+        expect(feeOnSend.mock.calls.at(-1)?.[0].toNumber()).toBe(1480);
     });
 
     test.each`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fee calculations for Boltz-routing now consistently use the quoted swap input when routing is available, and avoid unnecessary processing when specific routing conditions are absent—improving fee accuracy.

* **Tests**
  * Added test coverage to verify service fees use the quoted Boltz swap input for OFT/routed scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->