### PR TITLE
fix: use asset order in asset selector

### DIFF
--- a/src/components/AssetSelect.tsx
+++ b/src/components/AssetSelect.tsx
@@ -4,13 +4,13 @@ import { For, Show, createEffect, createMemo, createSignal } from "solid-js";
 
 import { config } from "../config";
 import {
-    LN,
     USDT0,
     getAssetDisplaySymbol,
     getAssetNetwork,
     getNetworkBadge,
     isUsdt0Asset,
     isUsdt0Variant,
+    assets as orderedAssets,
 } from "../consts/Assets";
 import { AssetSelection, Side } from "../consts/Enums";
 import { useCreateContext } from "../context/Create";
@@ -39,13 +39,11 @@ const SelectAsset = () => {
     let listRef: HTMLDivElement;
 
     const assets = createMemo(() =>
-        [...Object.keys(config.assets), LN]
-            .filter(
-                (asset) =>
-                    !isUsdt0Variant(asset) &&
-                    canSelectAsset(assetSelected(), asset),
-            )
-            .sort(),
+        orderedAssets.filter(
+            (asset) =>
+                !isUsdt0Variant(asset) &&
+                canSelectAsset(assetSelected(), asset),
+        ),
     );
 
     createEffect(() => {

--- a/src/consts/Assets.ts
+++ b/src/consts/Assets.ts
@@ -21,7 +21,16 @@ export type AssetType =
 
 export type RefundableAssetType = typeof BTC | typeof LBTC | typeof RBTC;
 
-export const assets = [LN, ...Object.keys(config.assets ?? {})];
+const assetDisplayOrder: string[] = [LN, BTC, LBTC, RBTC, TBTC, USDT0];
+
+export const assets: string[] = [
+    ...assetDisplayOrder.filter(
+        (asset) => asset === LN || asset in (config.assets ?? {}),
+    ),
+    ...Object.keys(config.assets ?? {}).filter(
+        (asset) => !assetDisplayOrder.includes(asset),
+    ),
+];
 
 export const refundableAssets = [BTC, LBTC, RBTC];
 

--- a/tests/components/AssetSelect.spec.tsx
+++ b/tests/components/AssetSelect.spec.tsx
@@ -4,7 +4,7 @@ import SelectAsset from "../../src/components/AssetSelect";
 import NetworkSelect from "../../src/components/NetworkSelect";
 import type * as ConfigModule from "../../src/config";
 import { config } from "../../src/config";
-import { BTC, LBTC, LN, RBTC, USDT0 } from "../../src/consts/Assets";
+import { BTC, LBTC, LN, RBTC, TBTC, USDT0 } from "../../src/consts/Assets";
 import { AssetSelection, Side } from "../../src/consts/Enums";
 import i18n from "../../src/i18n/i18n";
 import {
@@ -168,6 +168,38 @@ describe("AssetSelect", () => {
             ),
         );
         expect(header).not.toBeUndefined();
+    });
+
+    test("should render assets in configured order", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <SelectAsset />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        signals.setAssetSelection(AssetSelection.Asset);
+        signals.setAssetSelected(Side.Receive);
+
+        await screen.findByTestId(`select-${USDT0}`);
+
+        const assetIds = Array.from(
+            document.querySelectorAll(
+                ".asset-select-list [data-testid^='select-']",
+            ),
+        ).map((element) => element.getAttribute("data-testid"));
+
+        expect(assetIds).toEqual([
+            `select-${LN}`,
+            `select-${BTC}`,
+            `select-${LBTC}`,
+            `select-${RBTC}`,
+            `select-${TBTC}`,
+            `select-${USDT0}`,
+        ]);
     });
 
     test("should ignore same asset selection", async () => {


### PR DESCRIPTION
Before:
<img width="546" height="613" alt="image" src="https://github.com/user-attachments/assets/e85e3d83-9eb6-4d08-84de-aa0476268276" />

After:
<img width="500" height="562" alt="image" src="https://github.com/user-attachments/assets/b84e867f-f947-4335-b11f-4436ceb3b754" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enforced a deterministic, configurable asset display order and preserved that sequence in the selection UI.
  * Selection logic now excludes unsupported asset variants and enforces which assets can be chosen.

* **Tests**
  * Added coverage to verify the rendered asset order and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->