### PR TITLE
refactor: remove lockup address link for EVM chains

### DIFF
--- a/e2e/chainSwaps/chainSwaps.spec.ts
+++ b/e2e/chainSwaps/chainSwaps.spec.ts
@@ -46,7 +46,7 @@ test.describe("Chain swap", () => {
         const inputSendAmount = page.locator("input[data-testid='sendAmount']");
         const sendAmount = await expectApproxAmount(
             inputSendAmount,
-            "0.01002783",
+            "0.01002793",
         );
 
         const inputOnchainAddress = page.locator(
@@ -183,7 +183,7 @@ test.describe("Chain swap", () => {
         const inputSendAmount = page.locator("input[data-testid='sendAmount']");
         const sendAmount = await expectApproxAmount(
             inputSendAmount,
-            "0.01002783",
+            "0.01002793",
         );
 
         const inputOnchainAddress = page.locator(

--- a/e2e/chainSwaps/zeroAmount.spec.ts
+++ b/e2e/chainSwaps/zeroAmount.spec.ts
@@ -56,7 +56,7 @@ test.describe("Chain Swap 0-amount", () => {
         const txInfo = JSON.parse(await getElementsWalletTx(txId));
         expectApproxBtcAmount(
             txInfo.amount.bitcoin.toString(),
-            "0.00997303",
+            "0.00997297",
             amountBufferSats,
         );
     });

--- a/e2e/reverseSwap.spec.ts
+++ b/e2e/reverseSwap.spec.ts
@@ -27,7 +27,7 @@ test.describe("reverseSwap", () => {
         const inputSendAmount = page.locator("input[data-testid='sendAmount']");
         const sendAmount = await expectApproxAmount(
             inputSendAmount,
-            "0.01005284",
+            "0.01005294",
         );
 
         const inputOnchainAddress = page.locator(
@@ -88,7 +88,7 @@ test.describe("reverseSwap", () => {
         const inputSendAmount = page.locator("input[data-testid='sendAmount']");
         const sendAmount = await expectApproxAmount(
             inputSendAmount,
-            "0.01005284",
+            "0.01005294",
         );
 
         const inputOnchainAddress = page.locator(

--- a/e2e/submarineSwap.spec.ts
+++ b/e2e/submarineSwap.spec.ts
@@ -38,7 +38,7 @@ test.describe("Submarine swap", () => {
         const inputSendAmount = page.locator("input[data-testid='sendAmount']");
         const sendAmount = await expectApproxAmount(
             inputSendAmount,
-            "0.01001146",
+            "0.01001152",
         );
 
         const invoiceInput = page.locator("textarea[data-testid='invoice']");

--- a/src/components/BlockExplorerLink.tsx
+++ b/src/components/BlockExplorerLink.tsx
@@ -26,21 +26,36 @@ const ChainSwapLink = (props: {
         hasBeenClaimed() ? props.swap().assetReceive : props.swap().assetSend;
 
     return (
-        <BlockExplorer
-            asset={asset()}
-            txId={props.swap().claimTx}
-            explorer={
-                props.swap().oft !== undefined && isEvmAsset(asset())
-                    ? ExplorerKind.LayerZero
-                    : undefined
-            }
-            address={
-                // When it has been claimed, the "txId" is populated
-                hasBeenClaimed()
-                    ? undefined
-                    : (props.swap() as ChainSwap).lockupDetails.lockupAddress
-            }
-        />
+        <Show
+            when={!hasBeenClaimed() && isEvmAsset(asset())}
+            fallback={
+                <BlockExplorer
+                    asset={asset()}
+                    txId={props.swap().claimTx}
+                    explorer={
+                        props.swap().oft !== undefined && isEvmAsset(asset())
+                            ? ExplorerKind.LayerZero
+                            : undefined
+                    }
+                    address={
+                        // When it has been claimed, the "txId" is populated
+                        hasBeenClaimed()
+                            ? undefined
+                            : (props.swap() as ChainSwap).lockupDetails
+                                  .lockupAddress
+                    }
+                />
+            }>
+            {/* Showing addresses makes no sense for EVM based chains.
+                The lockup tx is a regular EVM tx, not a LayerZero message. */}
+            <Show when={props.swap().lockupTx}>
+                <BlockExplorer
+                    asset={asset()}
+                    txId={props.swap().lockupTx}
+                    typeLabel={"lockup_tx"}
+                />
+            </Show>
+        </Show>
     );
 };
 

--- a/tests/components/BlockExplorerLink.spec.tsx
+++ b/tests/components/BlockExplorerLink.spec.tsx
@@ -3,7 +3,7 @@ import { createSignal } from "solid-js";
 
 import BlockExplorerLink from "../../src/components/BlockExplorerLink";
 import { config } from "../../src/config";
-import { BTC, LBTC, USDT0 } from "../../src/consts/Assets";
+import { BTC, LBTC, RBTC, TBTC, USDT0 } from "../../src/consts/Assets";
 import { SwapType } from "../../src/consts/Enums";
 import type { ChainSwap, SomeSwap } from "../../src/utils/swapCreator";
 import { contextWrapper } from "../helper";
@@ -101,6 +101,8 @@ describe("BlockExplorerLink", () => {
     });
 
     describe("Chain Swaps", () => {
+        const evmSendAssets = [RBTC, TBTC, USDT0] as const;
+
         test("should show lockup address when not claimed yet", async () => {
             const [swap] = createSignal<ChainSwap>({
                 type: SwapType.Chain,
@@ -156,6 +158,122 @@ describe("BlockExplorerLink", () => {
             expect(button.href).toEqual(
                 // eslint-disable-next-line solid/reactivity
                 `${config.assets[BTC].blockExplorerUrl.normal}/tx/${swap().claimTx}`,
+            );
+        });
+
+        test.each(evmSendAssets)(
+            "should not show lockup address when sending from %s without lockup transaction",
+            (assetSend) => {
+                const [swap] = createSignal<ChainSwap>({
+                    type: SwapType.Chain,
+                    assetSend,
+                    assetReceive: BTC,
+                    lockupDetails: {
+                        lockupAddress: "0xabc",
+                    },
+                } as unknown as ChainSwap);
+
+                render(
+                    () => (
+                        <BlockExplorerLink swap={swap} swapStatus={() => ""} />
+                    ),
+                    { wrapper: contextWrapper },
+                );
+
+                expect(screen.queryByText("open lockup address")).toBeNull();
+                expect(
+                    screen.queryByText("open lockup transaction"),
+                ).toBeNull();
+            },
+        );
+
+        test.each(evmSendAssets)(
+            "should show lockup transaction (not address) when sending from %s",
+            async (assetSend) => {
+                const lockupTx = "0xdeadbeef";
+                const [swap] = createSignal<ChainSwap>({
+                    type: SwapType.Chain,
+                    assetSend,
+                    assetReceive: BTC,
+                    lockupTx,
+                    lockupDetails: {
+                        lockupAddress: "0xabc",
+                    },
+                } as unknown as ChainSwap);
+
+                render(
+                    () => (
+                        <BlockExplorerLink swap={swap} swapStatus={() => ""} />
+                    ),
+                    { wrapper: contextWrapper },
+                );
+
+                expect(screen.queryByText("open lockup address")).toBeNull();
+
+                const button = (await screen.findByText(
+                    "open lockup transaction",
+                )) as HTMLAnchorElement;
+
+                expect(button.href).toEqual(
+                    `${config.assets[assetSend].blockExplorerUrl.normal}/tx/${lockupTx}`,
+                );
+            },
+        );
+
+        test("should route EVM lockup transaction to asset explorer, not LayerZero, for OFT chain swaps", async () => {
+            const lockupTx = "0xdeadbeef";
+            const [swap] = createSignal<ChainSwap>({
+                type: SwapType.Chain,
+                assetSend: RBTC,
+                assetReceive: USDT0,
+                lockupTx,
+                oft: {
+                    sourceAsset: USDT0,
+                    destinationAsset: "USDT0-ETH",
+                },
+                lockupDetails: {
+                    lockupAddress: "0xabc",
+                },
+            } as unknown as ChainSwap);
+
+            render(
+                () => <BlockExplorerLink swap={swap} swapStatus={() => ""} />,
+                { wrapper: contextWrapper },
+            );
+
+            const button = (await screen.findByText(
+                "open lockup transaction",
+            )) as HTMLAnchorElement;
+
+            expect(button.href).toEqual(
+                `${config.assets[RBTC].blockExplorerUrl.normal}/tx/${lockupTx}`,
+            );
+        });
+
+        test("should still show claim transaction after claim when sending from EVM chain", async () => {
+            const claimTx = "0xclaim";
+            const [swap] = createSignal<ChainSwap>({
+                type: SwapType.Chain,
+                assetSend: RBTC,
+                assetReceive: BTC,
+                claimTx,
+                lockupTx: "0xdeadbeef",
+                lockupDetails: {
+                    lockupAddress: "0xabc",
+                },
+            } as unknown as ChainSwap);
+
+            render(
+                () => <BlockExplorerLink swap={swap} swapStatus={() => ""} />,
+                { wrapper: contextWrapper },
+            );
+
+            const button = (await screen.findByText(
+                "open claim transaction",
+            )) as HTMLAnchorElement;
+
+            expect(button.href).toEqual(
+                `${config.assets[BTC].blockExplorerUrl.normal}/tx/${claimTx}`,
             );
         });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Block explorer links for chain swaps now correctly show lockup transaction and claim transaction links depending on swap status and asset type (EVM vs non-EVM).
* **Tests**
  * Expanded unit tests for EVM send-asset cases covering presence/absence of lockup tx and claim links.
  * Updated several end-to-end test expected BTC amount values to reflect minor amount adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->