### PR TITLE
refactor: normalize L-BTC to LBTC and USDT0 to USDT in UI

### DIFF
--- a/e2e/create.spec.ts
+++ b/e2e/create.spec.ts
@@ -2,7 +2,7 @@ import { type Page, expect, test } from "@playwright/test";
 import BigNumber from "bignumber.js";
 import fs from "fs";
 
-import { BTC, LBTC, LN } from "../src/consts/Assets";
+import { BTC, LBTC, LN, getAssetDisplaySymbol } from "../src/consts/Assets";
 import { Denomination } from "../src/consts/Enums";
 import dict from "../src/i18n/i18n";
 import { formatAmount } from "../src/utils/denomination";
@@ -72,7 +72,7 @@ test.describe("BIP21 URIs", () => {
 
             const receiveAsset = page.getByTestId("asset-receive");
             await expect(receiveAsset).toContainClass(
-                `asset-${condition.expectedAsset}`,
+                `asset-${getAssetDisplaySymbol(condition.expectedAsset)}`,
             );
         });
     });

--- a/e2e/urlParams.spec.ts
+++ b/e2e/urlParams.spec.ts
@@ -2,7 +2,13 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import BigNumber from "bignumber.js";
 
-import { BTC, LBTC, LN, RBTC } from "../src/consts/Assets";
+import {
+    BTC,
+    LBTC,
+    LN,
+    RBTC,
+    getAssetDisplaySymbol,
+} from "../src/consts/Assets";
 import { Denomination } from "../src/consts/Enums";
 import { formatAmount } from "../src/utils/denomination";
 import {
@@ -39,7 +45,7 @@ test.describe("URL params", () => {
         const address = await getLiquidAddress();
 
         await page.goto(`/?destination=${address}`);
-        const receiveAsset = page.locator(".asset-L-BTC");
+        const receiveAsset = page.locator(".asset-LBTC");
         expect(receiveAsset).toBeDefined();
 
         const onchainAddress = page.getByTestId("onchainAddress");
@@ -253,14 +259,14 @@ test.describe("URL params", () => {
             if (condition.expectedSendAsset !== undefined) {
                 const sendAsset = page.getByTestId(`asset-send`);
                 await expect(sendAsset).toContainClass(
-                    `asset-${condition.expectedSendAsset}`,
+                    `asset-${getAssetDisplaySymbol(condition.expectedSendAsset)}`,
                 );
             }
 
             if (condition.expectedReceiveAsset !== undefined) {
                 const receiveAsset = page.getByTestId(`asset-receive`);
                 await expect(receiveAsset).toContainClass(
-                    `asset-${condition.expectedReceiveAsset}`,
+                    `asset-${getAssetDisplaySymbol(condition.expectedReceiveAsset)}`,
                 );
             }
 

--- a/src/components/QrCode.tsx
+++ b/src/components/QrCode.tsx
@@ -2,6 +2,7 @@ import log from "loglevel";
 import QRCode from "qrcode/lib/server";
 import { createResource, createSignal } from "solid-js";
 
+import { getAssetDisplaySymbol } from "../consts/Assets";
 import "../style/qrcode.scss";
 import { formatError } from "../utils/errors";
 
@@ -12,6 +13,10 @@ interface QrCodeProps {
 
 export const Qrcode = (params: QrCodeProps) => {
     const [dataUrl, setDataUrl] = createSignal("");
+    const displayAsset = () =>
+        params.asset === undefined
+            ? undefined
+            : getAssetDisplaySymbol(params.asset);
 
     createResource(async () => {
         try {
@@ -27,7 +32,7 @@ export const Qrcode = (params: QrCodeProps) => {
 
     return (
         <div
-            data-asset={params.asset}
+            data-asset={displayAsset()}
             id="qrcode"
             style={{ position: "relative" }}>
             <img src={dataUrl()} alt="Payment QR Code" />

--- a/src/consts/Assets.ts
+++ b/src/consts/Assets.ts
@@ -41,11 +41,18 @@ export const isUsdt0Variant = (asset: string): boolean =>
 export const isUsdt0Asset = (asset: string): boolean =>
     asset === USDT0 || isUsdt0Variant(asset);
 
-export const getAssetDisplaySymbol = (asset: string): string =>
-    isUsdt0Asset(asset) ? "USDT" : asset;
-
 export const getCanonicalAsset = (asset: string): string =>
     isUsdt0Variant(asset) ? USDT0 : asset;
+
+const assetDisplaySymbols: Record<string, string> = {
+    [LBTC]: "LBTC",
+    [USDT0]: "USDT",
+};
+
+export const getAssetDisplaySymbol = (asset: string): string => {
+    const canonicalAsset = getCanonicalAsset(asset);
+    return assetDisplaySymbols[canonicalAsset] ?? canonicalAsset;
+};
 
 const normalizeNetworkBadge = (chainName: string): string =>
     networkBadgeAliases[chainName] ??

--- a/src/context/Global.tsx
+++ b/src/context/Global.tsx
@@ -1,5 +1,10 @@
 /* @refresh skip */
-import { flatten, resolveTemplate, translator } from "@solid-primitives/i18n";
+import {
+    type BaseTemplateArgs,
+    flatten,
+    resolveTemplate,
+    translator,
+} from "@solid-primitives/i18n";
 import { makePersisted } from "@solid-primitives/storage";
 import localforage from "localforage";
 import log from "loglevel";
@@ -14,7 +19,14 @@ import type { Accessor, JSX, Setter } from "solid-js";
 import { getBtcPriceFailover } from "src/utils/fiat";
 
 import { config } from "../config";
-import { type AssetType, LBTC, isEvmAsset } from "../consts/Assets";
+import {
+    type AssetType,
+    LBTC,
+    getAssetDisplaySymbol,
+    getAssetNetwork,
+    isEvmAsset,
+    isUsdt0Asset,
+} from "../consts/Assets";
 import { Denomination } from "../consts/Enums";
 import { detectLanguage } from "../i18n/detect";
 import type { DictKey } from "../i18n/i18n";
@@ -539,10 +551,28 @@ const GlobalProvider = (props: { children: JSX.Element }) => {
         () => flatten(dict[i18n() || config.defaultLanguage]) as never,
     );
 
+    const resolveDisplaySymbols = (
+        template: string,
+        values?: BaseTemplateArgs,
+    ) => {
+        if (typeof values?.asset === "string") {
+            const raw = values.asset;
+            let display = getAssetDisplaySymbol(raw);
+            if (isUsdt0Asset(raw)) {
+                const network = getAssetNetwork(raw);
+                if (network) {
+                    display = `${display} (${network})`;
+                }
+            }
+            values = { ...values, asset: display };
+        }
+        return resolveTemplate(template, values);
+    };
+
     // eslint-disable-next-line solid/reactivity
-    const t = translator(dictLocale, resolveTemplate) as (
+    const t = translator(dictLocale, resolveDisplaySymbols) as (
         key: DictKey,
-        values?: Record<string, unknown>,
+        values?: BaseTemplateArgs,
     ) => string;
 
     return (

--- a/src/context/Web3.tsx
+++ b/src/context/Web3.tsx
@@ -61,7 +61,7 @@ declare global {
     }
 
     interface Window {
-        // @ts-expect-error - we can safely ignore this
+        // @ts-expect-error - conflicts with @reown/appkit-utils non-optional declaration
         ethereum?: EIP1193Provider;
     }
 }

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -83,7 +83,7 @@ const dict = {
         copy_bip21: "BIP21",
         refund_swap: "Refund Swap",
         rescue_a_swap_subline:
-            "If you sent BTC or L-BTC into a Boltz swap, upload or enter your rescue key to rescue a swap that is not available in this browser’s swap history.",
+            "If you sent BTC or LBTC into a Boltz swap, upload or enter your rescue key to rescue a swap that is not available in this browser’s swap history.",
         rescue_a_swap_mnemonic:
             "Enter your rescue key to rescue a swap that is not available in this browser’s swap history.",
         refund_past_swaps: "Past swaps",
@@ -1048,7 +1048,7 @@ const dict = {
         copy_bip21: "BIP21",
         refund_swap: "Reembolsar Intercambio",
         rescue_a_swap_subline:
-            "Si enviaste BTC o L-BTC a un intercambio Boltz, carga o introduce tu clave de rescate para rescatar un swap que no esté disponible en el historial de swaps de este navegador",
+            "Si enviaste BTC o LBTC a un intercambio Boltz, carga o introduce tu clave de rescate para rescatar un swap que no esté disponible en el historial de swaps de este navegador",
         rescue_a_swap_mnemonic:
             "Introduce tu clave de rescate para rescatar un intercambio que no está disponible en el historial de este navegador.",
         refund_past_swaps: "Intercambios anteriores",
@@ -1536,7 +1536,7 @@ const dict = {
         copy_bip21: "BIP21",
         refund_swap: "Reembolsar troca",
         rescue_a_swap_subline:
-            "Se enviou BTC ou L-BTC para uma troca Boltz, faça upload ou insira sua chave de resgate para resgatar uma troca que não está no histórico deste navegador.",
+            "Se enviou BTC ou LBTC para uma troca Boltz, faça upload ou insira sua chave de resgate para resgatar uma troca que não está no histórico deste navegador.",
         rescue_a_swap_mnemonic:
             "Insira sua chave de resgate para resgatar uma troca que não está no histórico deste navegador.",
         refund_past_swaps: "Trocas passadas",
@@ -2014,7 +2014,7 @@ const dict = {
         copy_bip21: "BIP21",
         refund_swap: "退还交换",
         rescue_a_swap_subline:
-            "如果您向 Boltz 交换发送了 BTC 或 L-BTC，请上传或输入您的救援密钥，以恢复在该浏览器的交换历史记录中不可用的交换。",
+            "如果您向 Boltz 交换发送了 BTC 或 LBTC，请上传或输入您的救援密钥，以恢复在该浏览器的交换历史记录中不可用的交换。",
         rescue_a_swap_mnemonic:
             "输入您的救援密钥以恢复此浏览器交换历史记录中不存在的交换。",
         refund_past_swaps: "过去的交换",
@@ -2456,7 +2456,7 @@ const dict = {
         copy_bip21: "BIP21をコピー",
         refund_swap: "スワップを返金する",
         rescue_a_swap_subline:
-            "BTCまたはL-BTCをBoltzスワップに送金した場合、このブラウザのスワップ履歴に表示されないスワップを復旧するには、復旧キーをアップロードまたは入力してください。",
+            "BTCまたはLBTCをBoltzスワップに送金した場合、このブラウザのスワップ履歴に表示されないスワップを復旧するには、復旧キーをアップロードまたは入力してください。",
         rescue_a_swap_mnemonic:
             "このブラウザの交換履歴にない交換を復元するには、復元キーを入力してください。",
         refund_past_swaps: "過去のスワップ",

--- a/src/style/asset.scss
+++ b/src/style/asset.scss
@@ -67,12 +67,12 @@
     }
 }
 
-.asset-L-BTC {
+.asset-LBTC {
     .icon {
         background-image: vars.$liquid_icon;
     }
     .asset-text:before {
-        content: "L-BTC";
+        content: "LBTC";
     }
 }
 

--- a/src/style/qrcode.scss
+++ b/src/style/qrcode.scss
@@ -19,7 +19,7 @@ $size: 40px;
     &[data-asset="BTC"] span {
         background-image: vars.$bitcoin_icon;
     }
-    &[data-asset="L-BTC"] span {
+    &[data-asset="LBTC"] span {
         background-image: vars.$liquid_icon;
     }
     &[data-asset="RBTC"] span {

--- a/src/style/swaplist.scss
+++ b/src/style/swaplist.scss
@@ -70,7 +70,7 @@
 .swaplist-asset span[data-asset="BTC"] {
     background-image: vars.$bitcoin_icon;
 }
-.swaplist-asset span[data-asset="L-BTC"] {
+.swaplist-asset span[data-asset="LBTC"] {
     background-image: vars.$liquid_icon;
 }
 .swaplist-asset span[data-asset="RBTC"] {

--- a/src/utils/denomination.ts
+++ b/src/utils/denomination.ts
@@ -106,7 +106,7 @@ export const formatDenomination = (denom: Denomination, asset: string) => {
     if (isErc20) {
         return getAssetDisplaySymbol(asset);
     }
-    return denom === Denomination.Sat ? "sats" : asset;
+    return denom === Denomination.Sat ? "sats" : getAssetDisplaySymbol(asset);
 };
 
 export const convertAmount = (

--- a/src/utils/rescue.ts
+++ b/src/utils/rescue.ts
@@ -336,7 +336,7 @@ const assetRescueRefund = async <T extends SubmarineSwap | ChainSwap>(
     transactionsToRefund: TransactionInterface[],
 ) => {
     if (swap.assetSend !== LBTC) {
-        throw new Error("Asset rescue refund is only supported for L-BTC");
+        throw new Error("Asset rescue refund is only supported for LBTC");
     }
 
     if (transactionsToRefund.length !== 1) {

--- a/tests/components/CreateButton.spec.tsx
+++ b/tests/components/CreateButton.spec.tsx
@@ -443,7 +443,7 @@ describe("CreateButton", () => {
         setPairAssets(LN, LBTC);
         signals.setOnchainAddress("");
         const btn = (await screen.findByText(
-            i18n.en.invalid_address.replace("{{ asset }}", "L-BTC"),
+            i18n.en.invalid_address.replace("{{ asset }}", "LBTC"),
         )) as HTMLButtonElement;
         expect(btn).not.toBeUndefined();
         expect(btn.disabled).toBeTruthy();

--- a/tests/components/FeeComparisonTable.spec.tsx
+++ b/tests/components/FeeComparisonTable.spec.tsx
@@ -103,7 +103,7 @@ describe("FeeComparisonTable", () => {
         expect(
             container.querySelectorAll("tbody .fee-comparison-row"),
         ).toHaveLength(1);
-        expect(container.querySelector('[data-asset="L-BTC"]')).toBeNull();
+        expect(container.querySelector('[data-asset="LBTC"]')).toBeNull();
         expect(container.querySelector('[data-asset="LN"]')).not.toBeNull();
         expect(container.querySelector('[data-asset="BTC"]')).not.toBeNull();
     });

--- a/tests/consts/Assets.spec.ts
+++ b/tests/consts/Assets.spec.ts
@@ -1,0 +1,43 @@
+import {
+    BTC,
+    LBTC,
+    LN,
+    RBTC,
+    USDT0,
+    getAssetDisplaySymbol,
+    getCanonicalAsset,
+} from "../../src/consts/Assets";
+
+describe("Assets", () => {
+    describe("getCanonicalAsset", () => {
+        test.each`
+            input           | expected
+            ${BTC}          | ${BTC}
+            ${LBTC}         | ${LBTC}
+            ${LN}           | ${LN}
+            ${RBTC}         | ${RBTC}
+            ${USDT0}        | ${USDT0}
+            ${"USDT0-ETH"}  | ${USDT0}
+            ${"USDT0-ARB"}  | ${USDT0}
+            ${"USDT0-BERA"} | ${USDT0}
+        `("$input -> $expected", ({ input, expected }) => {
+            expect(getCanonicalAsset(input)).toBe(expected);
+        });
+    });
+
+    describe("getAssetDisplaySymbol", () => {
+        test.each`
+            input           | expected
+            ${BTC}          | ${"BTC"}
+            ${LBTC}         | ${"LBTC"}
+            ${LN}           | ${"LN"}
+            ${RBTC}         | ${"RBTC"}
+            ${USDT0}        | ${"USDT"}
+            ${"USDT0-ETH"}  | ${"USDT"}
+            ${"USDT0-ARB"}  | ${"USDT"}
+            ${"USDT0-BERA"} | ${"USDT"}
+        `("$input -> $expected", ({ input, expected }) => {
+            expect(getAssetDisplaySymbol(input)).toBe(expected);
+        });
+    });
+});

--- a/tests/utils/denomination.spec.ts
+++ b/tests/utils/denomination.spec.ts
@@ -131,7 +131,7 @@ describe("denomination utils", () => {
         ${Denomination.Sat} | ${BTC}   | ${"sats"}
         ${Denomination.Sat} | ${LBTC}  | ${"sats"}
         ${Denomination.Btc} | ${BTC}   | ${BTC}
-        ${Denomination.Btc} | ${LBTC}  | ${LBTC}
+        ${Denomination.Btc} | ${LBTC}  | ${"LBTC"}
         ${Denomination.Sat} | ${USDT0} | ${"USDT"}
         ${Denomination.Btc} | ${USDT0} | ${"USDT"}
     `("should format denomination", ({ denomination, input, expected }) => {


### PR DESCRIPTION
Closes https://github.com/BoltzExchange/boltz-web-app/issues/1257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized Liquid Bitcoin display from "L-BTC" to "LBTC" across UI labels, QR code attributes, icons, help text, and error messages in all supported languages.

* **Refactor**
  * Canonicalized asset display symbols so assets like USDT variants show consistent labels (e.g., "USDT").

* **Bug Fixes**
  * Updated tests and end-to-end assertions to match the new display symbol logic.

* **Chores**
  * Added unit tests for asset canonicalization and display mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->