### PR TITLE
feat: Require Rescue Key backup for everything except Reverse Swaps

### DIFF
--- a/e2e/evm/rsk.spec.ts
+++ b/e2e/evm/rsk.spec.ts
@@ -234,6 +234,8 @@ test.describe("EVM", () => {
                 await expect(buttonCreateSwap).toBeEnabled({ timeout: 5000 });
                 await buttonCreateSwap.click();
 
+                await verifyRescueFile(page);
+
                 await expect(
                     page.locator("div[data-status='swap.created']"),
                 ).toBeVisible();
@@ -348,6 +350,8 @@ test.describe("EVM", () => {
         await expect(buttonCreateSwap).toBeEnabled();
         await buttonCreateSwap.click();
 
+        await verifyRescueFile(page);
+
         await expect(
             page.locator("div[data-status='invoice.set']"),
         ).toBeVisible();
@@ -402,6 +406,8 @@ test.describe("EVM", () => {
         );
         await expect(buttonCreateSwap).toBeEnabled();
         await buttonCreateSwap.click();
+
+        await verifyRescueFile(page);
 
         await expect(
             page.locator("div[data-status='invoice.set']"),

--- a/e2e/evm/rskRescue.spec.ts
+++ b/e2e/evm/rskRescue.spec.ts
@@ -245,6 +245,7 @@ test.describe("RSK Rescue", () => {
 
         await fillReceiveAmount(page, "0.001");
         await clickCreateSwap(page);
+        await downloadAndVerifyRescueFile(page, rescueFileName);
         await waitForSwapCreated(page);
 
         await page.getByRole("button", { name: "Send" }).click();

--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -450,11 +450,7 @@ const CreateButton = () => {
         claimAddress: string,
         gasAbstraction: GasAbstractionType,
     ): Promise<boolean> => {
-        if (
-            !rescueFileBackupDone() &&
-            !isEvmAsset(assetSend()) &&
-            swapType() !== SwapType.Reverse
-        ) {
+        if (!rescueFileBackupDone() && swapType() !== SwapType.Reverse) {
             navigate("/backup");
             return false;
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made backup/rescue file verification during swap creation consistent across swap types so users are prompted to secure backups when required.

* **Tests**
  * Expanded end-to-end checks to download and verify rescue files immediately after swap creation to ensure backup flow works reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->