### PR TITLE
test: E2E for performing asset rescue twice

### DIFF
--- a/e2e/rescue/assetRescue.spec.ts
+++ b/e2e/rescue/assetRescue.spec.ts
@@ -2,12 +2,14 @@ import { type Page, expect, test } from "@playwright/test";
 import fs from "fs";
 import path from "path";
 
+import { LBTC } from "../../src/consts/Assets";
 import dict from "../../src/i18n/i18n";
 import {
     createAndVerifySwap,
     execCommand,
     generateLiquidBlock,
     getLiquidAddress,
+    waitForUTXOs,
 } from "../utils";
 
 test.describe("Asset Rescue", () => {
@@ -19,46 +21,84 @@ test.describe("Asset Rescue", () => {
         }
     });
 
-    const refundAsset = async (page: Page) => {
-        const address = await page.evaluate(() => {
-            return navigator.clipboard.readText();
-        });
+    const amountIssued = 1;
+    const amountSent = 0.125;
 
-        const amountIssued = 1;
+    const sendWrongAsset = async (address: string): Promise<string> => {
         const { asset } = JSON.parse(
             await execCommand(
                 `elements-cli-sim-client issueasset ${amountIssued} ${amountIssued}`,
             ),
-        );
-        const amountSent = 0.125;
+        ) as { asset: string };
         await execCommand(
             `elements-cli-sim-client -named sendtoaddress address=${address} amount=${amountSent} assetlabel=${asset}`,
         );
 
-        let balances = JSON.parse(
+        const balances = JSON.parse(
             await execCommand("elements-cli-sim-client getbalance"),
         );
         expect(balances[asset]).toEqual(amountIssued - amountSent);
 
-        await expect(page.getByText("transaction.lockupFailed")).toBeVisible();
+        return asset;
+    };
 
-        await page.getByTestId("refundAddress").fill(await getLiquidAddress());
+    const performRefund = async (page: Page, asset: string) => {
+        const refundAddressInput = page.getByTestId("refundAddress");
+        await expect(refundAddressInput).toBeVisible();
+        await refundAddressInput.fill(await getLiquidAddress());
         await page.getByTestId("refundButton").click();
 
         await expect(page.getByText(dict.en.refunded)).toBeVisible();
 
         await generateLiquidBlock();
 
-        balances = JSON.parse(
+        const balances = JSON.parse(
             await execCommand("elements-cli-sim-client getbalance"),
         );
         expect(balances[asset]).toEqual(amountIssued);
+    };
+
+    const refundAssetToAddress = async (page: Page, address: string) => {
+        const asset = await sendWrongAsset(address);
+        await performRefund(page, asset);
+    };
+
+    const refundAsset = async (page: Page) => {
+        const address = await page.evaluate(() => {
+            return navigator.clipboard.readText();
+        });
+        await refundAssetToAddress(page, address);
     };
 
     test("Refunds assets sent to submarine swap", async ({ page }) => {
         await createAndVerifySwap(page, fileName);
 
         await refundAsset(page);
+    });
+
+    test("Refunds assets sent to same submarine swap twice", async ({
+        page,
+    }) => {
+        await createAndVerifySwap(page, fileName);
+
+        const address = await page.evaluate(() =>
+            navigator.clipboard.readText(),
+        );
+
+        await refundAssetToAddress(page, address);
+
+        // Second rescue goes via the rescue-file route
+        const asset = await sendWrongAsset(address);
+        await waitForUTXOs(LBTC, address, 1);
+
+        await page.getByRole("link", { name: "Rescue" }).click();
+        await page
+            .getByRole("button", { name: dict.en.rescue_external_swap })
+            .click();
+        await page.getByTestId("refundUpload").setInputFiles(fileName);
+        await page.locator(".swaplist-item").first().click();
+
+        await performRefund(page, asset);
     });
 
     test("Refunds assets sent to chain swap", async ({ page }) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new end-to-end test case for asset rescue functionality when assets are sent to the same address multiple times
  * Refactored test infrastructure with reusable helpers to improve maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->