### PR TITLE
fix: add check for solana rent exempt balance

### DIFF
--- a/e2e/evm/rsk.spec.ts
+++ b/e2e/evm/rsk.spec.ts
@@ -352,11 +352,9 @@ test.describe("EVM", () => {
 
         await verifyRescueFile(page);
 
-        await expect(
-            page.locator("div[data-status='invoice.set']"),
-        ).toBeVisible();
-
-        await page.getByRole("button", { name: "Send" }).click();
+        await page
+            .getByRole("button", { name: "Send" })
+            .click({ timeout: 30_000 });
 
         const settled = page.locator("div[data-status='invoice.settled']");
         const claimPending = page.locator(
@@ -409,11 +407,9 @@ test.describe("EVM", () => {
 
         await verifyRescueFile(page);
 
-        await expect(
-            page.locator("div[data-status='invoice.set']"),
-        ).toBeVisible();
-
-        await page.getByRole("button", { name: "Send" }).click();
+        await page
+            .getByRole("button", { name: "Send" })
+            .click({ timeout: 30_000 });
 
         await expect(
             page.getByText(dict.en.invoice_payment_failure),

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -256,16 +256,29 @@ export const getBolt12Offer = async (): Promise<string> => {
 };
 
 export const verifyRescueFile = async (page: Page) => {
-    const downloadPromise = page.waitForEvent("download");
-    await page.getByRole("button", { name: dict.en.download_new_key }).click();
+    let fileName: string | undefined;
 
-    const fileName = "rescue-file.json";
-    await (await downloadPromise).saveAs(fileName);
+    try {
+        const downloadButton = page.getByRole("button", {
+            name: dict.en.download_new_key,
+        });
+        await expect(downloadButton).toBeVisible({ timeout: 60_000 });
 
-    await page.getByTestId("rescueFileUpload").setInputFiles(fileName);
+        const downloadPromise = page.waitForEvent("download");
+        await downloadButton.click();
 
-    if (fs.existsSync(fileName)) {
-        fs.unlinkSync(fileName);
+        fileName = `rescue-file-${randomBytes(4).toString("hex")}.json`;
+        await (await downloadPromise).saveAs(fileName);
+
+        const rescueFileUpload = page.getByTestId("rescueFileUpload");
+        await expect(rescueFileUpload).toBeVisible({ timeout: 30_000 });
+        await rescueFileUpload.setInputFiles(fileName);
+
+        await expect(rescueFileUpload).toBeHidden({ timeout: 30_000 });
+    } finally {
+        if (fileName !== undefined && fs.existsSync(fileName)) {
+            fs.unlinkSync(fileName);
+        }
     }
 };
 

--- a/src/components/SendToOft.tsx
+++ b/src/components/SendToOft.tsx
@@ -28,9 +28,9 @@ import {
 } from "../utils/oft/directSend";
 import {
     createOftContract,
-    getBufferedOftNativeFee,
     getOftTransport,
     getQuotedOftContract,
+    getRequiredSolanaOftNativeBalance,
     getSolanaOftTokenBalance,
     quoteOftSend,
 } from "../utils/oft/oft";
@@ -247,11 +247,15 @@ const SendToOft = (props: {
 
     const refreshSolanaOftSendState = async (walletAddress: string) => {
         const { oftRoute, msgFee } = await quoteOftSendState(getOftRecipient());
-        const [balance, nativeBalance] = await Promise.all([
-            getSolanaOftTokenBalance(oftRoute, walletAddress),
-            getSolanaBalance(props.oft.sourceAsset, walletAddress),
-        ]);
-        const requiredNativeBalance = getBufferedOftNativeFee(msgFee[0]);
+        const [balance, nativeBalance, requiredNativeBalance] =
+            await Promise.all([
+                getSolanaOftTokenBalance(oftRoute, walletAddress),
+                getSolanaBalance(props.oft.sourceAsset, walletAddress),
+                getRequiredSolanaOftNativeBalance(
+                    props.oft.sourceAsset,
+                    msgFee[0],
+                ),
+            ]);
         const hasEnoughTokenBalance = balance >= props.amount;
         const hasEnoughNativeBalanceForMsgFee =
             nativeBalance >= requiredNativeBalance;

--- a/src/utils/chains/solana.ts
+++ b/src/utils/chains/solana.ts
@@ -12,11 +12,13 @@ import { constructRequestOptions } from "../helper";
 import { requireRpcUrls } from "../provider";
 
 export const solanaAddressLength = 32;
+export const solanaTokenAccountSize = 165;
 export const solanaAtaRentExemptLamports = 2_039_280n;
 const solanaGetAccountInfoMethod = "getAccountInfo";
 const solanaRpcProbeTimeout = 5_000;
 const solanaTokenAccountExistsCache = new Set<string>();
 const solanaConnectionCache = new Map<string, Promise<Connection>>();
+const solanaRentExemptBalanceCache = new Map<string, Promise<bigint>>();
 
 export const decodeSolanaAddress = (address: string): Uint8Array => {
     const decoded = base58.decode(address);
@@ -48,6 +50,10 @@ export const clearSolanaTokenAccountCreationCache = () => {
 
 export const clearSolanaConnectionCache = () => {
     solanaConnectionCache.clear();
+};
+
+export const clearSolanaRentExemptBalanceCache = () => {
+    solanaRentExemptBalanceCache.clear();
 };
 
 export const getConnectedSolanaWalletAddress = async (
@@ -171,6 +177,34 @@ export const getSolanaNativeBalance = async (
     return BigInt(
         await connection.getBalance(new web3.PublicKey(ownerAddress)),
     );
+};
+
+export const getSolanaRentExemptMinimumBalance = async (
+    sourceAsset: string,
+    accountSize: number,
+): Promise<bigint> => {
+    const cacheKey = `${sourceAsset}:${accountSize}`;
+    const cached = solanaRentExemptBalanceCache.get(cacheKey);
+    if (cached !== undefined) {
+        return await cached;
+    }
+
+    const created = getSolanaConnection(sourceAsset)
+        .then(async (connection) =>
+            BigInt(
+                await connection.getMinimumBalanceForRentExemption(
+                    accountSize,
+                    "confirmed",
+                ),
+            ),
+        )
+        .catch((error: unknown) => {
+            solanaRentExemptBalanceCache.delete(cacheKey);
+            throw error;
+        });
+    solanaRentExemptBalanceCache.set(cacheKey, created);
+
+    return await created;
 };
 
 const queryShouldCreateSolanaTokenAccount = async (

--- a/src/utils/oft/oft.ts
+++ b/src/utils/oft/oft.ts
@@ -22,8 +22,10 @@ import {
     clearSolanaTokenAccountCreationCache,
     encodeSolanaAtaCreationOption,
     encodeSolanaRecipient,
+    getSolanaRentExemptMinimumBalance,
     getSolanaTransactionSender,
     shouldCreateSolanaTokenAccount,
+    solanaTokenAccountSize,
 } from "../chains/solana";
 import { decodeTronBase58Address } from "../chains/tron";
 import {
@@ -429,6 +431,19 @@ const getLegacyMeshSourceAmount = (destinationAmount: bigint): bigint => {
 
 export const getBufferedOftNativeFee = (nativeFee: bigint): bigint =>
     (nativeFee * 110n) / 100n;
+
+export const getRequiredSolanaOftNativeBalance = async (
+    sourceAsset: string,
+    nativeFee: bigint,
+): Promise<bigint> => {
+    const bufferedFee = getBufferedOftNativeFee(nativeFee);
+    const rentExemptMinimum = await getSolanaRentExemptMinimumBalance(
+        sourceAsset,
+        solanaTokenAccountSize,
+    );
+
+    return bufferedFee > rentExemptMinimum ? bufferedFee : rentExemptMinimum;
+};
 
 const createOftSendParam = async (
     route: OftRoute,

--- a/tests/utils/chains/solana.spec.ts
+++ b/tests/utils/chains/solana.spec.ts
@@ -5,8 +5,11 @@ import { config as runtimeConfig } from "../../../src/config";
 import { config as mainnetConfig } from "../../../src/configs/mainnet";
 import lazySolana from "../../../src/lazy/solana";
 import {
+    clearSolanaConnectionCache,
+    clearSolanaRentExemptBalanceCache,
     clearSolanaTokenAccountCreationCache,
     decodeSolanaAddress,
+    getSolanaRentExemptMinimumBalance,
     isValidSolanaAddress,
     shouldCreateSolanaTokenAccount,
 } from "../../../src/utils/chains/solana";
@@ -28,6 +31,8 @@ beforeAll(() => {
 afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    clearSolanaConnectionCache();
+    clearSolanaRentExemptBalanceCache();
     clearSolanaTokenAccountCreationCache();
 });
 
@@ -118,6 +123,39 @@ test("should not cache true ATA creation results", async () => {
     ).resolves.toBe(true);
 
     expect(fetchSpy).toHaveBeenCalledTimes(2);
+});
+
+test("should query and cache Solana rent-exempt minimum balances", async () => {
+    const mockGetMinimumBalanceForRentExemption = vi
+        .fn()
+        .mockResolvedValue(2_039_280);
+    const mockGetVersion = vi
+        .fn()
+        .mockResolvedValue({ "solana-core": "2.1.0" });
+
+    vi.spyOn(lazySolana, "get").mockResolvedValue({
+        web3: {
+            Connection: class {
+                getVersion = mockGetVersion;
+                getMinimumBalanceForRentExemption =
+                    mockGetMinimumBalanceForRentExemption;
+            },
+        },
+    } as never);
+
+    await expect(
+        getSolanaRentExemptMinimumBalance("USDT0-SOL", 165),
+    ).resolves.toBe(2_039_280n);
+    await expect(
+        getSolanaRentExemptMinimumBalance("USDT0-SOL", 165),
+    ).resolves.toBe(2_039_280n);
+
+    expect(mockGetVersion).toHaveBeenCalledTimes(1);
+    expect(mockGetMinimumBalanceForRentExemption).toHaveBeenCalledTimes(1);
+    expect(mockGetMinimumBalanceForRentExemption).toHaveBeenCalledWith(
+        165,
+        "confirmed",
+    );
 });
 
 test("should detect live Solana USDT ATA creation requirements on mainnet", async () => {

--- a/tests/utils/oft.spec.ts
+++ b/tests/utils/oft.spec.ts
@@ -4,9 +4,24 @@ import { base58, hex } from "@scure/base";
 import { config as runtimeConfig } from "../../src/config";
 import { NetworkTransport } from "../../src/configs/base";
 import { config as mainnetConfig } from "../../src/configs/mainnet";
+import type * as SolanaChainsModule from "../../src/utils/chains/solana";
+
+vi.mock("../../src/utils/chains/solana", async () => {
+    const actual = await vi.importActual<typeof SolanaChainsModule>(
+        "../../src/utils/chains/solana",
+    );
+
+    return {
+        ...actual,
+        getSolanaRentExemptMinimumBalance: vi.fn(
+            actual.getSolanaRentExemptMinimumBalance,
+        ),
+    };
+});
 
 const {
     decodeExecutorNativeAmountExceedsCapError,
+    getRequiredSolanaOftNativeBalance,
     getOftReceivedEventByGuid,
     isExecutorNativeAmountExceedsCapError,
     quoteOftAmountInForAmountOut,
@@ -16,7 +31,7 @@ const {
 const { getOftContract } = await import("../../src/utils/oft/registry");
 const { getSolanaOftGuidFromLogs: getSolanaOftSentEventFromTransaction } =
     await import("../../src/utils/oft/solana");
-const { shouldCreateSolanaTokenAccount } =
+const { getSolanaRentExemptMinimumBalance, shouldCreateSolanaTokenAccount } =
     await import("../../src/utils/chains/solana");
 
 const getOftRoute = (from: string, to = from) => ({
@@ -219,6 +234,22 @@ describe("oft", () => {
 
         msgFee[0] = 6n;
         expect(msgFee[0]).toBe(6n);
+    });
+
+    test("should use the higher of the buffered Solana OFT fee or ATA rent", async () => {
+        vi.mocked(getSolanaRentExemptMinimumBalance).mockResolvedValue(
+            2_039_280n,
+        );
+        await expect(
+            getRequiredSolanaOftNativeBalance("USDT0-SOL", 1_000_000n),
+        ).resolves.toBe(2_039_280n);
+        await expect(
+            getRequiredSolanaOftNativeBalance("USDT0-SOL", 3_000_000n),
+        ).resolves.toBe(3_300_000n);
+        expect(getSolanaRentExemptMinimumBalance).toHaveBeenCalledWith(
+            "USDT0-SOL",
+            165,
+        );
     });
 
     test("should resolve legacy mesh assets by configured endpoint id", async () => {


### PR DESCRIPTION
Closes https://github.com/BoltzExchange/boltz-web-app/issues/1336

There's a minimum required balance for the account to interact with the
token programs, which as of now, is higher than the oft native fee,
which allowed an edge case where our balance check passes but the
transaction still fails.

Also update the rent exempt amount to be fetched from the mainnet rpc
since rent policy can change in the future


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate native balance checks for Solana OFT sends to prevent failed transactions due to rent-exempt requirements.

* **Performance**
  * Cached Solana rent-exempt balance lookups to reduce RPC calls and speed transaction preparation.

* **Tests**
  * Expanded unit and integration tests around balance calculations and caching.

* **Stability**
  * Improved end-to-end rescue file download/upload handling and UI synchronization for more reliable flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->