### PR TITLE
fix: asset routes

### DIFF
--- a/src/consts/Assets.ts
+++ b/src/consts/Assets.ts
@@ -107,8 +107,17 @@ export const getNetworkTransport = (
     return config.assets?.[asset]?.network?.transport;
 };
 
+const getAssetConfig = (asset: string) => config.assets?.[asset];
+
 export const getCanonicalAsset = (asset: string): string =>
     getAssetBridge(asset)?.canonicalAsset ?? asset;
+
+const getCanonicalAssetConfig = (asset: string) =>
+    getAssetConfig(getCanonicalAsset(asset));
+
+export const getRouteViaAsset = (asset: string): string | undefined =>
+    getAssetConfig(asset)?.token?.routeVia ??
+    getCanonicalAssetConfig(asset)?.token?.routeVia;
 
 export const getBridgeMesh = (from: string, to?: string): Usdt0Kind => {
     const meshKinds = [from, to]
@@ -259,18 +268,22 @@ export const getNetworkBadge = (asset: string): string | null => {
 };
 
 export const getRouterAddress = (asset: string): string | undefined => {
-    const assetConfig = config.assets?.[asset];
+    const assetConfig = getAssetConfig(asset);
     if (!assetConfig) {
         return undefined;
     }
 
-    // If this asset routes via another asset, get that asset's router
-    if (assetConfig.token?.routeVia) {
-        const routeViaConfig = config.assets?.[assetConfig.token.routeVia];
+    // Bridge variants inherit route metadata from their canonical asset.
+    const routeVia = getRouteViaAsset(asset);
+    if (routeVia) {
+        const routeViaConfig = getAssetConfig(routeVia);
         return routeViaConfig?.contracts?.router;
     }
 
-    return assetConfig.contracts?.router;
+    return (
+        assetConfig.contracts?.router ??
+        getCanonicalAssetConfig(asset)?.contracts?.router
+    );
 };
 
 export const requireRouterAddress = (asset: string): string => {

--- a/src/utils/Pair.ts
+++ b/src/utils/Pair.ts
@@ -10,6 +10,7 @@ import {
     LN,
     TBTC,
     getCanonicalAsset,
+    getRouteViaAsset,
     isBridgeAsset,
     isEvmAsset,
 } from "../consts/Assets";
@@ -50,7 +51,7 @@ import { assetAmountToSats, satsToAssetAmount } from "./rootstock";
  * Non-routed assets (like TBTC) use sats internally and need conversion.
  */
 const isRoutedAsset = (asset: string) =>
-    config.assets[asset]?.token?.routeVia !== undefined ||
+    getRouteViaAsset(asset) !== undefined ||
     config.assets[asset]?.bridge !== undefined;
 
 /** Convert an internal amount to EVM base units for the DEX API. */
@@ -173,8 +174,6 @@ export default class Pair {
         const routeTarget = getCanonicalAsset(to);
         const canonicalSourceAsset = config.assets[routeSource];
         const canonicalTargetAsset = config.assets[routeTarget];
-        const sourceRouteConfig = config.assets[from] ?? canonicalSourceAsset;
-        const targetRouteConfig = config.assets[to] ?? canonicalTargetAsset;
         this.preBridgeDriver = bridgeRegistry.getDriverForAsset(from);
         this.preBridge = this.preBridgeDriver?.getPreRoute(from);
         this.postBridgeDriver = bridgeRegistry.getDriverForAsset(to);
@@ -213,7 +212,7 @@ export default class Pair {
             canonicalTargetAsset !== undefined &&
             canonicalTargetAsset.type === AssetKind.ERC20
         ) {
-            const hopAssetSymbol = targetRouteConfig?.token?.routeVia;
+            const hopAssetSymbol = getRouteViaAsset(to);
             const hopAsset = config.assets[hopAssetSymbol];
             const hopPair =
                 hopAssetSymbol !== undefined
@@ -254,7 +253,7 @@ export default class Pair {
             canonicalSourceAsset !== undefined &&
             canonicalSourceAsset.type === AssetKind.ERC20
         ) {
-            const hopAssetSymbol = sourceRouteConfig?.token?.routeVia;
+            const hopAssetSymbol = getRouteViaAsset(from);
             const hopAsset = config.assets[hopAssetSymbol];
             const hopPair =
                 hopAssetSymbol !== undefined

--- a/tests/consts/Assets.spec.ts
+++ b/tests/consts/Assets.spec.ts
@@ -5,6 +5,7 @@ import {
     LBTC,
     LN,
     RBTC,
+    TBTC,
     USDT0,
     getAssetDisplaySymbol,
     getBridgeVariants,
@@ -15,6 +16,7 @@ import {
     isBridgeCanonicalAsset,
     isBridgeVariant,
     isStablecoinAsset,
+    requireRouterAddress,
 } from "../../src/consts/Assets";
 
 vi.mock("../../src/config", async () => {
@@ -118,21 +120,57 @@ describe("Assets", () => {
 
     describe("getRouteViaAsset", () => {
         test.each`
-            input           | expected
-            ${USDT0}        | ${"TBTC"}
-            ${"USDT0-ETH"}  | ${"TBTC"}
-            ${"USDT0-TRON"} | ${"TBTC"}
-            ${BTC}          | ${undefined}
+            input             | expected
+            ${USDT0}          | ${"TBTC"}
+            ${"USDT0-ETH"}    | ${"TBTC"}
+            ${"USDT0-TRON"}   | ${"TBTC"}
+            ${"USDT0-POL"}    | ${"TBTC"}
+            ${BTC}            | ${undefined}
+            ${TBTC}           | ${undefined}
+            ${"not-an-asset"} | ${undefined}
         `("$input -> $expected", ({ input, expected }) => {
             expect(getRouteViaAsset(input)).toBe(expected);
         });
     });
 
     describe("getRouterAddress", () => {
+        const tbtcRouter = "0x6EA68e965fcd19b6fbC6553BABbF87a5018F9B28";
+
+        test("resolves the canonical asset's routeVia hop router", () => {
+            expect(getRouterAddress(USDT0)).toBe(tbtcRouter);
+        });
+
         test("inherits the canonical router path for bridge variants", () => {
-            expect(getRouterAddress("USDT0-ETH")).toBe(getRouterAddress(USDT0));
-            expect(getRouterAddress("USDT0-TRON")).toBe(
-                getRouterAddress(USDT0),
+            expect(getRouterAddress("USDT0-ETH")).toBe(tbtcRouter);
+            expect(getRouterAddress("USDT0-TRON")).toBe(tbtcRouter);
+            expect(getRouterAddress("USDT0-POL")).toBe(tbtcRouter);
+        });
+
+        test("returns the asset's own router when it has no routeVia", () => {
+            expect(getRouterAddress(TBTC)).toBe(tbtcRouter);
+        });
+
+        test.each([BTC, RBTC, "not-an-asset"])(
+            "returns undefined for %s",
+            (asset) => {
+                expect(getRouterAddress(asset)).toBeUndefined();
+            },
+        );
+    });
+
+    describe("requireRouterAddress", () => {
+        test("returns the resolved router for bridge variants", () => {
+            expect(requireRouterAddress("USDT0-ETH")).toBe(
+                requireRouterAddress(USDT0),
+            );
+        });
+
+        test("throws when no router is configured", () => {
+            expect(() => requireRouterAddress(BTC)).toThrow(
+                /no router configured/,
+            );
+            expect(() => requireRouterAddress("not-an-asset")).toThrow(
+                /no router configured/,
             );
         });
     });

--- a/tests/consts/Assets.spec.ts
+++ b/tests/consts/Assets.spec.ts
@@ -9,6 +9,8 @@ import {
     getAssetDisplaySymbol,
     getBridgeVariants,
     getCanonicalAsset,
+    getRouteViaAsset,
+    getRouterAddress,
     isBridgeAsset,
     isBridgeCanonicalAsset,
     isBridgeVariant,
@@ -111,6 +113,27 @@ describe("Assets", () => {
         test("returns empty list for an asset with no variants", () => {
             expect(getBridgeVariants(BTC)).toEqual([]);
             expect(getBridgeVariants(RBTC)).toEqual([]);
+        });
+    });
+
+    describe("getRouteViaAsset", () => {
+        test.each`
+            input           | expected
+            ${USDT0}        | ${"TBTC"}
+            ${"USDT0-ETH"}  | ${"TBTC"}
+            ${"USDT0-TRON"} | ${"TBTC"}
+            ${BTC}          | ${undefined}
+        `("$input -> $expected", ({ input, expected }) => {
+            expect(getRouteViaAsset(input)).toBe(expected);
+        });
+    });
+
+    describe("getRouterAddress", () => {
+        test("inherits the canonical router path for bridge variants", () => {
+            expect(getRouterAddress("USDT0-ETH")).toBe(getRouterAddress(USDT0));
+            expect(getRouterAddress("USDT0-TRON")).toBe(
+                getRouterAddress(USDT0),
+            );
         });
     });
 

--- a/tests/utils/Pair.spec.ts
+++ b/tests/utils/Pair.spec.ts
@@ -80,9 +80,11 @@ vi.mock("../../src/config", async () => {
                             decimals: 18,
                         },
                     },
+                    // Intentionally omits `token.routeVia` to mirror real mainnet
+                    // variants, which inherit routing from the canonical asset.
                     token: {
-                        ...actual.config.assets.USDT0.token,
                         address: "0x0000000000000000000000000000000000000137",
+                        decimals: 6,
                     },
                 },
                 "USDT0-CFX": {
@@ -372,6 +374,14 @@ describe("Pair", () => {
         const pair = new Pair(undefined, "NONEXISTENT", LN);
         expect(pair.isRoutable).toBe(false);
         expect(pair.maxRoutingFee).toBeUndefined();
+    });
+
+    test("should route bridge variants that inherit routeVia from the canonical asset", () => {
+        // USDT0-POL has no own `token.routeVia` — it must inherit "TBTC" from
+        // the canonical USDT0 asset for the DEX hop to be discovered in either
+        // direction.
+        expect(new Pair(pairs, "USDT0-POL", LN).isRoutable).toBe(true);
+        expect(new Pair(pairs, LN, "USDT0-POL").isRoutable).toBe(true);
     });
 
     test("should treat unsupported send variants as non-routable", () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved router resolution for bridge variants: routeVia is now inherited from canonical assets and router lookup falls back to the canonical asset when needed, ensuring correct hop-routing detection.

* **Tests**
  * Added coverage validating routeVia inheritance, router resolution for canonical and bridge assets, and that bridge variants are routable in both directions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->