### PR TITLE
chore: disable chain swap route

### DIFF
--- a/src/utils/Pair.ts
+++ b/src/utils/Pair.ts
@@ -117,6 +117,12 @@ const toEncodedHop = (hop: Hop): EncodedHop => {
     };
 };
 
+const canUseRoutedBoltzHop = (
+    hop: Pick<Hop, "type" | "pair"> | undefined,
+): hop is Pick<Hop, "type" | "pair"> =>
+    hop !== undefined &&
+    (hop.type === SwapType.Submarine || hop.type === SwapType.Reverse);
+
 export default class Pair {
     private readonly route: Hop[] = [];
     private readonly preOft: OftRoute | undefined;
@@ -194,7 +200,7 @@ export default class Pair {
                     ? Pair.findPair(pairs, routeSource, hopAssetSymbol)
                     : undefined;
 
-            if (hopPair !== undefined && hopAsset !== undefined) {
+            if (canUseRoutedBoltzHop(hopPair) && hopAsset !== undefined) {
                 log.debug(
                     `Found route for ${from} -> ${hopAssetSymbol} -> ${routeTarget}`,
                 );
@@ -229,7 +235,7 @@ export default class Pair {
                     ? Pair.findPair(pairs, hopAssetSymbol, routeTarget)
                     : undefined;
 
-            if (hopPair !== undefined && hopAsset !== undefined) {
+            if (canUseRoutedBoltzHop(hopPair) && hopAsset !== undefined) {
                 log.debug(
                     `Found route for ${from} -> ${hopAssetSymbol} -> ${routeTarget}`,
                 );

--- a/tests/utils/Pair.spec.ts
+++ b/tests/utils/Pair.spec.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "bignumber.js";
 
 import type * as ConfigModule from "../../src/config";
-import { BTC, LN, USDT0 } from "../../src/consts/Assets";
+import { BTC, LBTC, LN, USDT0 } from "../../src/consts/Assets";
 import Pair, { RequiredInput } from "../../src/utils/Pair";
 import type * as BoltzClientModule from "../../src/utils/boltzClient";
 import type { Pairs, QuoteData } from "../../src/utils/boltzClient";
@@ -203,6 +203,41 @@ describe("Pair", () => {
 
     test("should treat unsupported send variants as non-routable", () => {
         const pair = new Pair(pairs, "USDT0-CFX", LN);
+
+        expect(pair.isRoutable).toBe(false);
+        expect(pair.swapToCreate).toBeUndefined();
+        expect(pair.requiredInput).toBe(RequiredInput.Unknown);
+    });
+
+    test("should reject fallback routes that require a chain-swap Boltz hop", () => {
+        const chainOnlyFallbackPairs: Pairs = {
+            ...pairs,
+            chain: {
+                LBTC: {
+                    TBTC: {
+                        hash: "lbtc-tbtc-chain-hop",
+                        rate: 1,
+                        limits: {
+                            maximal: 1_000_000,
+                            minimal: 1,
+                            maximalZeroConf: 0,
+                        },
+                        fees: {
+                            percentage: 0,
+                            minerFees: {
+                                server: 0,
+                                user: {
+                                    claim: 0,
+                                    lockup: 0,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        const pair = new Pair(chainOnlyFallbackPairs, LBTC, USDT0);
 
         expect(pair.isRoutable).toBe(false);
         expect(pair.swapToCreate).toBeUndefined();


### PR DESCRIPTION
So that we can test on mainnet without screwing with the beta deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for multi-hop routing paths. Routes combining chain-based and decentralized exchange swaps will now be correctly rejected if they lack required swap capabilities.
  * Improved routing logic ensures only valid swap combinations are offered to users, preventing impossible routes from being constructed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->