### PR TITLE
chore: optimize solana rpc calls

### DIFF
--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,62 @@
+type CacheOptions<T> = {
+    shouldRetain?: (value: T) => boolean;
+};
+
+const entries = new Map<string, unknown>();
+
+const cacheAsyncValue = async <T>(
+    key: string,
+    value: Promise<T>,
+    { shouldRetain }: CacheOptions<T>,
+): Promise<T> => {
+    try {
+        const resolved = await value;
+        if (shouldRetain?.(resolved) === false) {
+            entries.delete(key);
+        }
+
+        return resolved;
+    } catch (error: unknown) {
+        entries.delete(key);
+        throw error;
+    }
+};
+
+export function getCachedValue<T>(
+    prefix: string,
+    key: string,
+    create: () => T,
+    options?: CacheOptions<T>,
+): T;
+export function getCachedValue<T>(
+    prefix: string,
+    key: string,
+    create: () => T | Promise<T>,
+    options: CacheOptions<T> = {},
+): T | Promise<T> {
+    const entryKey = `${prefix}${key}`;
+
+    if (entries.has(entryKey)) {
+        return entries.get(entryKey) as T | Promise<T>;
+    }
+
+    const created = create();
+    if (created instanceof Promise) {
+        const cached = cacheAsyncValue(entryKey, created, options);
+        entries.set(entryKey, cached);
+
+        return cached;
+    }
+
+    if (options.shouldRetain?.(created) === false) {
+        return created;
+    }
+
+    entries.set(entryKey, created);
+
+    return created;
+}
+
+export const clearCache = () => {
+    entries.clear();
+};

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -26,29 +26,27 @@ export function getCachedValue<T>(
     prefix: string,
     key: string,
     create: () => T,
-    options?: CacheOptions<T>,
-): T;
-export function getCachedValue<T>(
-    prefix: string,
-    key: string,
-    create: () => T | Promise<T>,
-    options: CacheOptions<T> = {},
-): T | Promise<T> {
+    options: CacheOptions<Awaited<T>> = {},
+): T {
     const entryKey = `${prefix}${key}`;
 
     if (entries.has(entryKey)) {
-        return entries.get(entryKey) as T | Promise<T>;
+        return entries.get(entryKey) as T;
     }
 
     const created = create();
     if (created instanceof Promise) {
-        const cached = cacheAsyncValue(entryKey, created, options);
+        const cached = cacheAsyncValue(
+            entryKey,
+            created as Promise<Awaited<T>>,
+            options,
+        ) as T;
         entries.set(entryKey, cached);
 
         return cached;
     }
 
-    if (options.shouldRetain?.(created) === false) {
+    if (options.shouldRetain?.(created as Awaited<T>) === false) {
         return created;
     }
 

--- a/src/utils/chains/solana.ts
+++ b/src/utils/chains/solana.ts
@@ -8,17 +8,83 @@ import { config } from "../../config";
 import { NetworkTransport } from "../../configs/base";
 import lazySolana from "../../lazy/solana";
 import { formatError } from "../errors";
-import { constructRequestOptions } from "../helper";
 import { requireRpcUrls } from "../provider";
 
 export const solanaAddressLength = 32;
 export const solanaTokenAccountSize = 165;
 export const solanaAtaRentExemptLamports = 2_039_280n;
-const solanaGetAccountInfoMethod = "getAccountInfo";
-const solanaRpcProbeTimeout = 5_000;
-const solanaTokenAccountExistsCache = new Set<string>();
-const solanaConnectionCache = new Map<string, Promise<Connection>>();
-const solanaRentExemptBalanceCache = new Map<string, Promise<bigint>>();
+const rpcProbeTimeout = 5_000;
+
+type AccountInfo = Awaited<ReturnType<Connection["getAccountInfo"]>>;
+
+type CacheOptions<T> = {
+    shouldCache?: (value: T) => boolean;
+};
+
+const connectionPrefix = "connection:";
+const rentExemptBalancePrefix = "rent:";
+const tokenAccountExistsPrefix = "token-account-exists:";
+const accountInfoPrefix = "account-info:";
+
+const createCache = () => {
+    const entries = new Map<string, Promise<unknown>>();
+    const getCacheKey = (prefix: string, key: string): string =>
+        `${prefix}${key}`;
+
+    const set = <T>(
+        key: string,
+        value: Promise<T>,
+        { shouldCache }: CacheOptions<T> = {},
+    ): Promise<T> => {
+        const cached = value
+            .then((resolved) => {
+                if (shouldCache !== undefined && !shouldCache(resolved)) {
+                    entries.delete(key);
+                }
+
+                return resolved;
+            })
+            .catch((error: unknown) => {
+                entries.delete(key);
+                throw error;
+            });
+        entries.set(key, cached as Promise<unknown>);
+
+        return cached;
+    };
+
+    return {
+        clear: () => {
+            entries.clear();
+        },
+        delete: (key: string) => {
+            entries.delete(key);
+        },
+        getOrCreate: <T>(
+            prefix: string,
+            key: string,
+            create: () => Promise<T>,
+            options: CacheOptions<T> = {},
+        ): Promise<T> => {
+            const cacheKey = getCacheKey(prefix, key);
+            const cached = entries.get(cacheKey);
+            if (cached !== undefined) {
+                return cached as Promise<T>;
+            }
+
+            return set(cacheKey, create(), options);
+        },
+    };
+};
+
+const cache = createCache();
+
+export const getCachedSolanaValue = <T>(
+    prefix: string,
+    key: string,
+    create: () => Promise<T>,
+    options: CacheOptions<T> = {},
+): Promise<T> => cache.getOrCreate(prefix, key, create, options);
 
 export const decodeSolanaAddress = (address: string): Uint8Array => {
     const decoded = base58.decode(address);
@@ -44,16 +110,8 @@ export const encodeSolanaRecipient = (recipient: string): string =>
 export const encodeSolanaAtaCreationOption = (): string =>
     solidityPacked(["uint128", "uint128"], [0n, solanaAtaRentExemptLamports]);
 
-export const clearSolanaTokenAccountCreationCache = () => {
-    solanaTokenAccountExistsCache.clear();
-};
-
-export const clearSolanaConnectionCache = () => {
-    solanaConnectionCache.clear();
-};
-
-export const clearSolanaRentExemptBalanceCache = () => {
-    solanaRentExemptBalanceCache.clear();
+export const clearSolanaCache = () => {
+    cache.clear();
 };
 
 export const getConnectedSolanaWalletAddress = async (
@@ -91,10 +149,10 @@ const createSolanaConnection = async (rpcUrl: string): Promise<Connection> => {
                 timeoutHandle = setTimeout(() => {
                     reject(
                         new Error(
-                            `Solana RPC request timed out after ${solanaRpcProbeTimeout}ms`,
+                            `Solana RPC request timed out after ${rpcProbeTimeout}ms`,
                         ),
                     );
-                }, solanaRpcProbeTimeout);
+                }, rpcProbeTimeout);
             }),
         ]);
     } finally {
@@ -108,25 +166,15 @@ const createSolanaConnection = async (rpcUrl: string): Promise<Connection> => {
 
 const getOrCreateSolanaConnection = async (
     rpcUrl: string,
-): Promise<Connection> => {
-    const cached = solanaConnectionCache.get(rpcUrl);
-    if (cached !== undefined) {
-        return await cached;
-    }
-
-    const created = createSolanaConnection(rpcUrl).catch((error: unknown) => {
-        solanaConnectionCache.delete(rpcUrl);
-        throw error;
-    });
-    solanaConnectionCache.set(rpcUrl, created);
-
-    return await created;
-};
+): Promise<Connection> =>
+    await cache.getOrCreate(connectionPrefix, rpcUrl, () =>
+        createSolanaConnection(rpcUrl),
+    );
 
 export const getSolanaConnection = async (
-    sourceAsset: string,
+    asset: string,
 ): Promise<Connection> => {
-    const rpcUrls = requireRpcUrls(sourceAsset);
+    const rpcUrls = requireRpcUrls(asset);
     let lastError: unknown;
 
     for (const rpcUrl of rpcUrls) {
@@ -135,7 +183,7 @@ export const getSolanaConnection = async (
         } catch (error) {
             lastError = error;
             log.warn("Failed to create Solana connection", {
-                sourceAsset,
+                asset,
                 rpcUrl,
                 error: formatError(lastError),
             });
@@ -143,15 +191,15 @@ export const getSolanaConnection = async (
     }
 
     throw new Error(
-        `Failed to connect to Solana RPC for ${sourceAsset}: ${formatError(lastError)}`,
+        `Failed to connect to Solana RPC for ${asset}: ${formatError(lastError)}`,
     );
 };
 
 export const getSolanaTransactionSender = async (
-    sourceAsset: string,
+    asset: string,
     txHash: string,
 ): Promise<string | undefined> => {
-    const connection = await getSolanaConnection(sourceAsset);
+    const connection = await getSolanaConnection(asset);
     const transaction = await connection.getParsedTransaction(txHash, {
         commitment: "confirmed",
         maxSupportedTransactionVersion: 0,
@@ -166,12 +214,12 @@ export const getSolanaTransactionSender = async (
 };
 
 export const getSolanaNativeBalance = async (
-    sourceAsset: string,
+    asset: string,
     ownerAddress: string,
 ): Promise<bigint> => {
     const [{ web3 }, connection] = await Promise.all([
         lazySolana.get(),
-        getSolanaConnection(sourceAsset),
+        getSolanaConnection(asset),
     ]);
 
     return BigInt(
@@ -180,132 +228,66 @@ export const getSolanaNativeBalance = async (
 };
 
 export const getSolanaRentExemptMinimumBalance = async (
-    sourceAsset: string,
+    asset: string,
     accountSize: number,
-): Promise<bigint> => {
-    const cacheKey = `${sourceAsset}:${accountSize}`;
-    const cached = solanaRentExemptBalanceCache.get(cacheKey);
-    if (cached !== undefined) {
-        return await cached;
-    }
-
-    const created = getSolanaConnection(sourceAsset)
-        .then(async (connection) =>
-            BigInt(
+): Promise<bigint> =>
+    await cache.getOrCreate(
+        rentExemptBalancePrefix,
+        accountSize.toString(),
+        async () => {
+            const connection = await getSolanaConnection(asset);
+            return BigInt(
                 await connection.getMinimumBalanceForRentExemption(
                     accountSize,
                     "confirmed",
                 ),
-            ),
-        )
-        .catch((error: unknown) => {
-            solanaRentExemptBalanceCache.delete(cacheKey);
-            throw error;
-        });
-    solanaRentExemptBalanceCache.set(cacheKey, created);
+            );
+        },
+    );
 
-    return await created;
+export const getSolanaAccountInfo = async (
+    asset: string,
+    accountAddress: string,
+): Promise<AccountInfo> => {
+    const { web3 } = await lazySolana.get();
+    const publicKey = new web3.PublicKey(accountAddress);
+    const normalizedAddress = publicKey.toBase58();
+
+    return await cache.getOrCreate(
+        accountInfoPrefix,
+        normalizedAddress,
+        async () => {
+            const connection = await getSolanaConnection(asset);
+            return await connection.getAccountInfo(publicKey, "confirmed");
+        },
+        {
+            shouldCache: (accountInfo) => accountInfo !== null,
+        },
+    );
 };
 
 const queryShouldCreateSolanaTokenAccount = async (
     destinationAsset: string,
     recipient: string,
+    mintAddress: string,
 ): Promise<boolean> => {
-    const destinationConfig = config.assets?.[destinationAsset];
-    const mintAddress = destinationConfig.token?.address;
-    if (mintAddress === undefined || mintAddress === "") {
-        throw new Error(
-            `Missing Solana token mint address for asset: ${destinationAsset}`,
-        );
-    }
-
     decodeSolanaAddress(recipient);
     const { web3, splToken } = await lazySolana.get();
 
     const recipientPublicKey = new web3.PublicKey(recipient);
-    const associatedTokenAddress = splToken.getAssociatedTokenAddressSync(
-        new web3.PublicKey(mintAddress),
-        recipientPublicKey,
-        true,
-    );
+    const associatedTokenAddress = splToken
+        .getAssociatedTokenAddressSync(
+            new web3.PublicKey(mintAddress),
+            recipientPublicKey,
+            true,
+        )
+        .toBase58();
 
-    const rpcUrls = requireRpcUrls(destinationAsset);
-    let lastError: unknown;
-    for (const rpcUrl of rpcUrls) {
-        const { opts, requestTimeout } = constructRequestOptions(
-            {
-                method: "POST",
-                headers: {
-                    "content-type": "application/json",
-                },
-                body: JSON.stringify({
-                    jsonrpc: "2.0",
-                    id: 1,
-                    method: solanaGetAccountInfoMethod,
-                    params: [
-                        associatedTokenAddress.toBase58(),
-                        {
-                            encoding: "base64",
-                        },
-                    ],
-                }),
-            },
-            solanaRpcProbeTimeout,
-        );
-
-        try {
-            const response = await fetch(rpcUrl, opts);
-
-            if (!response.ok) {
-                throw new Error(
-                    `Solana RPC ${response.status} ${response.statusText}`,
-                );
-            }
-
-            const payload: unknown = await response.json();
-            const { error, result } = payload as {
-                error?: {
-                    code?: number;
-                    message?: string;
-                };
-                result?: {
-                    value?: Record<string, unknown> | null;
-                };
-            };
-            if (error !== undefined) {
-                throw new Error(
-                    `Solana RPC error ${error.code ?? "unknown"}: ${error.message ?? "unknown error"}`,
-                );
-            }
-            if (result?.value === undefined) {
-                throw new Error("Unexpected Solana account info response");
-            }
-
-            return result.value === null;
-        } catch (error) {
-            const isAbortError =
-                (error instanceof DOMException &&
-                    error.name === "AbortError") ||
-                opts.signal?.aborted === true;
-            lastError = isAbortError
-                ? new Error(
-                      `Solana RPC request timed out after ${solanaRpcProbeTimeout}ms`,
-                  )
-                : error;
-            log.warn("Failed to query Solana associated token account", {
-                destinationAsset,
-                recipient,
-                associatedTokenAddress: associatedTokenAddress.toBase58(),
-                rpcUrl,
-                error: formatError(lastError),
-            });
-        } finally {
-            clearTimeout(requestTimeout);
-        }
-    }
-
-    throw new Error(
-        `Failed to query Solana associated token account for ${destinationAsset}: ${formatError(lastError)}`,
+    return (
+        (await getSolanaAccountInfo(
+            destinationAsset,
+            associatedTokenAddress,
+        )) === null
     );
 };
 
@@ -325,19 +307,29 @@ export const shouldCreateSolanaTokenAccount = (
         return Promise.resolve(false);
     }
 
-    const cacheKey = `${destinationAsset}:${recipient}`;
-    if (solanaTokenAccountExistsCache.has(cacheKey)) {
-        return Promise.resolve(false);
+    const mintAddress = destinationConfig.token?.address;
+    if (mintAddress === undefined || mintAddress === "") {
+        return Promise.reject(
+            new Error(
+                `Missing Solana token mint address for asset: ${destinationAsset}`,
+            ),
+        );
     }
 
-    return queryShouldCreateSolanaTokenAccount(
-        destinationAsset,
-        recipient,
-    ).then((shouldCreate) => {
-        if (!shouldCreate) {
-            solanaTokenAccountExistsCache.add(cacheKey);
-        }
-
-        return shouldCreate;
-    });
+    return cache
+        .getOrCreate(
+            tokenAccountExistsPrefix,
+            `${mintAddress}:${recipient}`,
+            async () => {
+                return !(await queryShouldCreateSolanaTokenAccount(
+                    destinationAsset,
+                    recipient,
+                    mintAddress,
+                ));
+            },
+            {
+                shouldCache: (exists) => exists,
+            },
+        )
+        .then((exists) => !exists);
 };

--- a/src/utils/chains/solana.ts
+++ b/src/utils/chains/solana.ts
@@ -7,6 +7,7 @@ import log from "loglevel";
 import { config } from "../../config";
 import { NetworkTransport } from "../../configs/base";
 import lazySolana from "../../lazy/solana";
+import { getCachedValue } from "../cache";
 import { formatError } from "../errors";
 import { requireRpcUrls } from "../provider";
 
@@ -16,75 +17,11 @@ export const solanaAtaRentExemptLamports = 2_039_280n;
 const rpcProbeTimeout = 5_000;
 
 type AccountInfo = Awaited<ReturnType<Connection["getAccountInfo"]>>;
-
-type CacheOptions<T> = {
-    shouldCache?: (value: T) => boolean;
-};
-
-const connectionPrefix = "connection:";
-const rentExemptBalancePrefix = "rent:";
-const tokenAccountExistsPrefix = "token-account-exists:";
-const accountInfoPrefix = "account-info:";
-
-const createCache = () => {
-    const entries = new Map<string, Promise<unknown>>();
-    const getCacheKey = (prefix: string, key: string): string =>
-        `${prefix}${key}`;
-
-    const set = <T>(
-        key: string,
-        value: Promise<T>,
-        { shouldCache }: CacheOptions<T> = {},
-    ): Promise<T> => {
-        const cached = value
-            .then((resolved) => {
-                if (shouldCache !== undefined && !shouldCache(resolved)) {
-                    entries.delete(key);
-                }
-
-                return resolved;
-            })
-            .catch((error: unknown) => {
-                entries.delete(key);
-                throw error;
-            });
-        entries.set(key, cached as Promise<unknown>);
-
-        return cached;
-    };
-
-    return {
-        clear: () => {
-            entries.clear();
-        },
-        delete: (key: string) => {
-            entries.delete(key);
-        },
-        getOrCreate: <T>(
-            prefix: string,
-            key: string,
-            create: () => Promise<T>,
-            options: CacheOptions<T> = {},
-        ): Promise<T> => {
-            const cacheKey = getCacheKey(prefix, key);
-            const cached = entries.get(cacheKey);
-            if (cached !== undefined) {
-                return cached as Promise<T>;
-            }
-
-            return set(cacheKey, create(), options);
-        },
-    };
-};
-
-const cache = createCache();
-
-export const getCachedSolanaValue = <T>(
-    prefix: string,
-    key: string,
-    create: () => Promise<T>,
-    options: CacheOptions<T> = {},
-): Promise<T> => cache.getOrCreate(prefix, key, create, options);
+const cachePrefix = "solana:";
+const connectionPrefix = `${cachePrefix}connection:`;
+const rentExemptBalancePrefix = `${cachePrefix}rent:`;
+const tokenAccountExistsPrefix = `${cachePrefix}token-account-exists:`;
+const accountInfoPrefix = `${cachePrefix}account-info:`;
 
 export const decodeSolanaAddress = (address: string): Uint8Array => {
     const decoded = base58.decode(address);
@@ -109,10 +46,6 @@ export const encodeSolanaRecipient = (recipient: string): string =>
 
 export const encodeSolanaAtaCreationOption = (): string =>
     solidityPacked(["uint128", "uint128"], [0n, solanaAtaRentExemptLamports]);
-
-export const clearSolanaCache = () => {
-    cache.clear();
-};
 
 export const getConnectedSolanaWalletAddress = async (
     walletProvider: SolanaWalletProvider,
@@ -167,7 +100,7 @@ const createSolanaConnection = async (rpcUrl: string): Promise<Connection> => {
 const getOrCreateSolanaConnection = async (
     rpcUrl: string,
 ): Promise<Connection> =>
-    await cache.getOrCreate(connectionPrefix, rpcUrl, () =>
+    await getCachedValue(connectionPrefix, rpcUrl, () =>
         createSolanaConnection(rpcUrl),
     );
 
@@ -231,9 +164,9 @@ export const getSolanaRentExemptMinimumBalance = async (
     asset: string,
     accountSize: number,
 ): Promise<bigint> =>
-    await cache.getOrCreate(
+    await getCachedValue(
         rentExemptBalancePrefix,
-        accountSize.toString(),
+        `${asset}:${accountSize}`,
         async () => {
             const connection = await getSolanaConnection(asset);
             return BigInt(
@@ -248,20 +181,22 @@ export const getSolanaRentExemptMinimumBalance = async (
 export const getSolanaAccountInfo = async (
     asset: string,
     accountAddress: string,
+    connection?: Connection,
 ): Promise<AccountInfo> => {
     const { web3 } = await lazySolana.get();
     const publicKey = new web3.PublicKey(accountAddress);
     const normalizedAddress = publicKey.toBase58();
 
-    return await cache.getOrCreate(
+    if (connection === undefined) {
+        connection = await getSolanaConnection(asset);
+    }
+
+    return await getCachedValue(
         accountInfoPrefix,
-        normalizedAddress,
-        async () => {
-            const connection = await getSolanaConnection(asset);
-            return await connection.getAccountInfo(publicKey, "confirmed");
-        },
+        `${asset}:${normalizedAddress}`,
+        async () => await connection.getAccountInfo(publicKey, "confirmed"),
         {
-            shouldCache: (accountInfo) => accountInfo !== null,
+            shouldRetain: (accountInfo) => accountInfo !== null,
         },
     );
 };
@@ -316,20 +251,17 @@ export const shouldCreateSolanaTokenAccount = (
         );
     }
 
-    return cache
-        .getOrCreate(
-            tokenAccountExistsPrefix,
-            `${mintAddress}:${recipient}`,
-            async () => {
-                return !(await queryShouldCreateSolanaTokenAccount(
-                    destinationAsset,
-                    recipient,
-                    mintAddress,
-                ));
-            },
-            {
-                shouldCache: (exists) => exists,
-            },
-        )
-        .then((exists) => !exists);
+    return getCachedValue(
+        tokenAccountExistsPrefix,
+        `${destinationAsset}:${mintAddress}:${recipient}`,
+        async () =>
+            await queryShouldCreateSolanaTokenAccount(
+                destinationAsset,
+                recipient,
+                mintAddress,
+            ),
+        {
+            shouldRetain: (shouldCreate) => !shouldCreate,
+        },
+    );
 };

--- a/src/utils/oft/oft.ts
+++ b/src/utils/oft/oft.ts
@@ -19,7 +19,7 @@ import type { AlchemyCall } from "../../alchemy/Alchemy";
 import { config } from "../../config";
 import { NetworkTransport, Usdt0Kind } from "../../configs/base";
 import {
-    clearSolanaTokenAccountCreationCache,
+    clearSolanaCache,
     encodeSolanaAtaCreationOption,
     encodeSolanaRecipient,
     getSolanaRentExemptMinimumBalance,
@@ -140,7 +140,7 @@ export const decodeExecutorNativeAmountExceedsCapError = (
 export const clearOftDeployments = () => {
     clearOftRegistry();
     providerCache.clear();
-    clearSolanaTokenAccountCreationCache();
+    clearSolanaCache();
 };
 
 export const getOftTransport = (asset: string): NetworkTransport => {
@@ -247,7 +247,7 @@ export const createOftContract = async (
         case NetworkTransport.Solana: {
             const oftStore = await getOftStoreContract(route, oftName);
             return createSolanaOftContract({
-                sourceAsset: route.sourceAsset,
+                asset: route.sourceAsset,
                 programAddress: oftContract.address,
                 storeAddress: oftStore.address,
                 walletProvider: getSolanaOftWalletProvider(route, runner),
@@ -439,12 +439,12 @@ export const getBufferedOftNativeFee = (nativeFee: bigint): bigint =>
     (nativeFee * 110n) / 100n;
 
 export const getRequiredSolanaOftNativeBalance = async (
-    sourceAsset: string,
+    asset: string,
     nativeFee: bigint,
 ): Promise<bigint> => {
     const bufferedFee = getBufferedOftNativeFee(nativeFee);
     const rentExemptMinimum = await getSolanaRentExemptMinimumBalance(
-        sourceAsset,
+        asset,
         solanaTokenAccountSize,
     );
 
@@ -640,7 +640,7 @@ export const getSolanaOftTokenBalance = async (
 
     return await getSolanaLegacyMeshTokenBalance(
         {
-            sourceAsset: route.sourceAsset,
+            asset: route.sourceAsset,
             programAddress: oftContract.address,
             storeAddress: oftStore.address,
         },

--- a/src/utils/oft/oft.ts
+++ b/src/utils/oft/oft.ts
@@ -18,8 +18,8 @@ import type { Signer } from "src/context/Web3";
 import type { AlchemyCall } from "../../alchemy/Alchemy";
 import { config } from "../../config";
 import { NetworkTransport, Usdt0Kind } from "../../configs/base";
+import { clearCache, getCachedValue } from "../cache";
 import {
-    clearSolanaCache,
     encodeSolanaAtaCreationOption,
     encodeSolanaRecipient,
     getSolanaRentExemptMinimumBalance,
@@ -42,7 +42,6 @@ import {
 } from "./evm";
 import {
     type OftContract,
-    clearOftRegistry,
     defaultOftName,
     formatRoute,
     getOftChain,
@@ -79,7 +78,7 @@ export type {
     SendParam,
 } from "./types";
 
-const providerCache = new Map<string, Provider>();
+const providerCachePrefix = "oft:provider:";
 const executorNativeAmountExceedsCapSelector = "0x0084ce02";
 const type3Option = 3;
 const executorWorkerId = 1;
@@ -138,9 +137,7 @@ export const decodeExecutorNativeAmountExceedsCapError = (
 };
 
 export const clearOftDeployments = () => {
-    clearOftRegistry();
-    providerCache.clear();
-    clearSolanaCache();
+    clearCache();
 };
 
 export const getOftTransport = (asset: string): NetworkTransport => {
@@ -160,19 +157,18 @@ export const getOftProvider = (sourceAsset: string): Provider => {
     }
 
     const rpcUrls = requireRpcUrls(sourceAsset);
-    const cacheKey = `${sourceAsset}:${rpcUrls.join(",")}`;
-    const cached = providerCache.get(cacheKey);
-    if (cached) {
-        return cached;
-    }
-
-    const provider = createAssetProvider(sourceAsset);
-    providerCache.set(cacheKey, provider);
-    log.debug("Created OFT provider", {
-        sourceAsset,
-        rpcUrlCount: rpcUrls.length,
-    });
-    return provider;
+    return getCachedValue(
+        providerCachePrefix,
+        `${sourceAsset}:${rpcUrls.join(",")}`,
+        () => {
+            const provider = createAssetProvider(sourceAsset);
+            log.debug("Created OFT provider", {
+                sourceAsset,
+                rpcUrlCount: rpcUrls.length,
+            });
+            return provider;
+        },
+    );
 };
 
 const getOftStoreContract = async (

--- a/src/utils/oft/registry.ts
+++ b/src/utils/oft/registry.ts
@@ -3,6 +3,7 @@ import { getUsdt0Mesh } from "src/consts/Assets";
 
 import { config } from "../../config";
 import { Usdt0Kind } from "../../configs/base";
+import { getCachedValue } from "../cache";
 import { formatError } from "../errors";
 import type { OftRoute } from "./types";
 
@@ -30,15 +31,11 @@ type OftRegistry = Record<string, OftTokenConfig>;
 const oftDeploymentsEndpoint = "https://docs.usdt0.to/api/deployments";
 export const defaultOftName = "usdt0";
 const primaryOftContractNames = ["OFT", "OFT Adapter", "OFT Program"] as const;
-
-let oftDeploymentsPromise: Promise<OftRegistry> | undefined;
+const oftPrefix = "oft:";
+const deploymentsKey = "deployments";
 
 export const formatRoute = (route: OftRoute) =>
     `${route.sourceAsset} -> ${route.destinationAsset}`;
-
-export const clearOftRegistry = () => {
-    oftDeploymentsPromise = undefined;
-};
 
 const fetchOftDeployments = async (): Promise<OftRegistry> => {
     const response = await fetch(oftDeploymentsEndpoint);
@@ -52,22 +49,15 @@ const fetchOftDeployments = async (): Promise<OftRegistry> => {
     return data as OftRegistry;
 };
 
-export const getOftDeployments = (): Promise<OftRegistry> => {
-    if (!oftDeploymentsPromise) {
-        oftDeploymentsPromise = fetchOftDeployments().catch(
-            (error: unknown) => {
-                log.error(
-                    "Failed to fetch OFT deployments",
-                    formatError(error),
-                );
-                oftDeploymentsPromise = undefined;
-                throw error;
-            },
-        );
-    }
-
-    return oftDeploymentsPromise;
-};
+export const getOftDeployments = (): Promise<OftRegistry> =>
+    getCachedValue(oftPrefix, deploymentsKey, async () => {
+        try {
+            return await fetchOftDeployments();
+        } catch (error) {
+            log.error("Failed to fetch OFT deployments", formatError(error));
+            throw error;
+        }
+    });
 
 export const getOftChain = async (
     asset: string,

--- a/src/utils/oft/solana.ts
+++ b/src/utils/oft/solana.ts
@@ -14,8 +14,8 @@ import log from "loglevel";
 import { config } from "../../config";
 import { NetworkTransport } from "../../configs/base";
 import lazySolanaOft from "../../lazy/solanaOft";
+import { getCachedValue } from "../cache";
 import {
-    getCachedSolanaValue,
     getConnectedSolanaWalletAddress,
     getSolanaAccountInfo,
     getSolanaAssociatedTokenAddress,
@@ -249,7 +249,11 @@ export const getSolanaLegacyMeshContext = async ({
     const modules = await lazySolanaOft.get();
     try {
         const connection = await getSolanaConnection(asset);
-        const accountInfo = await getSolanaAccountInfo(asset, storeAddress);
+        const accountInfo = await getSolanaAccountInfo(
+            asset,
+            storeAddress,
+            connection,
+        );
         if (accountInfo === null) {
             throw new Error(`missing Solana OFT store account ${storeAddress}`);
         }
@@ -370,7 +374,7 @@ const getLegacyPeerReceiver = async (
     context: Context,
     dstEid: number,
 ): Promise<Uint8Array> =>
-    await getCachedSolanaValue(
+    await getCachedValue(
         peerReceiverCachePrefix,
         `${getCacheScope(context)}:${dstEid}`,
         async () => {
@@ -383,6 +387,7 @@ const getLegacyPeerReceiver = async (
             const peerInfo = await getSolanaAccountInfo(
                 context.asset,
                 peerAddress,
+                context.connection,
             );
             if (peerInfo === null) {
                 throw new Error(
@@ -405,7 +410,7 @@ const getRemainingAccounts = async (
     receiver: Uint8Array,
 ) => {
     const { modules } = context;
-    return await getCachedSolanaValue(
+    return await getCachedValue(
         remainingAccountsCachePrefix,
         `${getCacheScope(context)}:${kind}:${payer}:${dstEid}:${hex.encode(receiver)}`,
         async (): Promise<AccountMeta[]> => {
@@ -499,6 +504,7 @@ const createTransaction = async (
         const lookupTableAccount = await getSolanaAccountInfo(
             context.asset,
             context.addressLookupTableAddress,
+            context.connection,
         );
         if (lookupTableAccount === null) {
             throw new Error(

--- a/src/utils/oft/solana.ts
+++ b/src/utils/oft/solana.ts
@@ -15,7 +15,9 @@ import { config } from "../../config";
 import { NetworkTransport } from "../../configs/base";
 import lazySolanaOft from "../../lazy/solanaOft";
 import {
+    getCachedSolanaValue,
     getConnectedSolanaWalletAddress,
+    getSolanaAccountInfo,
     getSolanaAssociatedTokenAddress,
     getSolanaConnection,
 } from "../chains/solana";
@@ -26,6 +28,7 @@ type SolanaOftModules = Awaited<ReturnType<(typeof lazySolanaOft)["get"]>>;
 
 type Context = {
     modules: SolanaOftModules;
+    asset: string;
     connection: Connection;
     umi: Umi;
     walletProvider?: SolanaWalletProvider;
@@ -49,7 +52,7 @@ type SolanaReturnSerializer<T> =
       };
 
 export type SolanaLegacyMeshConfig = {
-    sourceAsset: string;
+    asset: string;
     programAddress: string;
     storeAddress: string;
     walletProvider?: SolanaWalletProvider;
@@ -60,6 +63,9 @@ const programReturnPrefix = "Program return: ";
 const creditsSeed = "Credits";
 const eventAuthoritySeed = "__event_authority";
 const peerSeed = "Peer";
+const cachePrefix = "oft:";
+const peerReceiverCachePrefix = `${cachePrefix}peer-receiver:`;
+const remainingAccountsCachePrefix = `${cachePrefix}remaining-accounts:`;
 
 const encodeU32 = (value: number, littleEndian = true): Uint8Array => {
     const bytes = new Uint8Array(4);
@@ -75,6 +81,14 @@ const hexToBytes = (value: string): Uint8Array =>
     value === "0x"
         ? new Uint8Array()
         : hex.decode(value.startsWith("0x") ? value.slice(2) : value);
+
+const getCacheScope = (context: Context): string =>
+    [
+        context.asset,
+        context.programAddress,
+        context.storeAddress,
+        context.endpointProgram,
+    ].join(":");
 
 const getSendParamArgs = (
     sendParam: SendParam,
@@ -175,7 +189,7 @@ const createSolanaWalletAdapter = async (
 };
 
 const getQuotePayer = async (
-    sourceAsset: string,
+    asset: string,
     walletProvider?: SolanaWalletProvider,
 ): Promise<string> => {
     const walletAddress =
@@ -187,14 +201,13 @@ const getQuotePayer = async (
         return walletAddress;
     }
 
-    const configuredQuotePayer =
-        config.assets?.[sourceAsset]?.network?.oftQuotePayer;
+    const configuredQuotePayer = config.assets?.[asset]?.network?.oftQuotePayer;
     if (configuredQuotePayer !== undefined) {
         return configuredQuotePayer;
     }
 
     throw new Error(
-        `Could not determine a valid Solana quote payer for ${sourceAsset}`,
+        `Could not determine a valid Solana quote payer for ${asset}`,
     );
 };
 
@@ -228,18 +241,15 @@ const createUmiContext = async (
 };
 
 export const getSolanaLegacyMeshContext = async ({
-    sourceAsset,
+    asset,
     programAddress,
     storeAddress,
     walletProvider,
 }: SolanaLegacyMeshConfig): Promise<Context> => {
     const modules = await lazySolanaOft.get();
     try {
-        const connection = await getSolanaConnection(sourceAsset);
-        const accountInfo = await connection.getAccountInfo(
-            new modules.web3.PublicKey(storeAddress),
-            "confirmed",
-        );
+        const connection = await getSolanaConnection(asset);
+        const accountInfo = await getSolanaAccountInfo(asset, storeAddress);
         if (accountInfo === null) {
             throw new Error(`missing Solana OFT store account ${storeAddress}`);
         }
@@ -263,6 +273,7 @@ export const getSolanaLegacyMeshContext = async ({
 
         return {
             modules,
+            asset,
             connection,
             umi,
             walletProvider,
@@ -277,17 +288,17 @@ export const getSolanaLegacyMeshContext = async ({
             tokenMint,
             tokenEscrow,
             endpointProgram,
-            quotePayer: await getQuotePayer(sourceAsset, walletProvider),
+            quotePayer: await getQuotePayer(asset, walletProvider),
             addressLookupTableAddress,
         };
     } catch (error) {
         log.warn(
             "Failed to initialize Solana OFT context",
-            sourceAsset,
+            asset,
             formatError(error),
         );
         throw new Error(
-            `Failed to initialize Solana OFT context for ${sourceAsset}: ${formatError(error)}`,
+            `Failed to initialize Solana OFT context for ${asset}: ${formatError(error)}`,
         );
     }
 };
@@ -358,28 +369,33 @@ const createLegacySendInstruction = (
 const getLegacyPeerReceiver = async (
     context: Context,
     dstEid: number,
-): Promise<Uint8Array> => {
-    const { modules } = context;
-    const peerAddress = derivePeerAddress(
-        modules,
-        context.programAddress,
-        dstEid,
-    );
-    const peerInfo = await context.connection.getAccountInfo(
-        new modules.web3.PublicKey(peerAddress),
-        "confirmed",
-    );
-    if (peerInfo === null) {
-        throw new Error(
-            `Missing Solana legacy peer account ${peerAddress} for ${dstEid}`,
-        );
-    }
+): Promise<Uint8Array> =>
+    await getCachedSolanaValue(
+        peerReceiverCachePrefix,
+        `${getCacheScope(context)}:${dstEid}`,
+        async () => {
+            const { modules } = context;
+            const peerAddress = derivePeerAddress(
+                modules,
+                context.programAddress,
+                dstEid,
+            );
+            const peerInfo = await getSolanaAccountInfo(
+                context.asset,
+                peerAddress,
+            );
+            if (peerInfo === null) {
+                throw new Error(
+                    `Missing Solana legacy peer account ${peerAddress} for ${dstEid}`,
+                );
+            }
 
-    return Uint8Array.from(
-        modules.generated.getPeerConfigDecoder().decode(peerInfo.data)
-            .peerAddress,
+            return Uint8Array.from(
+                modules.generated.getPeerConfigDecoder().decode(peerInfo.data)
+                    .peerAddress,
+            );
+        },
     );
-};
 
 const getRemainingAccounts = async (
     kind: "quote" | "send",
@@ -389,67 +405,79 @@ const getRemainingAccounts = async (
     receiver: Uint8Array,
 ) => {
     const { modules } = context;
-    const endpoint = new modules.lzSolanaUmi.EndpointProgram.Endpoint(
-        modules.umi.publicKey(context.endpointProgram) as never,
-    );
-    const sendLibrary = await endpoint.getSendLibrary(
-        context.umi.rpc as never,
-        modules.umi.publicKey(context.storeAddress) as never,
-        dstEid,
-    );
-    if (!sendLibrary.programId) {
-        throw new Error("Send library not initialized for Solana legacy mesh");
-    }
-
-    const sendLibraryProgramId = String(sendLibrary.programId);
-    let msgLibProgram;
-    switch (sendLibraryProgramId) {
-        case modules.lzSolanaUmi.SimpleMessageLibProgram
-            .SIMPLE_MESSAGELIB_PROGRAM_ID:
-            msgLibProgram =
-                new modules.lzSolanaUmi.SimpleMessageLibProgram.SimpleMessageLib(
-                    modules.umi.publicKey(sendLibraryProgramId) as never,
+    return await getCachedSolanaValue(
+        remainingAccountsCachePrefix,
+        `${getCacheScope(context)}:${kind}:${payer}:${dstEid}:${hex.encode(receiver)}`,
+        async (): Promise<AccountMeta[]> => {
+            const endpoint = new modules.lzSolanaUmi.EndpointProgram.Endpoint(
+                modules.umi.publicKey(context.endpointProgram) as never,
+            );
+            const sendLibrary = await endpoint.getSendLibrary(
+                context.umi.rpc as never,
+                modules.umi.publicKey(context.storeAddress) as never,
+                dstEid,
+            );
+            if (!sendLibrary.programId) {
+                throw new Error(
+                    "Send library not initialized for Solana legacy mesh",
                 );
-            break;
+            }
 
-        case modules.lzSolanaUmi.UlnProgram.ULN_PROGRAM_ID:
-            msgLibProgram = new modules.lzSolanaUmi.UlnProgram.Uln(
-                modules.umi.publicKey(sendLibraryProgramId) as never,
-            );
-            break;
+            const sendLibraryProgramId = String(sendLibrary.programId);
+            let msgLibProgram;
+            switch (sendLibraryProgramId) {
+                case modules.lzSolanaUmi.SimpleMessageLibProgram
+                    .SIMPLE_MESSAGELIB_PROGRAM_ID:
+                    msgLibProgram =
+                        new modules.lzSolanaUmi.SimpleMessageLibProgram.SimpleMessageLib(
+                            modules.umi.publicKey(
+                                sendLibraryProgramId,
+                            ) as never,
+                        );
+                    break;
 
-        default:
-            throw new Error(
-                `Unsupported Solana legacy mesh send library ${sendLibraryProgramId}`,
-            );
-    }
+                case modules.lzSolanaUmi.UlnProgram.ULN_PROGRAM_ID:
+                    msgLibProgram = new modules.lzSolanaUmi.UlnProgram.Uln(
+                        modules.umi.publicKey(sendLibraryProgramId) as never,
+                    );
+                    break;
 
-    const cpiPath = {
-        path: {
-            sender: modules.umi.publicKey(context.storeAddress) as never,
-            dstEid,
-            receiver,
+                default:
+                    throw new Error(
+                        `Unsupported Solana legacy mesh send library ${sendLibraryProgramId}`,
+                    );
+            }
+
+            const cpiPath = {
+                path: {
+                    sender: modules.umi.publicKey(
+                        context.storeAddress,
+                    ) as never,
+                    dstEid,
+                    receiver,
+                },
+                msgLibProgram,
+            };
+            const accountMetas =
+                kind === "quote"
+                    ? await endpoint.getQuoteIXAccountMetaForCPI(
+                          context.umi.rpc as never,
+                          modules.umi.publicKey(payer) as never,
+                          cpiPath,
+                      )
+                    : await endpoint.getSendIXAccountMetaForCPI(
+                          context.umi.rpc as never,
+                          modules.umi.publicKey(payer) as never,
+                          cpiPath,
+                      );
+
+            return accountMetas.map((meta) => ({
+                pubkey: new modules.web3.PublicKey(meta.pubkey),
+                isSigner: meta.isSigner,
+                isWritable: meta.isWritable,
+            }));
         },
-        msgLibProgram,
-    };
-    const metas =
-        kind === "quote"
-            ? await endpoint.getQuoteIXAccountMetaForCPI(
-                  context.umi.rpc as never,
-                  modules.umi.publicKey(payer) as never,
-                  cpiPath,
-              )
-            : await endpoint.getSendIXAccountMetaForCPI(
-                  context.umi.rpc as never,
-                  modules.umi.publicKey(payer) as never,
-                  cpiPath,
-              );
-
-    return metas.map((meta) => ({
-        pubkey: new modules.web3.PublicKey(meta.pubkey),
-        isSigner: meta.isSigner,
-        isWritable: meta.isWritable,
-    }));
+    );
 };
 
 const formatSolanaLogsMessage = (logs: string[] | undefined | null): string =>
@@ -468,9 +496,9 @@ const createTransaction = async (
 
     let lookupTables = [];
     if (context.addressLookupTableAddress !== undefined) {
-        const lookupTableAccount = await context.connection.getAccountInfo(
-            new modules.web3.PublicKey(context.addressLookupTableAddress),
-            "confirmed",
+        const lookupTableAccount = await getSolanaAccountInfo(
+            context.asset,
+            context.addressLookupTableAddress,
         );
         if (lookupTableAccount === null) {
             throw new Error(
@@ -674,7 +702,7 @@ const quoteSend = async (
 };
 
 const sendLegacyMesh = async (
-    sourceAsset: string,
+    asset: string,
     context: Context,
     sendParam: SendParam,
     msgFee: MsgFee,
@@ -684,7 +712,7 @@ const sendLegacyMesh = async (
     const walletProvider = context.walletProvider;
     if (signerAddress === undefined || walletProvider === undefined) {
         throw new Error(
-            `Missing connected Solana wallet for OFT send from ${sourceAsset}`,
+            `Missing connected Solana wallet for OFT send from ${asset}`,
         );
     }
 
@@ -822,7 +850,7 @@ export const createSolanaOftContract = (
             await quoteSend(await contextPromise, sendParam, payInLzToken),
         send: async (sendParam, msgFee) =>
             await sendLegacyMesh(
-                contextConfig.sourceAsset,
+                contextConfig.asset,
                 await contextPromise,
                 sendParam,
                 msgFee,

--- a/tests/utils/cache.spec.ts
+++ b/tests/utils/cache.spec.ts
@@ -1,0 +1,51 @@
+import { afterEach, expect, test, vi } from "vitest";
+
+import { clearCache, getCachedValue } from "../../src/utils/cache";
+
+afterEach(() => {
+    clearCache();
+});
+
+test("should cache synchronous values", () => {
+    const createValue = vi.fn(() => ({ value: 1 }));
+
+    const first = getCachedValue("sync:", "key", createValue);
+    const second = getCachedValue("sync:", "key", createValue);
+
+    expect(first).toBe(second);
+    expect(createValue).toHaveBeenCalledTimes(1);
+});
+
+test("should dedupe async values while they are in flight", async () => {
+    const createValue = vi.fn(() => Promise.resolve("cached"));
+
+    const [first, second] = await Promise.all([
+        getCachedValue("async:", "key", createValue, {
+            shouldRetain: () => false,
+        }),
+        getCachedValue("async:", "key", createValue, {
+            shouldRetain: () => false,
+        }),
+    ]);
+
+    expect(first).toBe("cached");
+    expect(second).toBe("cached");
+    expect(createValue).toHaveBeenCalledTimes(1);
+});
+
+test("should not retain async values when shouldRetain returns false", async () => {
+    const createValue = vi.fn(() => Promise.resolve("ephemeral"));
+
+    await expect(
+        getCachedValue("async:", "ephemeral", createValue, {
+            shouldRetain: () => false,
+        }),
+    ).resolves.toBe("ephemeral");
+    await expect(
+        getCachedValue("async:", "ephemeral", createValue, {
+            shouldRetain: () => false,
+        }),
+    ).resolves.toBe("ephemeral");
+
+    expect(createValue).toHaveBeenCalledTimes(2);
+});

--- a/tests/utils/cache.spec.ts
+++ b/tests/utils/cache.spec.ts
@@ -1,51 +1,220 @@
-import { afterEach, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { clearCache, getCachedValue } from "../../src/utils/cache";
 
-afterEach(() => {
-    clearCache();
-});
+const createDeferred = <T>() => {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
 
-test("should cache synchronous values", () => {
-    const createValue = vi.fn(() => ({ value: 1 }));
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
 
-    const first = getCachedValue("sync:", "key", createValue);
-    const second = getCachedValue("sync:", "key", createValue);
+    return {
+        promise,
+        reject,
+        resolve,
+    };
+};
 
-    expect(first).toBe(second);
-    expect(createValue).toHaveBeenCalledTimes(1);
-});
+describe("cache", () => {
+    afterEach(() => {
+        clearCache();
+    });
 
-test("should dedupe async values while they are in flight", async () => {
-    const createValue = vi.fn(() => Promise.resolve("cached"));
+    describe("synchronous values", () => {
+        test("should cache by default", () => {
+            const createValue = vi.fn(() => ({ value: 1 }));
 
-    const [first, second] = await Promise.all([
-        getCachedValue("async:", "key", createValue, {
-            shouldRetain: () => false,
-        }),
-        getCachedValue("async:", "key", createValue, {
-            shouldRetain: () => false,
-        }),
-    ]);
+            const first = getCachedValue("sync:", "key", createValue);
+            const second = getCachedValue("sync:", "key", createValue);
 
-    expect(first).toBe("cached");
-    expect(second).toBe("cached");
-    expect(createValue).toHaveBeenCalledTimes(1);
-});
+            expect(first).toBe(second);
+            expect(createValue).toHaveBeenCalledTimes(1);
+        });
 
-test("should not retain async values when shouldRetain returns false", async () => {
-    const createValue = vi.fn(() => Promise.resolve("ephemeral"));
+        test("should not retain when shouldRetain returns false", () => {
+            const createValue = vi.fn(() => ({ value: 1 }));
 
-    await expect(
-        getCachedValue("async:", "ephemeral", createValue, {
-            shouldRetain: () => false,
-        }),
-    ).resolves.toBe("ephemeral");
-    await expect(
-        getCachedValue("async:", "ephemeral", createValue, {
-            shouldRetain: () => false,
-        }),
-    ).resolves.toBe("ephemeral");
+            const first = getCachedValue("sync:", "ephemeral", createValue, {
+                shouldRetain: () => false,
+            });
+            const second = getCachedValue("sync:", "ephemeral", createValue, {
+                shouldRetain: () => false,
+            });
 
-    expect(createValue).toHaveBeenCalledTimes(2);
+            expect(first).toEqual({ value: 1 });
+            expect(second).toEqual({ value: 1 });
+            expect(first).not.toBe(second);
+            expect(createValue).toHaveBeenCalledTimes(2);
+        });
+
+        test("should retain when shouldRetain returns true", () => {
+            const createValue = vi.fn(() => ({ value: 1 }));
+
+            const first = getCachedValue("sync:", "retained", createValue, {
+                shouldRetain: () => true,
+            });
+            const second = getCachedValue("sync:", "retained", createValue, {
+                shouldRetain: () => false,
+            });
+
+            expect(first).toBe(second);
+            expect(createValue).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("async values", () => {
+        test("should cache resolved values by default", async () => {
+            const createValue = vi.fn(() => Promise.resolve("cached"));
+
+            await expect(
+                getCachedValue("async:", "key", createValue),
+            ).resolves.toBe("cached");
+            await expect(
+                getCachedValue("async:", "key", createValue),
+            ).resolves.toBe("cached");
+
+            expect(createValue).toHaveBeenCalledTimes(1);
+        });
+
+        test("should not retain when shouldRetain returns false", async () => {
+            const createValue = vi.fn(() => Promise.resolve("ephemeral"));
+
+            await expect(
+                getCachedValue("async:", "ephemeral", createValue, {
+                    shouldRetain: () => false,
+                }),
+            ).resolves.toBe("ephemeral");
+            await expect(
+                getCachedValue("async:", "ephemeral", createValue, {
+                    shouldRetain: () => false,
+                }),
+            ).resolves.toBe("ephemeral");
+
+            expect(createValue).toHaveBeenCalledTimes(2);
+        });
+
+        test("should retain when shouldRetain returns true", async () => {
+            const createValue = vi.fn(() => Promise.resolve("retained"));
+
+            await expect(
+                getCachedValue("async:", "retained", createValue, {
+                    shouldRetain: () => true,
+                }),
+            ).resolves.toBe("retained");
+            await expect(
+                getCachedValue("async:", "retained", createValue, {
+                    shouldRetain: () => true,
+                }),
+            ).resolves.toBe("retained");
+
+            expect(createValue).toHaveBeenCalledTimes(1);
+        });
+
+        test("should pass the resolved value to shouldRetain", async () => {
+            const shouldRetain = vi.fn(() => true);
+            const createValue = vi.fn(() => Promise.resolve("the-value"));
+
+            await getCachedValue("async:", "inspect", createValue, {
+                shouldRetain,
+            });
+
+            expect(shouldRetain).toHaveBeenCalledTimes(1);
+            expect(shouldRetain).toHaveBeenCalledWith("the-value");
+        });
+
+        test("should dedupe in-flight values then evict when shouldRetain returns false", async () => {
+            const deferred = createDeferred<string>();
+            const createValue = vi
+                .fn<() => Promise<string>>()
+                .mockImplementationOnce(() => deferred.promise)
+                .mockImplementationOnce(() => Promise.resolve("fresh"));
+
+            const first = getCachedValue("async:", "pending", createValue, {
+                shouldRetain: () => false,
+            });
+            const second = getCachedValue("async:", "pending", createValue, {
+                shouldRetain: () => false,
+            });
+
+            expect(first).toBe(second);
+            expect(createValue).toHaveBeenCalledTimes(1);
+
+            deferred.resolve("original");
+
+            await expect(first).resolves.toBe("original");
+            await expect(second).resolves.toBe("original");
+
+            await expect(
+                getCachedValue("async:", "pending", createValue, {
+                    shouldRetain: () => false,
+                }),
+            ).resolves.toBe("fresh");
+            expect(createValue).toHaveBeenCalledTimes(2);
+        });
+
+        test("should remove rejected values so they can be retried", async () => {
+            const deferred = createDeferred<string>();
+            const createValue = vi
+                .fn<() => Promise<string>>()
+                .mockImplementationOnce(() => deferred.promise)
+                .mockImplementationOnce(() => Promise.resolve("recovered"));
+
+            const first = getCachedValue("async:", "retry", createValue);
+            const second = getCachedValue("async:", "retry", createValue);
+
+            expect(first).toBe(second);
+            expect(createValue).toHaveBeenCalledTimes(1);
+
+            deferred.reject(new Error("boom"));
+
+            await expect(first).rejects.toThrow("boom");
+            await expect(second).rejects.toThrow("boom");
+
+            await expect(
+                getCachedValue("async:", "retry", createValue),
+            ).resolves.toBe("recovered");
+            expect(createValue).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe("key isolation", () => {
+        test("should treat different prefixes and keys as separate entries", () => {
+            const createValue = vi.fn(() => ({ value: 1 }));
+
+            const first = getCachedValue("sync:", "key-a", createValue);
+            const second = getCachedValue("sync:", "key-b", createValue);
+            const third = getCachedValue("other:", "key-a", createValue);
+
+            expect(first).not.toBe(second);
+            expect(first).not.toBe(third);
+            expect(second).not.toBe(third);
+            expect(createValue).toHaveBeenCalledTimes(3);
+        });
+    });
+
+    describe("clearCache", () => {
+        test("should invalidate both sync and async entries", async () => {
+            const createSyncValue = vi.fn(() => ({ value: 1 }));
+            const createAsyncValue = vi.fn(() => Promise.resolve("cached"));
+
+            const firstSync = getCachedValue("sync:", "key", createSyncValue);
+            await expect(
+                getCachedValue("async:", "key", createAsyncValue),
+            ).resolves.toBe("cached");
+
+            clearCache();
+
+            const secondSync = getCachedValue("sync:", "key", createSyncValue);
+            await expect(
+                getCachedValue("async:", "key", createAsyncValue),
+            ).resolves.toBe("cached");
+
+            expect(firstSync).not.toBe(secondSync);
+            expect(createSyncValue).toHaveBeenCalledTimes(2);
+            expect(createAsyncValue).toHaveBeenCalledTimes(2);
+        });
+    });
 });

--- a/tests/utils/chains/solana.spec.ts
+++ b/tests/utils/chains/solana.spec.ts
@@ -4,8 +4,8 @@ import { afterAll, afterEach, beforeAll, expect, test, vi } from "vitest";
 import { config as runtimeConfig } from "../../../src/config";
 import { config as mainnetConfig } from "../../../src/configs/mainnet";
 import lazySolana from "../../../src/lazy/solana";
+import { clearCache } from "../../../src/utils/cache";
 import {
-    clearSolanaCache,
     decodeSolanaAddress,
     getSolanaAccountInfo,
     getSolanaRentExemptMinimumBalance,
@@ -30,7 +30,7 @@ beforeAll(() => {
 afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
-    clearSolanaCache();
+    clearCache();
 });
 
 afterAll(() => {
@@ -90,7 +90,7 @@ const stubSolanaAtaLookup = (
 };
 
 test("should cache false ATA creation results", async () => {
-    clearSolanaCache();
+    clearCache();
     const { mockGetAccountInfo } = stubSolanaAtaLookup({
         data: ["", "base64"],
     });
@@ -106,7 +106,7 @@ test("should cache false ATA creation results", async () => {
 });
 
 test("should not cache true ATA creation results", async () => {
-    clearSolanaCache();
+    clearCache();
     const { mockGetAccountInfo } = stubSolanaAtaLookup(null);
 
     await expect(

--- a/tests/utils/chains/solana.spec.ts
+++ b/tests/utils/chains/solana.spec.ts
@@ -5,10 +5,9 @@ import { config as runtimeConfig } from "../../../src/config";
 import { config as mainnetConfig } from "../../../src/configs/mainnet";
 import lazySolana from "../../../src/lazy/solana";
 import {
-    clearSolanaConnectionCache,
-    clearSolanaRentExemptBalanceCache,
-    clearSolanaTokenAccountCreationCache,
+    clearSolanaCache,
     decodeSolanaAddress,
+    getSolanaAccountInfo,
     getSolanaRentExemptMinimumBalance,
     isValidSolanaAddress,
     shouldCreateSolanaTokenAccount,
@@ -31,9 +30,7 @@ beforeAll(() => {
 afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
-    clearSolanaConnectionCache();
-    clearSolanaRentExemptBalanceCache();
-    clearSolanaTokenAccountCreationCache();
+    clearSolanaCache();
 });
 
 afterAll(() => {
@@ -62,8 +59,17 @@ test("should validate Solana base58 recipients", () => {
 const stubSolanaAtaLookup = (
     accountInfoValue: Record<string, unknown> | null,
 ) => {
+    const mockGetAccountInfo = vi.fn().mockResolvedValue(accountInfoValue);
+    const mockGetVersion = vi.fn().mockResolvedValue({
+        "solana-core": "2.1.0",
+    });
+
     vi.spyOn(lazySolana, "get").mockResolvedValue({
         web3: {
+            Connection: class {
+                getVersion = mockGetVersion;
+                getAccountInfo = mockGetAccountInfo;
+            },
             PublicKey: class {
                 constructor(private readonly value: string) {}
 
@@ -77,21 +83,15 @@ const stubSolanaAtaLookup = (
         },
     } as never);
 
-    const fetchSpy = vi.fn().mockResolvedValue({
-        ok: true,
-        json: vi.fn().mockResolvedValue({
-            result: {
-                value: accountInfoValue,
-            },
-        }),
-    });
-    vi.stubGlobal("fetch", fetchSpy);
-    return fetchSpy;
+    return {
+        mockGetAccountInfo,
+        mockGetVersion,
+    };
 };
 
 test("should cache false ATA creation results", async () => {
-    clearSolanaTokenAccountCreationCache();
-    const fetchSpy = stubSolanaAtaLookup({
+    clearSolanaCache();
+    const { mockGetAccountInfo } = stubSolanaAtaLookup({
         data: ["", "base64"],
     });
 
@@ -102,12 +102,12 @@ test("should cache false ATA creation results", async () => {
         shouldCreateSolanaTokenAccount("USDT0-SOL", knownRecipientWithUsdtAta),
     ).resolves.toBe(false);
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(mockGetAccountInfo).toHaveBeenCalledTimes(1);
 });
 
 test("should not cache true ATA creation results", async () => {
-    clearSolanaTokenAccountCreationCache();
-    const fetchSpy = stubSolanaAtaLookup(null);
+    clearSolanaCache();
+    const { mockGetAccountInfo } = stubSolanaAtaLookup(null);
 
     await expect(
         shouldCreateSolanaTokenAccount(
@@ -122,7 +122,27 @@ test("should not cache true ATA creation results", async () => {
         ),
     ).resolves.toBe(true);
 
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(mockGetAccountInfo).toHaveBeenCalledTimes(2);
+});
+
+test("should cache Solana account info for existing accounts", async () => {
+    const { mockGetAccountInfo, mockGetVersion } = stubSolanaAtaLookup({
+        data: ["", "base64"],
+    });
+
+    await expect(
+        getSolanaAccountInfo("USDT0-SOL", mockAssociatedTokenAddress),
+    ).resolves.toEqual({
+        data: ["", "base64"],
+    });
+    await expect(
+        getSolanaAccountInfo("USDT0-SOL", mockAssociatedTokenAddress),
+    ).resolves.toEqual({
+        data: ["", "base64"],
+    });
+
+    expect(mockGetVersion).toHaveBeenCalledTimes(1);
+    expect(mockGetAccountInfo).toHaveBeenCalledTimes(1);
 });
 
 test("should query and cache Solana rent-exempt minimum balances", async () => {

--- a/tests/utils/oft.spec.ts
+++ b/tests/utils/oft.spec.ts
@@ -16,6 +16,7 @@ vi.mock("../../src/utils/chains/solana", async () => {
         getSolanaRentExemptMinimumBalance: vi.fn(
             actual.getSolanaRentExemptMinimumBalance,
         ),
+        shouldCreateSolanaTokenAccount: vi.fn().mockResolvedValue(false),
     };
 });
 
@@ -87,6 +88,8 @@ describe("oft", () => {
     afterEach(() => {
         vi.restoreAllMocks();
         vi.unstubAllGlobals();
+        vi.mocked(shouldCreateSolanaTokenAccount).mockReset();
+        vi.mocked(shouldCreateSolanaTokenAccount).mockResolvedValue(false);
         clearOftDeployments();
     });
 
@@ -405,6 +408,7 @@ describe("oft", () => {
             },
         } as never;
 
+        vi.mocked(shouldCreateSolanaTokenAccount).mockResolvedValue(true);
         const rpcFetchSpy = vi
             .fn()
             .mockResolvedValue(
@@ -441,10 +445,11 @@ describe("oft", () => {
             200n,
         );
 
-        expect(rpcFetchSpy).toHaveBeenCalledTimes(2);
+        expect(shouldCreateSolanaTokenAccount).toHaveBeenCalledTimes(2);
     });
 
     test("should include Solana ATA creation options in OFT send params", async () => {
+        vi.mocked(shouldCreateSolanaTokenAccount).mockResolvedValue(true);
         const rpcFetchSpy = vi
             .fn()
             .mockResolvedValue(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified scattered Solana caching into a single prefix-based cache with one clear operation; replaced ad-hoc cache handling across the codebase.
  * Routed repeated on-chain reads through the shared cache to simplify logic and reduce duplicated retrieval flows.

* **New Features**
  * Added a general-purpose caching utility with conditional retention and in-flight deduplication.
  * Added cached account-info retrieval to cut repeated RPC calls.

* **Tests**
  * Updated and added tests covering cache semantics, dedupe, conditional retention, and invalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->