### PR TITLE
fix: sendAmount below minimum value after clicking the "min" button

### DIFF
--- a/src/components/InvoiceInput.tsx
+++ b/src/components/InvoiceInput.tsx
@@ -29,7 +29,6 @@ const InvoiceInput = () => {
         invoice,
         receiveAmount,
         sendAmount,
-        amountValid,
         setAmountChanged,
         setInvoice,
         setInvoiceValid,
@@ -143,7 +142,7 @@ const InvoiceInput = () => {
     };
 
     createEffect(
-        on([amountValid, invoice], async () => {
+        on([invoice, pair, minerFee], async () => {
             if (
                 pair().swapToCreate?.type === SwapType.Submarine ||
                 pair().toAsset === LN


### PR DESCRIPTION
Closes #1272

**Summary**

- Fixes a regression where clicking min on submarine swaps could still result in sendAmount dropping below the minimum.
- Prevents InvoiceInput from re-running invoice validation when only amountValid changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized invoice input validation to prevent unnecessary re-validation cycles, improving performance and reliability of the validation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->