### PR TITLE
fix: aqua link, line break in Spanish

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1033,7 +1033,7 @@ const dict = {
         blockexplorer_refund_tx: "Transacción de Reembolso",
         help: "Ayuda",
         network_fee: "Comisión de red",
-        swap_fees: "Comisiones del intercambio",
+        swap_fees: "Comisiones intercambio",
         fee: "Comisión de Boltz",
         denomination: "Denominación",
         send: "Enviar",

--- a/src/pages/Hero.tsx
+++ b/src/pages/Hero.tsx
@@ -147,10 +147,7 @@ export const Hero = () => {
                         />
                     </div>
                     <div>
-                        <ExternalLink
-                            href="https://aquawallet.io/"
-                            class="aqua"
-                        />
+                        <ExternalLink href="https://aqua.net/" class="aqua" />
                     </div>
                     <div>
                         <ExternalLink


### PR DESCRIPTION
Before:
<img width="595" height="66" alt="image" src="https://github.com/user-attachments/assets/88eb90ca-e9ad-491f-90b0-659bcd03a605" />
After:
<img width="595" height="66" alt="image" src="https://github.com/user-attachments/assets/1d5a211d-9ad1-4fdc-978f-2e2b144cb895" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Spanish translation for swap fees.

* **Updates**
  * Updated Aqua integration link to the latest URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->