### PR TITLE
feat: show "invalid send asset" for a more specific error for unsendable assets

### DIFF
--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -53,6 +53,7 @@ import {
 import { findMagicRoutingHint } from "../utils/magicRoutingHint";
 import { firstResolved, promiseWithTimeout } from "../utils/promise";
 import { gasTopUpSupported } from "../utils/qouter";
+import { canSendAsset } from "../utils/selectableAsset";
 import {
     type GasAbstraction,
     GasAbstractionType,
@@ -280,7 +281,11 @@ const CreateButton = () => {
                     return;
                 }
                 if (!pair().isRoutable) {
-                    setButtonLabel({ key: "invalid_pair" });
+                    if (!canSendAsset(pair().fromAsset)) {
+                        setButtonLabel({ key: "invalid_send_asset" });
+                    } else {
+                        setButtonLabel({ key: "invalid_pair" });
+                    }
                     return;
                 }
 

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -219,6 +219,7 @@ const dict = {
         on: "on",
         off: "off",
         invalid_pair: "Invalid pair",
+        invalid_send_asset: "Invalid send asset",
         error_starting_qr_scanner:
             "Couldn't access camera, please check permissions!",
         insufficient_balance: "Insufficient balance",
@@ -712,6 +713,7 @@ const dict = {
         on: "an",
         off: "aus",
         invalid_pair: "Ungültiges Paar",
+        invalid_send_asset: "Ungültiges Sende-Asset",
         error_starting_qr_scanner:
             "Konnte nicht auf Kamera zugreifen, bitte Berechtigungen überprüfen!",
         insufficient_balance: "Unzureichendes Guthaben",
@@ -1214,6 +1216,7 @@ const dict = {
         on: "on",
         off: "off",
         invalid_pair: "Par no válido",
+        invalid_send_asset: "Activo de envío no válido",
         error_starting_qr_scanner:
             "No se pudo acceder a la cámara, por favor comprueba los permisos!",
         insufficient_balance: "Saldo insuficiente",
@@ -1711,6 +1714,7 @@ const dict = {
         on: "on",
         off: "off",
         invalid_pair: "Par inválido",
+        invalid_send_asset: "Ativo de envio inválido",
         error_starting_qr_scanner:
             "Não foi possível acessar a câmera, verifique as permissões!",
         insufficient_balance: "Saldo insuficiente",
@@ -2183,6 +2187,7 @@ const dict = {
         on: "开",
         off: "关",
         invalid_pair: "无效交换对",
+        invalid_send_asset: "无效发送资产",
         error_starting_qr_scanner: "无法访问摄像头, 请检查权限！",
         insufficient_balance: "余额不足",
         insufficient_balance_line: "您的钱包余额不足以进行此次交换。",
@@ -2652,6 +2657,7 @@ const dict = {
         on: "オン",
         off: "オフ",
         invalid_pair: "無効なペア",
+        invalid_send_asset: "無効な送信アセット",
         error_starting_qr_scanner:
             "カメラにアクセスできませんでした。権限を確認してください！",
         insufficient_balance: "残高不足",

--- a/tests/components/CreateButton.spec.tsx
+++ b/tests/components/CreateButton.spec.tsx
@@ -580,7 +580,7 @@ describe("CreateButton", () => {
         await waitFor(() => {
             expect(signals.valid()).toBe(false);
             expect(btn.disabled).toBe(true);
-            expect(btn.textContent).toBe(i18n.en.invalid_pair);
+            expect(btn.textContent).toBe(i18n.en.invalid_send_asset);
         });
     });
 


### PR DESCRIPTION
As unsendable assets can end up in the sendAsset box via the swap direction switch but blocking the switch in these cases is uncommon UX, we decided to give a clearer error message instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced asset validation with improved error messaging that specifically indicates when an asset cannot be sent, providing users with more precise and actionable feedback compared to previous generic error notifications. Translations are now available in English, German, Spanish, Portuguese, Chinese, and Japanese to support diverse user bases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->