### PR TITLE
fix: increase request timeout value for Tor

### DIFF
--- a/src/alchemy/Alchemy.ts
+++ b/src/alchemy/Alchemy.ts
@@ -5,6 +5,7 @@ import {
     toBeHex,
 } from "ethers";
 
+import { isTor } from "../configs/base";
 import { formatError } from "../utils/errors";
 import { constructRequestOptions } from "../utils/helper";
 
@@ -71,16 +72,19 @@ const requestAlchemy = async <T extends JsonRpcSuccessResponse<unknown>>(
     params: unknown[],
 ): Promise<T> => {
     let response: Response;
-    const { opts, requestTimeout } = constructRequestOptions({
-        method: "POST",
-        headers: alchemyHeaders,
-        body: JSON.stringify({
-            id: jsonRpcId,
-            jsonrpc: jsonRpcVersion,
-            method,
-            params,
-        }),
-    });
+    const { opts, requestTimeout } = constructRequestOptions(
+        {
+            method: "POST",
+            headers: alchemyHeaders,
+            body: JSON.stringify({
+                id: jsonRpcId,
+                jsonrpc: jsonRpcVersion,
+                method,
+                params,
+            }),
+        },
+        isTor() ? 60_000 : undefined,
+    );
 
     try {
         response = await fetch(alchemyUrl(), opts);

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -151,11 +151,13 @@ const defaults = {
     },
 };
 
-const isTor = () => window?.location.hostname.endsWith(".onion");
+const isTor = () =>
+    typeof window !== "undefined" &&
+    window.location.hostname.endsWith(".onion");
 
 const chooseUrl = (url?: Url) =>
     url ? (isTor() && url.tor ? url.tor : url.normal) : undefined;
 
 const baseConfig: Config = defaults;
 
-export { baseConfig, chooseUrl };
+export { baseConfig, chooseUrl, isTor };

--- a/src/utils/fiat.ts
+++ b/src/utils/fiat.ts
@@ -2,13 +2,14 @@ import BigNumber from "bignumber.js";
 import log from "loglevel";
 
 import { config } from "../config";
+import { isTor } from "../configs/base";
 import { BTC } from "../consts/Assets";
 import { Currency } from "../consts/Enums";
 import { satToBtc } from "./denomination";
 import { formatError } from "./errors";
 import { constructRequestOptions } from "./helper";
 
-const requestTimeoutDuration = 6_000;
+const requestTimeoutDuration = isTor() ? 25_000 : 6_000;
 const weiPerEther = BigNumber(10).pow(18);
 
 type KrakenTickerResponse = {

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -2,6 +2,7 @@ import { hex } from "@scure/base";
 import { Buffer } from "buffer";
 
 import { chooseUrl, config } from "../config";
+import { isTor } from "../configs/base";
 import { type AssetType, BTC, LN } from "../consts/Assets";
 import { SwapType } from "../consts/Enums";
 import type { deriveKeyFn } from "../context/Global";
@@ -22,7 +23,7 @@ import {
     isEvmSwap,
 } from "./swapCreator";
 
-export const defaultTimeoutDuration = 15_000;
+export const defaultTimeoutDuration = isTor() ? 45_000 : 15_000;
 
 export const isIos = () =>
     !!navigator.userAgent.match(/iphone|ipad/gi) || false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network reliability for users on Tor by detecting Tor access and automatically using longer request timeouts. Regular connections keep prior timeout behavior, preserving performance. This reduces request failures and improves price and API fetches for privacy-sensitive or slower-network users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->