### PR TITLE
fix: fees CSS and HTML structure for fees

### DIFF
--- a/src/components/FeesCollapse.tsx
+++ b/src/components/FeesCollapse.tsx
@@ -234,20 +234,28 @@ const FeesCollapse = () => {
         switch (view.status) {
             case FeeUsdViewStatus.Ok:
                 return (
-                    <>
-                        ≈{" "}
+                    <span class="fees-toggle-value">
+                        ≈&nbsp;
                         <span data-testid="fees-total-amount">
                             {view.amount.toFixed(2)}
-                        </span>{" "}
-                        {Currency.USD}
-                    </>
+                        </span>
+                        &nbsp;{Currency.USD}
+                    </span>
                 );
 
             case FeeUsdViewStatus.Loading:
-                return <span class="skeleton" />;
+                return (
+                    <span class="fees-toggle-value">
+                        <span class="skeleton" />
+                    </span>
+                );
 
             case FeeUsdViewStatus.Error:
-                return t("fiat_rate_not_available");
+                return (
+                    <span class="fees-toggle-value">
+                        {t("fiat_rate_not_available")}
+                    </span>
+                );
 
             default: {
                 const exhaustiveCheck: never = view;
@@ -279,10 +287,13 @@ const FeesCollapse = () => {
                 data-testid="fees-toggle"
                 aria-expanded={feesExpanded()}
                 onClick={() => setFeesExpanded(!feesExpanded())}>
-                <span class="fees-toggle-icon">
-                    <VsChevronRight />
+                <span class="fees-toggle-label">
+                    <span class="fees-toggle-icon">
+                        <VsChevronRight />
+                    </span>
+                    {t("swap_fees")}:
                 </span>
-                {t("swap_fees")}: {renderTotalCollapsibleFeesUsdView()}
+                {renderTotalCollapsibleFeesUsdView()}
             </button>
             <div
                 class="fees-details-shell"

--- a/src/components/SwapLimits.tsx
+++ b/src/components/SwapLimits.tsx
@@ -31,28 +31,30 @@ type SwapLimitsProps = {
 
 const SwapLimit = (props: SwapLimitProps) => {
     return (
-        <span>
-            {props.label}
-            {props.loading ? (
-                <span
-                    class="swap-limit-value swap-limit-value-loading"
-                    aria-busy="true"
-                    aria-disabled="true">
-                    <span class="skeleton" aria-hidden="true" />
-                </span>
-            ) : (
-                <span
-                    onClick={() => props.onClick()}
-                    class="btn-small btn-light swap-limit-value">
-                    {formatAmount(
-                        BigNumber(props.amount),
-                        props.denomination,
-                        props.separator,
-                        props.asset,
-                    )}
-                </span>
-            )}
-            <AmountDenominator value={props.icon} />
+        <span class="swap-limit">
+            <span class="swap-limit-label">{props.label}</span>
+            <span class="swap-limit-amount">
+                {props.loading ? (
+                    <span
+                        class="swap-limit-value swap-limit-value-loading"
+                        aria-busy="true"
+                        aria-disabled="true">
+                        <span class="skeleton" aria-hidden="true" />
+                    </span>
+                ) : (
+                    <span
+                        onClick={() => props.onClick()}
+                        class="btn-small btn-light swap-limit-value">
+                        {formatAmount(
+                            BigNumber(props.amount),
+                            props.denomination,
+                            props.separator,
+                            props.asset,
+                        )}
+                    </span>
+                )}
+                <AmountDenominator value={props.icon} />
+            </span>
         </span>
     );
 };

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1033,7 +1033,7 @@ const dict = {
         blockexplorer_refund_tx: "Transacción de Reembolso",
         help: "Ayuda",
         network_fee: "Comisión de red",
-        swap_fees: "Comisiones intercambio",
+        swap_fees: "Comisiones del intercambio",
         fee: "Comisión de Boltz",
         denomination: "Denominación",
         send: "Enviar",

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -690,7 +690,9 @@ const Create = () => {
         <Show when={wasmSupported()} fallback={<ErrorWasm />}>
             <div class="frame">
                 <SettingsCog />
-                <h2 data-testid="create-swap-title">{t("create_swap")}</h2>
+                <h2 class="frame-title" data-testid="create-swap-title">
+                    {t("create_swap")}
+                </h2>
                 {t("create_swap_subline")} <br />
                 <SwapLimits
                     asset={pair().fromAsset}

--- a/src/pages/FeeComparison.tsx
+++ b/src/pages/FeeComparison.tsx
@@ -18,7 +18,7 @@ const FeeComparison = () => {
         <div class="frame opportunities">
             <SettingsCog />
             <SettingsMenu />
-            <h2>{t("swap_opportunities")}</h2>
+            <h2 class="frame-title">{t("swap_opportunities")}</h2>
             <p>{t("swap_opportunities_subline")}</p>
             <Accordion title={t("swap_opportunities_accordion")} isOpen={true}>
                 <FeeComparisonTable

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -46,7 +46,7 @@ const History = () => {
         <div id="history">
             <div class="frame">
                 <SettingsCog />
-                <h2>{t("refund_past_swaps")}</h2>
+                <h2 class="frame-title">{t("refund_past_swaps")}</h2>
                 <p>{t("refund_past_swaps_subline")}</p>
                 <Show
                     when={swaps().length > 0}

--- a/src/pages/Rescue.tsx
+++ b/src/pages/Rescue.tsx
@@ -65,7 +65,7 @@ const Rescue = () => {
                 <div class="frame refund" data-testid="refundFrame">
                     <header>
                         <SettingsCog />
-                        <h2>{t("rescue_swap")}</h2>
+                        <h2 class="frame-title">{t("rescue_swap")}</h2>
                     </header>
                     <Show
                         when={allSwaps()?.length > 0}

--- a/src/pages/RescueEvm.tsx
+++ b/src/pages/RescueEvm.tsx
@@ -282,7 +282,9 @@ const RescueEvm = () => {
                     <Match when={rescueData.state === "ready"}>
                         <SettingsCog />
                         <SettingsMenu />
-                        <h2 style={{ "margin-bottom": "6px" }}>
+                        <h2
+                            class="frame-title"
+                            style={{ "margin-bottom": "6px" }}>
                             {pageTitle()} {cropString(params.txHash, 15, 5)}
                         </h2>
                         <hr />

--- a/src/pages/RescueExternal.tsx
+++ b/src/pages/RescueExternal.tsx
@@ -896,7 +896,9 @@ const RescueExternal = () => {
                     <div class="frame refund" data-testid="refundFrame">
                         <header>
                             <SettingsCog />
-                            <h2>{t("rescue_external_swap")}</h2>
+                            <h2 class="frame-title">
+                                {t("rescue_external_swap")}
+                            </h2>
                         </header>
                         <Show when={evmAvailable}>
                             <div class="tabs">

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -855,20 +855,14 @@ textarea.invalid {
     border-right: 0;
     background: var(--color-secondary-700);
 }
-.frame > h2 {
+.frame-title {
     padding-inline-end: 1.9rem;
     overflow-wrap: break-word;
 }
 
 @media (min-width: 400px) {
-    .frame > h2 {
+    .frame-title {
         padding-inline-start: 2.75rem;
-    }
-}
-
-@media (max-width: 399px) {
-    .frame-header > h2 {
-        padding-inline-end: 0;
     }
 }
 .swap-status {

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -118,13 +118,18 @@ hr.spacer {
 
 .fees-dyn {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: auto 1fr;
     align-items: start;
+    gap: 0.5rem;
 }
 
 .fees-dyn > .fees-dyn-denom {
     display: flex;
     align-items: center;
+}
+
+.fees-dyn > .fees-dyn-right {
+    min-width: 0;
 }
 
 .fees-dyn-right {
@@ -161,9 +166,10 @@ hr.spacer {
 
 .fees-toggle {
     display: inline-flex;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: flex-end;
-    gap: 0.2rem;
+    gap: 0.2rem 0.35rem;
     border: none;
     background: none;
     margin: 0;
@@ -173,6 +179,14 @@ hr.spacer {
     color: inherit;
     text-align: right;
     transition: color 0.18s ease-out;
+}
+
+.fees-toggle-label,
+.fees-toggle-value {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+    white-space: nowrap;
 }
 
 @media (hover: hover) {
@@ -1326,7 +1340,9 @@ header {
 
 .swap-limits {
     display: inline-flex;
-    gap: 0.8rem;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.35rem 0.8rem;
 
     .denominator-text {
         margin-left: 0.5rem;
@@ -1337,6 +1353,19 @@ header {
         align-items: center;
         padding: 0 6px;
     }
+}
+
+.swap-limit {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    white-space: nowrap;
+}
+
+.swap-limit-amount {
+    display: inline-flex;
+    align-items: center;
+    white-space: nowrap;
 }
 
 .text-bold {

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -855,6 +855,22 @@ textarea.invalid {
     border-right: 0;
     background: var(--color-secondary-700);
 }
+.frame > h2 {
+    padding-inline-end: 1.9rem;
+    overflow-wrap: break-word;
+}
+
+@media (min-width: 400px) {
+    .frame > h2 {
+        padding-inline-start: 2.75rem;
+    }
+}
+
+@media (max-width: 399px) {
+    .frame-header > h2 {
+        padding-inline-end: 0;
+    }
+}
 .swap-status {
     display: inline-flex;
     gap: 0.5rem;


### PR DESCRIPTION
Closes #1345 

iPhone SE
<img width="381" height="593" alt="image" src="https://github.com/user-attachments/assets/f5438f19-7802-41cb-be7a-68e4c41cab4b" />

This screenshot below is smaller than iPhone SE (323px width)
<img width="381" height="674" alt="image" src="https://github.com/user-attachments/assets/49ab5859-08de-4633-bbc7-72b0f6aaa5c4" />

I don't know what device is smaller than iPhone SE, but I've seen people using it. Spanish still looks the worst, but it's readable. 

Checked all other languages, no more settings cog overlap or confusing line breaks.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced layout, spacing and wrapping for fee and swap-limit displays; added responsive title padding for better small-width handling
  * Standardized fee toggle and swap-limit visual wrappers for consistent alignment and whitespace

* **Refactor**
  * Restructured markup for fee toggle and swap-limit components to improve rendering consistency

* **Localization**
  * Spanish translation updated for the fees label
<!-- end of auto-generated comment: release notes by coderabbit.ai -->