### PR TITLE
chore: add missing asset url params and test

### DIFF
--- a/docs/urlParams.md
+++ b/docs/urlParams.md
@@ -24,6 +24,7 @@ are:
 - `L-BTC`
 - `RBTC`
 - `TBTC`
+- `USDT0` (Arbitrum)
 - `USDT0-ETH`
 - `USDT0-BERA`
 - `USDT0-CFX`
@@ -43,6 +44,7 @@ are:
 - `USDT0-SEI`
 - `USDT0-SOL`
 - `USDT0-STABLE`
+- `USDT0-TEMPO`
 - `USDT0-TRON`
 - `USDT0-UNI`
 - `USDT0-XLAYER`

--- a/tests/configs/urlParamsDoc.spec.ts
+++ b/tests/configs/urlParamsDoc.spec.ts
@@ -1,0 +1,44 @@
+import docMarkdown from "../../docs/urlParams.md?raw";
+import { config } from "../../src/configs/mainnet";
+import { LN } from "../../src/consts/Assets";
+
+const parseDocumentedAssetsFromUrlParamsDoc = (markdown: string): string[] => {
+    const sectionStartRe = /^## Assets\s*$/m;
+    const startMatch = sectionStartRe.exec(markdown);
+    if (startMatch === null) {
+        throw new Error("docs/urlParams.md: missing ## Assets section");
+    }
+
+    const fromHeading = markdown.slice(startMatch.index + startMatch[0].length);
+    const nextHeading = fromHeading.search(/\n## /);
+    const section =
+        nextHeading === -1 ? fromHeading : fromHeading.slice(0, nextHeading);
+
+    const documented: string[] = [];
+    const lineRe = /^- `([^`]+)`/gm;
+    let match: RegExpExecArray | null;
+    while ((match = lineRe.exec(section)) !== null) {
+        documented.push(match[1]);
+    }
+    return documented;
+};
+
+describe("docs/urlParams.md", () => {
+    test("documents every sendAsset/receiveAsset value for mainnet", () => {
+        const expected = [LN, ...Object.keys(config.assets)];
+
+        const documented = parseDocumentedAssetsFromUrlParamsDoc(docMarkdown);
+
+        const missing = expected.filter((a) => !documented.includes(a));
+        const stale = documented.filter((a) => !expected.includes(a));
+
+        expect(
+            missing,
+            `Add to docs/urlParams.md ## Assets: ${missing.join(", ")}`,
+        ).toEqual([]);
+        expect(
+            stale,
+            `Remove from docs/urlParams.md ## Assets: ${stale.join(", ")}`,
+        ).toEqual([]);
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the list of supported values for `sendAsset` and `receiveAsset` query parameters to include `USDT0` (Arbitrum) and `USDT0-TEMPO`.

* **Tests**
  * Added an automated check that validates the documented asset list matches the system's expected asset configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->