### PR TITLE
fix: block 0 amount receive

### DIFF
--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -306,6 +306,14 @@ const CreateButton = () => {
                         swapType() !== SwapType.Submarine);
 
                 if (shouldShowAmountError()) {
+                    if (
+                        sendAmount().isGreaterThan(0) &&
+                        receiveAmount().isZero()
+                    ) {
+                        setButtonLabel({ key: "error_zero_quote" });
+                        return;
+                    }
+
                     const lessThanMin = Number(sendAmount()) < minimum();
                     setButtonLabel({
                         key: lessThanMin ? "minimum_amount" : "maximum_amount",

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -706,8 +706,7 @@ const dict = {
         retry: "Erneut versuchen",
         error_no_quote:
             "Ein Angebot konnte nicht abgerufen werden. Bitte prüfe deine Verbindung und versuche es erneut.",
-        error_zero_quote:
-            "Der angezeigte Empfangsbetrag ist null. Bitte erhöhe den Sendebetrag und versuche es erneut.",
+        error_zero_quote: "Sendebetrag erhöhen",
         waiting_for_oft: "Warte auf OFT",
         dex_quote_changed: "DEX-Kurs hat sich geändert",
         zero_conf: "Zero-Conf",
@@ -1211,8 +1210,7 @@ const dict = {
         retry: "Reintentar",
         error_no_quote:
             "No se pudo obtener una cotización. Por favor, verifique su conexión e inténtelo de nuevo.",
-        error_zero_quote:
-            "La cantidad cotizada a recibir es cero. Aumente la cantidad a enviar y vuelva a intentarlo.",
+        error_zero_quote: "Aumenta la cantidad a enviar",
         waiting_for_oft: "Esperando OFT",
         dex_quote_changed: "La cotización de DEX ha cambiado",
         zero_conf: "Zero-Conf",
@@ -1711,8 +1709,7 @@ const dict = {
         retry: "Tentar novamente",
         error_no_quote:
             "Não foi possível obter uma cotação. Por favor, verifique sua conexão e tente novamente.",
-        error_zero_quote:
-            "O valor cotado para receber é zero. Aumente o valor a enviar e tente novamente.",
+        error_zero_quote: "Aumente o valor a enviar",
         waiting_for_oft: "Aguardando OFT",
         dex_quote_changed: "A cotação da DEX mudou",
         zero_conf: "Zero-Conf",
@@ -2187,7 +2184,7 @@ const dict = {
         legacy_mesh_fee_label: "Legacy Mesh 费用",
         retry: "重试",
         error_no_quote: "无法获取报价。请检查您的网络连接并重试。",
-        error_zero_quote: "报价的接收金额为零。请提高发送金额后重试。",
+        error_zero_quote: "提高发送金额",
         waiting_for_oft: "等待 OFT",
         dex_quote_changed: "DEX 报价已变更",
         zero_conf: "零确认",
@@ -2658,8 +2655,7 @@ const dict = {
         retry: "再試行",
         error_no_quote:
             "見積もりを取得できませんでした。接続を確認してもう一度お試しください。",
-        error_zero_quote:
-            "見積もりの受取額が0です。送信額を増やしてもう一度お試しください。",
+        error_zero_quote: "送信額を増やす",
         waiting_for_oft: "OFTを待機中",
         dex_quote_changed: "DEXのクオートが変更されました",
         zero_conf: "ゼロ確認",

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -211,6 +211,7 @@ const dict = {
         retry: "Retry",
         error_no_quote:
             "A quote could not be obtained. Please check your connection and try again.",
+        error_zero_quote: "Increase send amount",
         waiting_for_oft: "Waiting for OFT",
         dex_quote_changed: "DEX quote has changed",
         zero_conf: "Zero-Conf",
@@ -705,6 +706,8 @@ const dict = {
         retry: "Erneut versuchen",
         error_no_quote:
             "Ein Angebot konnte nicht abgerufen werden. Bitte prüfe deine Verbindung und versuche es erneut.",
+        error_zero_quote:
+            "Der angezeigte Empfangsbetrag ist null. Bitte erhöhe den Sendebetrag und versuche es erneut.",
         waiting_for_oft: "Warte auf OFT",
         dex_quote_changed: "DEX-Kurs hat sich geändert",
         zero_conf: "Zero-Conf",
@@ -1208,6 +1211,8 @@ const dict = {
         retry: "Reintentar",
         error_no_quote:
             "No se pudo obtener una cotización. Por favor, verifique su conexión e inténtelo de nuevo.",
+        error_zero_quote:
+            "La cantidad cotizada a recibir es cero. Aumente la cantidad a enviar y vuelva a intentarlo.",
         waiting_for_oft: "Esperando OFT",
         dex_quote_changed: "La cotización de DEX ha cambiado",
         zero_conf: "Zero-Conf",
@@ -1706,6 +1711,8 @@ const dict = {
         retry: "Tentar novamente",
         error_no_quote:
             "Não foi possível obter uma cotação. Por favor, verifique sua conexão e tente novamente.",
+        error_zero_quote:
+            "O valor cotado para receber é zero. Aumente o valor a enviar e tente novamente.",
         waiting_for_oft: "Aguardando OFT",
         dex_quote_changed: "A cotação da DEX mudou",
         zero_conf: "Zero-Conf",
@@ -2180,6 +2187,7 @@ const dict = {
         legacy_mesh_fee_label: "Legacy Mesh 费用",
         retry: "重试",
         error_no_quote: "无法获取报价。请检查您的网络连接并重试。",
+        error_zero_quote: "报价的接收金额为零。请提高发送金额后重试。",
         waiting_for_oft: "等待 OFT",
         dex_quote_changed: "DEX 报价已变更",
         zero_conf: "零确认",
@@ -2650,6 +2658,8 @@ const dict = {
         retry: "再試行",
         error_no_quote:
             "見積もりを取得できませんでした。接続を確認してもう一度お試しください。",
+        error_zero_quote:
+            "見積もりの受取額が0です。送信額を増やしてもう一度お試しください。",
         waiting_for_oft: "OFTを待機中",
         dex_quote_changed: "DEXのクオートが変更されました",
         zero_conf: "ゼロ確認",

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -498,6 +498,12 @@ const Create = () => {
             return;
         }
 
+        if (amount > 0 && receiveAmount().isZero()) {
+            setCustomValidity(t("error_zero_quote"), false);
+            setAmountValid(false);
+            return;
+        }
+
         const lessThanMin = amount < minimum();
 
         if (lessThanMin || amount > maximum()) {

--- a/tests/pages/Create.spec.tsx
+++ b/tests/pages/Create.spec.tsx
@@ -350,6 +350,66 @@ describe("Create", () => {
         }
     });
 
+    test("should block creation when a routed quote resolves to zero", async () => {
+        vi.useFakeTimers();
+
+        try {
+            render(
+                () => (
+                    <>
+                        <TestComponent />
+                        <Create />
+                    </>
+                ),
+                {
+                    wrapper: contextWrapper,
+                },
+            );
+
+            globalSignals.setOnline(true);
+            globalSignals.setPairs(pairs);
+            setPairAssets("USDT0-SOL", BTC);
+
+            const currentPair = signals.pair();
+            Object.defineProperty(currentPair, "needsNetworkForQuote", {
+                configurable: true,
+                get: () => true,
+            });
+            currentPair.calculateReceiveAmount = vi
+                .fn(() => Promise.resolve(BigNumber(0)))
+                .mockName("calculateReceiveAmount");
+
+            signals.setAddressValid(true);
+            signals.setOnchainAddress(
+                "bcrt1q7vq47xpsg4t080205edaulc3sdsjpdxy9svhr3",
+            );
+
+            fireEvent.input(await screen.findByTestId("sendAmount"), {
+                target: { value: "100000" },
+            });
+
+            await flushQuoteDebounce();
+
+            await waitFor(() => {
+                expect(currentPair.calculateReceiveAmount).toHaveBeenCalled();
+            });
+
+            const button = (await screen.findByTestId(
+                "create-swap-button",
+            )) as HTMLButtonElement;
+
+            vi.useRealTimers();
+
+            await waitFor(() => {
+                expect(signals.amountValid()).toBe(false);
+                expect(button.disabled).toBe(true);
+                expect(button.textContent).toBe(i18n.en.error_zero_quote);
+            });
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     test("should update receive amount on asset change", async () => {
         render(
             () => (
@@ -626,9 +686,7 @@ describe("Create", () => {
 
         await waitFor(() => {
             expect(createButton.disabled).toEqual(true);
-            expect(createButton.textContent).toEqual(
-                "Minimum amount is 50 000 sats",
-            );
+            expect(createButton.textContent).toEqual(i18n.en.error_zero_quote);
         });
     });
 


### PR DESCRIPTION
closes: https://github.com/BoltzExchange/boltz-web-app/issues/1333


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation to prevent swap creation when a send amount is entered but the quoted receive amount is zero, with a clear error message prompting users to increase the send amount.

* **Localization**
  * Added translated error message across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->