### PR TITLE
fix: handle auto-claim of already claimed swap

### DIFF
--- a/src/context/Pay.tsx
+++ b/src/context/Pay.tsx
@@ -275,7 +275,7 @@ const PayProvider = (props: { children: JSX.Element }) => {
                     if (vout !== undefined) {
                         try {
                             log.debug(
-                                `checking for spent status of tx ${data.transaction.id}:${vout} from swap ${currentSwap.id}`,
+                                `swap ${currentSwap.id}: checking for spent status of tx output ${data.transaction.id}:${vout}`,
                             );
                             const outspend = await getTransactionOutSpend(
                                 currentSwap.assetReceive,
@@ -285,7 +285,7 @@ const PayProvider = (props: { children: JSX.Element }) => {
 
                             if (outspend?.spent && outspend.txid) {
                                 log.debug(
-                                    `lockup tx from swap ${currentSwap.id} was already claimed, updating claimTx id to ${outspend.txid}`,
+                                    `swap ${currentSwap.id}: lockup tx was already claimed, updating claimTx id to ${outspend.txid}`,
                                 );
                                 currentSwap.claimTx = outspend.txid;
                                 await setSwapStorage(currentSwap);

--- a/src/context/Pay.tsx
+++ b/src/context/Pay.tsx
@@ -12,11 +12,14 @@ import { hiddenInformation } from "src/components/settings/PrivacyMode";
 import { BTC, LBTC } from "src/consts/Assets";
 import { SwapType } from "src/consts/Enums";
 import { swapStatusPending, swapStatusSuccess } from "src/consts/SwapStatus";
+import { getTransactionOutSpend } from "src/utils/blockchain";
 import {
     claim,
     createSubmarineSignature,
     createTheirPartialChainSwapSignature,
+    findSwapOutputVout,
 } from "src/utils/claim";
+import { getTransaction } from "src/utils/compat";
 import { getPair } from "src/utils/helper";
 
 import {
@@ -254,6 +257,41 @@ const PayProvider = (props: { children: JSX.Element }) => {
                     }),
                 );
             } catch (e) {
+                if (
+                    typeof e === "string" &&
+                    e.includes("bad-txns-inputs-missingorspent")
+                ) {
+                    const lockupTx = getTransaction(
+                        currentSwap.assetReceive,
+                    ).fromHex(data.transaction.hex);
+                    const vout = findSwapOutputVout(
+                        deriveKey,
+                        currentSwap as ReverseSwap | ChainSwap,
+                        lockupTx,
+                    );
+
+                    if (vout !== undefined) {
+                        const outspend = await getTransactionOutSpend(
+                            currentSwap.assetReceive,
+                            data.transaction.id,
+                            vout,
+                        );
+
+                        if (outspend?.spent && outspend.txid) {
+                            log.debug(
+                                `tx ${data.transaction.id}:${vout} was already claimed, updating claimTx id to ${outspend.txid}`,
+                            );
+                            currentSwap.claimTx = outspend.txid;
+                            await setSwapStorage(currentSwap);
+                            return;
+                        }
+                    }
+
+                    log.debug(
+                        `got bad-txns-inputs-missingorspent when claiming swap ${currentSwap.id} but tx ${data.transaction.id} is not spent`,
+                    );
+                }
+
                 const msg = t("claim_fail", {
                     id: privacyMode() ? hiddenInformation : currentSwap.id,
                 });

--- a/src/context/Pay.tsx
+++ b/src/context/Pay.tsx
@@ -259,7 +259,9 @@ const PayProvider = (props: { children: JSX.Element }) => {
             } catch (e) {
                 if (
                     typeof e === "string" &&
-                    e.includes("bad-txns-inputs-missingorspent")
+                    (e.includes("bad-txns-inputs-missingorspent") ||
+                        e.includes("Transaction outputs already in utxo set") ||
+                        e.includes("Inputs missing or spent"))
                 ) {
                     const lockupTx = getTransaction(
                         currentSwap.assetReceive,

--- a/src/context/Pay.tsx
+++ b/src/context/Pay.tsx
@@ -271,31 +271,44 @@ const PayProvider = (props: { children: JSX.Element }) => {
                     );
 
                     if (vout !== undefined) {
-                        const outspend = await getTransactionOutSpend(
-                            currentSwap.assetReceive,
-                            data.transaction.id,
-                            vout,
-                        );
-
-                        if (outspend?.spent && outspend.txid) {
+                        try {
                             log.debug(
-                                `tx ${data.transaction.id}:${vout} was already claimed, updating claimTx id to ${outspend.txid}`,
+                                `checking for spent status of tx ${data.transaction.id}:${vout} from swap ${currentSwap.id}`,
                             );
-                            currentSwap.claimTx = outspend.txid;
-                            await setSwapStorage(currentSwap);
-                            return;
+                            const outspend = await getTransactionOutSpend(
+                                currentSwap.assetReceive,
+                                data.transaction.id,
+                                vout,
+                            );
+
+                            if (outspend?.spent && outspend.txid) {
+                                log.debug(
+                                    `lockup tx from swap ${currentSwap.id} was already claimed, updating claimTx id to ${outspend.txid}`,
+                                );
+                                currentSwap.claimTx = outspend.txid;
+                                await setSwapStorage(currentSwap);
+
+                                if (currentSwap.id === swap()?.id) {
+                                    setSwap(currentSwap);
+                                }
+
+                                return;
+                            }
+                            log.debug(
+                                `got bad-txns-inputs-missingorspent when claiming swap ${currentSwap.id} but tx ${data.transaction.id} is not spent`,
+                            );
+                        } catch (e) {
+                            log.error(
+                                `could not check if lockup tx from swap ${currentSwap.id} is spent: ${formatError(e)}`,
+                            );
                         }
                     }
-
-                    log.debug(
-                        `got bad-txns-inputs-missingorspent when claiming swap ${currentSwap.id} but tx ${data.transaction.id} is not spent`,
-                    );
                 }
 
                 const msg = t("claim_fail", {
                     id: privacyMode() ? hiddenInformation : currentSwap.id,
                 });
-                log.warn(msg, e);
+                log.error(msg, e);
                 notify("error", msg);
             } finally {
                 claimingSwaps.delete(swapId);

--- a/src/utils/blockchain.ts
+++ b/src/utils/blockchain.ts
@@ -191,6 +191,17 @@ export const getBlockTipHeight = async (asset: string) => {
     return height;
 };
 
+export const getTransactionOutSpend = async (
+    asset: string,
+    txid: string,
+    vout: number,
+) => {
+    return await fetchBlockExplorer<{ spent: boolean; txid?: string }>(
+        asset,
+        `/tx/${txid}/outspend/${vout}`,
+    );
+};
+
 export const broadcastToExplorer = async (
     asset: string,
     txHex: string,

--- a/src/utils/claim.ts
+++ b/src/utils/claim.ts
@@ -1,6 +1,6 @@
 import { sha256 } from "@noble/hashes/sha2.js";
 import { hex } from "@scure/base";
-import type { ClaimDetails } from "boltz-core";
+import type { ClaimDetails, Musig, Types } from "boltz-core";
 import { OutputType, SwapTreeSerializer, detectSwap } from "boltz-core";
 import type { LiquidClaimDetails } from "boltz-core/liquid";
 import { type Buffer } from "buffer";
@@ -30,29 +30,26 @@ import {
     txToHex,
     txToId,
 } from "./compat";
+import type { ECKeys } from "./ecpair";
 import { parseBlindingKey, parsePrivateKey } from "./helper";
 import { decodeInvoice } from "./invoice";
 import type { ChainSwap, ReverseSwap, SubmarineSwap } from "./swapCreator";
 import { getRelevantAssetForSwap } from "./swapCreator";
 import { createMusig, hashForWitnessV1, tweakMusig } from "./taproot/musig";
 
-type ClaimSwap = ReverseSwap | ChainSwap;
-type ClaimPrivateKey = ReturnType<typeof parsePrivateKey>;
-type ClaimSwapTree = ReturnType<typeof SwapTreeSerializer.deserializeSwapTree>;
-type ClaimKeyAgg = ReturnType<typeof createMusig>;
-type ClaimTweaked = ReturnType<typeof tweakMusig>;
+type ClaimableSwap = ReverseSwap | ChainSwap;
 
 type ClaimTaprootContext = {
-    privateKey: ClaimPrivateKey;
+    privateKey: ECKeys;
     boltzPublicKey: Uint8Array;
-    tree: ClaimSwapTree;
-    keyAgg: ClaimKeyAgg;
-    tweaked: ClaimTweaked;
+    tree: Types.SwapTree;
+    keyAgg: Musig.MusigKeyAgg;
+    tweaked: Musig.MusigKeyAgg;
 };
 
 const getClaimTaprootContext = (
     deriveKey: deriveKeyFn,
-    swap: ClaimSwap,
+    swap: ClaimableSwap,
 ): ClaimTaprootContext => {
     const privateKey = parsePrivateKey(
         deriveKey,
@@ -62,7 +59,7 @@ const getClaimTaprootContext = (
     );
 
     let boltzPublicKey: Uint8Array;
-    let tree: ClaimSwapTree;
+    let tree: ClaimTaprootContext["tree"];
 
     switch (swap.type) {
         case SwapType.Reverse: {
@@ -99,7 +96,7 @@ const getClaimTaprootContext = (
 };
 
 const findSwapOutput = (
-    tweaked: ClaimTweaked,
+    tweaked: ClaimTaprootContext["tweaked"],
     lockupTx: TransactionInterface,
 ) => detectSwap(tweaked.aggPubkey, lockupTx);
 
@@ -108,7 +105,7 @@ const createAdjustedClaim = async <
         | (ClaimDetails & { blindingPrivateKey?: Uint8Array })
         | LiquidClaimDetails,
 >(
-    swap: ClaimSwap,
+    swap: ClaimableSwap,
     claimDetails: T[],
     destination: Uint8Array,
     liquidNetwork?: LiquidNetwork,
@@ -372,7 +369,7 @@ const claimChainSwap = async (
 
 export const findSwapOutputVout = (
     deriveKey: deriveKeyFn,
-    swap: ClaimSwap,
+    swap: ClaimableSwap,
     lockupTx: TransactionInterface,
 ): number | undefined => {
     const { tweaked } = getClaimTaprootContext(deriveKey, swap);

--- a/src/utils/claim.ts
+++ b/src/utils/claim.ts
@@ -36,12 +36,79 @@ import type { ChainSwap, ReverseSwap, SubmarineSwap } from "./swapCreator";
 import { getRelevantAssetForSwap } from "./swapCreator";
 import { createMusig, hashForWitnessV1, tweakMusig } from "./taproot/musig";
 
+type ClaimSwap = ReverseSwap | ChainSwap;
+type ClaimPrivateKey = ReturnType<typeof parsePrivateKey>;
+type ClaimSwapTree = ReturnType<typeof SwapTreeSerializer.deserializeSwapTree>;
+type ClaimKeyAgg = ReturnType<typeof createMusig>;
+type ClaimTweaked = ReturnType<typeof tweakMusig>;
+
+type ClaimTaprootContext = {
+    privateKey: ClaimPrivateKey;
+    boltzPublicKey: Uint8Array;
+    tree: ClaimSwapTree;
+    keyAgg: ClaimKeyAgg;
+    tweaked: ClaimTweaked;
+};
+
+const getClaimTaprootContext = (
+    deriveKey: deriveKeyFn,
+    swap: ClaimSwap,
+): ClaimTaprootContext => {
+    const privateKey = parsePrivateKey(
+        deriveKey,
+        swap.assetReceive as AssetType,
+        swap.claimPrivateKeyIndex,
+        swap.claimPrivateKey,
+    );
+
+    let boltzPublicKey: Uint8Array;
+    let tree: ClaimSwapTree;
+
+    switch (swap.type) {
+        case SwapType.Reverse: {
+            const reverseSwap = swap as ReverseSwap;
+            boltzPublicKey = hex.decode(reverseSwap.refundPublicKey);
+            tree = SwapTreeSerializer.deserializeSwapTree(reverseSwap.swapTree);
+            break;
+        }
+
+        case SwapType.Chain: {
+            const chainSwap = swap as ChainSwap;
+            boltzPublicKey = hex.decode(chainSwap.claimDetails.serverPublicKey);
+            tree = SwapTreeSerializer.deserializeSwapTree(
+                chainSwap.claimDetails.swapTree,
+            );
+            break;
+        }
+
+        default: {
+            throw new Error(`unhandled swap type: ${swap.type as string}`);
+        }
+    }
+
+    const keyAgg = createMusig(privateKey, boltzPublicKey);
+    const tweaked = tweakMusig(swap.assetReceive, keyAgg, tree.tree);
+
+    return {
+        privateKey,
+        boltzPublicKey,
+        tree,
+        keyAgg,
+        tweaked,
+    };
+};
+
+const findSwapOutput = (
+    tweaked: ClaimTweaked,
+    lockupTx: TransactionInterface,
+) => detectSwap(tweaked.aggPubkey, lockupTx);
+
 const createAdjustedClaim = async <
     T extends
         | (ClaimDetails & { blindingPrivateKey?: Uint8Array })
         | LiquidClaimDetails,
 >(
-    swap: ReverseSwap | ChainSwap,
+    swap: ClaimSwap,
     claimDetails: T[],
     destination: Uint8Array,
     liquidNetwork?: LiquidNetwork,
@@ -86,20 +153,12 @@ const claimReverseSwap = async (
     log.info(`Claiming Taproot swap cooperatively: ${cooperative}`);
     const asset = getRelevantAssetForSwap(swap);
 
-    const privateKey = parsePrivateKey(
-        deriveKey,
-        swap.assetReceive as AssetType,
-        swap.claimPrivateKeyIndex,
-        swap.claimPrivateKey,
-    );
+    const { privateKey, boltzPublicKey, tree, keyAgg, tweaked } =
+        getClaimTaprootContext(deriveKey, swap);
     const preimage = hex.decode(swap.preimage);
 
     const decodedAddress = decodeAddress(asset, swap.claimAddress);
-    const boltzPublicKey = hex.decode(swap.refundPublicKey);
-    const keyAgg = createMusig(privateKey, boltzPublicKey);
-    const tree = SwapTreeSerializer.deserializeSwapTree(swap.swapTree);
-    const tweaked = tweakMusig(asset, keyAgg, tree.tree);
-    const swapOutput = detectSwap(tweaked.aggPubkey, lockupTx);
+    const swapOutput = findSwapOutput(tweaked, lockupTx);
 
     if (swapOutput === undefined) {
         throw new Error("Swap output is undefined");
@@ -230,24 +289,15 @@ const claimChainSwap = async (
     cooperative = true,
 ): Promise<TransactionInterface> => {
     log.info(`Claiming Chain swap cooperatively: ${cooperative}`);
-    const boltzRefundPublicKey = hex.decode(swap.claimDetails.serverPublicKey);
-    const claimPrivateKey = parsePrivateKey(
-        deriveKey,
-        swap.assetReceive as AssetType,
-        swap.claimPrivateKeyIndex,
-        swap.claimPrivateKey,
-    );
-    const ourClaimKeyAgg = createMusig(claimPrivateKey, boltzRefundPublicKey);
-    const claimTree = SwapTreeSerializer.deserializeSwapTree(
-        swap.claimDetails.swapTree,
-    );
-    const tweaked = tweakMusig(
-        swap.assetReceive,
-        ourClaimKeyAgg,
-        claimTree.tree,
-    );
+    const {
+        privateKey: claimPrivateKey,
+        boltzPublicKey: boltzRefundPublicKey,
+        tree: claimTree,
+        keyAgg: ourClaimKeyAgg,
+        tweaked,
+    } = getClaimTaprootContext(deriveKey, swap);
 
-    const swapOutput = detectSwap(tweaked.aggPubkey, lockupTx);
+    const swapOutput = findSwapOutput(tweaked, lockupTx);
 
     const details = [
         {
@@ -322,49 +372,11 @@ const claimChainSwap = async (
 
 export const findSwapOutputVout = (
     deriveKey: deriveKeyFn,
-    swap: ReverseSwap | ChainSwap,
+    swap: ClaimSwap,
     lockupTx: TransactionInterface,
 ): number | undefined => {
-    let privateKey: ReturnType<typeof parsePrivateKey>;
-    let boltzPublicKey: Uint8Array;
-    let tree: ReturnType<typeof SwapTreeSerializer.deserializeSwapTree>;
-
-    switch (swap.type) {
-        case SwapType.Reverse: {
-            const reverseSwap = swap as ReverseSwap;
-            privateKey = parsePrivateKey(
-                deriveKey,
-                reverseSwap.assetReceive as AssetType,
-                reverseSwap.claimPrivateKeyIndex,
-                reverseSwap.claimPrivateKey,
-            );
-            boltzPublicKey = hex.decode(reverseSwap.refundPublicKey);
-            tree = SwapTreeSerializer.deserializeSwapTree(reverseSwap.swapTree);
-            break;
-        }
-
-        case SwapType.Chain: {
-            const chainSwap = swap as ChainSwap;
-            privateKey = parsePrivateKey(
-                deriveKey,
-                chainSwap.assetReceive as AssetType,
-                chainSwap.claimPrivateKeyIndex,
-                chainSwap.claimPrivateKey,
-            );
-            boltzPublicKey = hex.decode(chainSwap.claimDetails.serverPublicKey);
-            tree = SwapTreeSerializer.deserializeSwapTree(
-                chainSwap.claimDetails.swapTree,
-            );
-            break;
-        }
-
-        default:
-            throw new Error(`unhandled swap type: ${swap.type as string}`);
-    }
-
-    const keyAgg = createMusig(privateKey, boltzPublicKey);
-    const tweaked = tweakMusig(swap.assetReceive, keyAgg, tree.tree);
-    return detectSwap(tweaked.aggPubkey, lockupTx)?.vout;
+    const { tweaked } = getClaimTaprootContext(deriveKey, swap);
+    return findSwapOutput(tweaked, lockupTx)?.vout;
 };
 
 export const claim = async <T extends ReverseSwap | ChainSwap>(

--- a/src/utils/claim.ts
+++ b/src/utils/claim.ts
@@ -320,6 +320,53 @@ const claimChainSwap = async (
     }
 };
 
+export const findSwapOutputVout = (
+    deriveKey: deriveKeyFn,
+    swap: ReverseSwap | ChainSwap,
+    lockupTx: TransactionInterface,
+): number | undefined => {
+    let privateKey: ReturnType<typeof parsePrivateKey>;
+    let boltzPublicKey: Uint8Array;
+    let tree: ReturnType<typeof SwapTreeSerializer.deserializeSwapTree>;
+
+    switch (swap.type) {
+        case SwapType.Reverse: {
+            const reverseSwap = swap as ReverseSwap;
+            privateKey = parsePrivateKey(
+                deriveKey,
+                reverseSwap.assetReceive as AssetType,
+                reverseSwap.claimPrivateKeyIndex,
+                reverseSwap.claimPrivateKey,
+            );
+            boltzPublicKey = hex.decode(reverseSwap.refundPublicKey);
+            tree = SwapTreeSerializer.deserializeSwapTree(reverseSwap.swapTree);
+            break;
+        }
+
+        case SwapType.Chain: {
+            const chainSwap = swap as ChainSwap;
+            privateKey = parsePrivateKey(
+                deriveKey,
+                chainSwap.assetReceive as AssetType,
+                chainSwap.claimPrivateKeyIndex,
+                chainSwap.claimPrivateKey,
+            );
+            boltzPublicKey = hex.decode(chainSwap.claimDetails.serverPublicKey);
+            tree = SwapTreeSerializer.deserializeSwapTree(
+                chainSwap.claimDetails.swapTree,
+            );
+            break;
+        }
+
+        default:
+            throw new Error(`unhandled swap type: ${swap.type as string}`);
+    }
+
+    const keyAgg = createMusig(privateKey, boltzPublicKey);
+    const tweaked = tweakMusig(swap.assetReceive, keyAgg, tree.tree);
+    return detectSwap(tweaked.aggPubkey, lockupTx)?.vout;
+};
+
 export const claim = async <T extends ReverseSwap | ChainSwap>(
     deriveKey: deriveKeyFn,
     swap: T,

--- a/tests/pages/Pay.spec.tsx
+++ b/tests/pages/Pay.spec.tsx
@@ -1,6 +1,7 @@
 import type * as SolidRouter from "@solidjs/router";
 import { useLocation } from "@solidjs/router";
 import { render, screen, waitFor } from "@solidjs/testing-library";
+import { OutputType } from "boltz-core";
 
 import { BTC, LBTC, LN } from "../../src/consts/Assets";
 import { SwapType } from "../../src/consts/Enums";
@@ -11,16 +12,21 @@ import {
 } from "../../src/consts/SwapStatus";
 import dict from "../../src/i18n/i18n";
 import Pay from "../../src/pages/Pay";
-import { getSwapUTXOs } from "../../src/utils/blockchain";
+import {
+    getSwapUTXOs,
+    getTransactionOutSpend,
+} from "../../src/utils/blockchain";
 import {
     getLockupTransaction,
     getSwapStatus,
 } from "../../src/utils/boltzClient";
+import { claim, findSwapOutputVout } from "../../src/utils/claim";
 import {
     getCurrentBlockHeight,
     getTimeoutEta,
     hasSwapTimedOut,
     isRefundableSwapType,
+    isSwapClaimable,
 } from "../../src/utils/rescue";
 import type {
     ChainSwap,
@@ -29,6 +35,20 @@ import type {
 } from "../../src/utils/swapCreator";
 import { TestComponent } from "../helper";
 import { contextWrapper, globalSignals, payContext } from "../helper";
+
+vi.mock("@solid-primitives/storage", () => ({
+    makePersisted: <T,>(signal: T) => signal,
+}));
+vi.mock("loglevel", () => ({
+    default: {
+        info: vi.fn(),
+        debug: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        rebuild: vi.fn(),
+        methodFactory: vi.fn(),
+    },
+}));
 
 vi.mock("../../src/utils/boltzClient", () => ({
     getSwapStatus: vi.fn(),
@@ -39,12 +59,29 @@ vi.mock("../../src/utils/blockchain", async () => {
     return {
         ...actual,
         getSwapUTXOs: vi.fn(),
+        getTransactionOutSpend: vi.fn(),
+    };
+});
+vi.mock("../../src/utils/claim", () => ({
+    claim: vi.fn(),
+    createSubmarineSignature: vi.fn(),
+    createTheirPartialChainSwapSignature: vi.fn(),
+    findSwapOutputVout: vi.fn(),
+}));
+vi.mock("../../src/utils/compat", async () => {
+    const actual = await vi.importActual("../../src/utils/compat");
+    return {
+        ...actual,
+        getTransaction: vi.fn(() => ({
+            fromHex: vi.fn(() => ({})),
+        })),
     };
 });
 vi.mock("../../src/utils/rescue", () => ({
     getCurrentBlockHeight: vi.fn(),
     getTimeoutEta: vi.fn(),
     hasSwapTimedOut: vi.fn(),
+    isSwapClaimable: vi.fn(),
     isRefundableSwapType: vi.fn(),
 }));
 vi.mock("../../src/components/QrCode", () => ({
@@ -62,18 +99,22 @@ const mockGetTimeoutEta = vi.mocked(getTimeoutEta);
 const mockHasSwapTimedOut = vi.mocked(hasSwapTimedOut);
 const mockIsRefundableSwapType = vi.mocked(isRefundableSwapType);
 
+const { swapsGetItemMock, swapsSetItemMock } = vi.hoisted(() => ({
+    swapsGetItemMock: vi.fn(),
+    swapsSetItemMock: vi.fn(),
+}));
+
 vi.mock("localforage", () => ({
     default: {
+        INDEXEDDB: "INDEXEDDB",
+        LOCALSTORAGE: "LOCALSTORAGE",
         config: vi.fn(),
         createInstance: vi.fn(() => ({
-            getItem: vi.fn().mockResolvedValue({
-                id: "123",
-                type: SwapType.Chain,
-                assetReceive: BTC,
-                assetSend: LBTC,
-                lockupDetails: {},
-            }),
-            iterate: vi.fn(),
+            getItem: swapsGetItemMock,
+            setItem: swapsSetItemMock,
+            removeItem: vi.fn().mockResolvedValue(undefined),
+            clear: vi.fn().mockResolvedValue(undefined),
+            iterate: vi.fn().mockResolvedValue(undefined),
         })),
     },
 }));
@@ -113,7 +154,13 @@ const renderPay = (backupDone: boolean = true) => {
 describe("Pay", () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        localStorage.clear();
+        swapsGetItemMock.mockResolvedValue({
+            id: "123",
+            type: SwapType.Chain,
+            assetReceive: BTC,
+            assetSend: LBTC,
+            lockupDetails: {},
+        });
         mockUseLocation.mockReturnValue({
             hash: "",
             key: "",
@@ -343,5 +390,92 @@ describe("Pay", () => {
             "refundButton",
         )) as HTMLButtonElement;
         expect(button).toBeTruthy();
+    });
+
+    test("should update storage and pay context when claim was already broadcast externally", async () => {
+        const swapFromStorage = {
+            id: "123",
+            type: SwapType.Chain,
+            assetReceive: BTC,
+            assetSend: LBTC,
+            version: OutputType.Taproot,
+            claimTx: undefined,
+            lockupDetails: {},
+        } as unknown as ChainSwap;
+
+        swapsGetItemMock.mockResolvedValue(swapFromStorage);
+        vi.mocked(isSwapClaimable).mockReturnValue(true);
+        vi.mocked(claim).mockRejectedValue(
+            "bad-txns-inputs-missingorspent: mocked rejection",
+        );
+        vi.mocked(findSwapOutputVout).mockReturnValue(0);
+        vi.mocked(getTransactionOutSpend).mockResolvedValue({
+            spent: true,
+            txid: "already-claimed-txid",
+        });
+
+        renderPay();
+        payContext.setSwap({ ...swapFromStorage });
+
+        await payContext.claimSwap("123", {
+            id: "123",
+            status: swapStatusPending.TransactionMempool,
+            transaction: {
+                id: "lockup-txid",
+                hex: "00",
+            },
+        });
+
+        await waitFor(() => {
+            expect(swapsSetItemMock).toHaveBeenCalledWith(
+                "123",
+                expect.objectContaining({
+                    claimTx: "already-claimed-txid",
+                }),
+            );
+            expect(payContext.swap()?.claimTx).toBe("already-claimed-txid");
+        });
+    });
+
+    test("should still show claim failure when outspend lookup throws", async () => {
+        const swapFromStorage = {
+            id: "123",
+            type: SwapType.Chain,
+            assetReceive: BTC,
+            assetSend: LBTC,
+            version: OutputType.Taproot,
+            claimTx: undefined,
+            lockupDetails: {},
+        } as unknown as ChainSwap;
+
+        swapsGetItemMock.mockResolvedValue(swapFromStorage);
+        vi.mocked(isSwapClaimable).mockReturnValue(true);
+        vi.mocked(claim).mockRejectedValue(
+            "bad-txns-inputs-missingorspent: mocked rejection",
+        );
+        vi.mocked(findSwapOutputVout).mockReturnValue(0);
+        vi.mocked(getTransactionOutSpend).mockRejectedValue(
+            new Error("network error"),
+        );
+
+        renderPay();
+        payContext.setSwap({ ...swapFromStorage });
+
+        await payContext.claimSwap("123", {
+            id: "123",
+            status: swapStatusPending.TransactionMempool,
+            transaction: {
+                id: "lockup-txid",
+                hex: "00",
+            },
+        });
+
+        await waitFor(() => {
+            expect(globalSignals.notificationType()).toBe("error");
+            expect(swapsSetItemMock).not.toHaveBeenCalledWith(
+                "123",
+                expect.objectContaining({ claimTx: expect.any(String) }),
+            );
+        });
     });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cooperative-claim recovery: when a swap lockup output is already spent the app records the spend, updates stored claim transaction info, and avoids showing duplicate claim-failure UI.

* **New Features**
  * Added on-chain output spend detection to determine whether a swap output was spent and act accordingly.

* **Tests**
  * Added tests covering claim-failure recovery, persistence updates, and error-notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->