### PR TITLE
chore: disable usdt0 swaps on tor

### DIFF
--- a/src/context/Create.tsx
+++ b/src/context/Create.tsx
@@ -12,13 +12,16 @@ import {
 import type { Accessor, JSX, Setter } from "solid-js";
 
 import { config } from "../config";
+import { isTor } from "../configs/base";
 import {
     type AssetType,
     BTC,
     LBTC,
     LN,
+    TBTC,
     assets,
     isBitcoinOnlyPair,
+    isUsdt0Asset,
 } from "../consts/Assets";
 import { type AssetSelection, Side, UrlParam } from "../consts/Enums";
 import type { DictKey } from "../i18n/i18n";
@@ -135,7 +138,9 @@ const setDestination = (
 };
 
 const isValidAsset = (asset: string) =>
-    urlParamIsSet(asset) && assets.includes(asset);
+    urlParamIsSet(asset) &&
+    assets.includes(asset) &&
+    !(isTor() && (asset === TBTC || isUsdt0Asset(asset)));
 
 const parseAmount = (amount: string): BigNumber | undefined => {
     if (!urlParamIsSet(amount)) {

--- a/src/utils/Pair.ts
+++ b/src/utils/Pair.ts
@@ -3,10 +3,12 @@ import { ZeroAddress } from "ethers";
 import log from "loglevel";
 
 import { config } from "../config";
+import { isTor } from "../configs/base";
 import {
     AssetKind,
     BTC,
     LN,
+    TBTC,
     USDT0,
     getCanonicalAsset,
     getUsdt0Mesh,
@@ -140,6 +142,17 @@ export default class Pair {
     ) {
         if (config.assets[from]?.canSend === false) {
             log.info(`Send asset ${from} is not allowed`);
+            return;
+        }
+
+        if (
+            isTor() &&
+            (from === TBTC ||
+                to === TBTC ||
+                isUsdt0Asset(from) ||
+                isUsdt0Asset(to))
+        ) {
+            log.info("TBTC and USDT0 pairs are disabled on Tor");
             return;
         }
 

--- a/src/utils/selectableAsset.ts
+++ b/src/utils/selectableAsset.ts
@@ -1,4 +1,6 @@
 import { config } from "../config";
+import { isTor } from "../configs/base";
+import { TBTC, USDT0, isUsdt0Variant } from "../consts/Assets";
 import { Side } from "../consts/Enums";
 
 export const canSendAsset = (asset: string) =>
@@ -7,4 +9,13 @@ export const canSendAsset = (asset: string) =>
 export const canSelectAsset = (
     selectedSide: Side | string | null | undefined,
     asset: string,
-) => selectedSide !== Side.Send || canSendAsset(asset);
+) => {
+    if (
+        isTor() &&
+        (asset === TBTC || asset === USDT0 || isUsdt0Variant(asset))
+    ) {
+        return false;
+    }
+
+    return selectedSide !== Side.Send || canSendAsset(asset);
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tor mode compatibility by restricting USDT0 asset selection and trading pairs when Tor is enabled.
  * URL parameters containing USDT0 assets are now properly ignored in Tor mode to prevent misconfigurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->