### PR TITLE
fix: TrustWallet on iOs v2

### DIFF
--- a/src/components/WalletConnect.tsx
+++ b/src/components/WalletConnect.tsx
@@ -10,7 +10,10 @@ import { NetworkTransport } from "../configs/base";
 import { getEvmAssets } from "../consts/Assets";
 import { useWeb3Signer } from "../context/Web3";
 import loader from "../lazy/walletConnect";
-import type { WalletConnectRuntimeProvider } from "../utils/WalletConnectProvider";
+import type {
+    RawEvmProvider,
+    WalletConnectRuntimeProvider,
+} from "../utils/WalletConnectProvider";
 import WalletConnectProvider from "../utils/WalletConnectProvider";
 import { buildWalletConnectNetworks } from "../utils/walletConnectNetworks";
 
@@ -104,35 +107,35 @@ export const WalletConnect = () => {
             const transport = WalletConnectProvider.getRequestedTransport();
             const namespace = getWalletConnectNamespace(transport);
             const address = created.getAddress(namespace);
-            const evmProvider = created.getProvider<{
-                request: (request: {
-                    method: string;
-                    params?: Array<unknown>;
-                }) => Promise<unknown>;
-            }>("eip155");
             let provider: WalletConnectRuntimeProvider | undefined;
             switch (transport) {
-                case NetworkTransport.Evm:
-                    provider =
-                        evmProvider !== undefined
-                            ? new BrowserProvider(
-                                  evmProvider as {
-                                      request: (request: {
-                                          method: string;
-                                          params?: Array<unknown>;
-                                      }) => Promise<unknown>;
-                                  },
-                              )
-                            : undefined;
+                case NetworkTransport.Evm: {
+                    const evmProvider =
+                        created.getProvider<RawEvmProvider>(namespace);
+                    const chainId = created.getCaipNetwork(namespace)?.id;
+
+                    if (
+                        evmProvider === undefined ||
+                        typeof chainId !== "number"
+                    ) {
+                        WalletConnectProvider.setRawEvmProvider(undefined);
+                        WalletConnectProvider.setEvmChainId(undefined);
+                        break;
+                    }
+
+                    provider = new BrowserProvider(evmProvider);
+                    WalletConnectProvider.setRawEvmProvider(evmProvider);
+                    WalletConnectProvider.setEvmChainId(chainId);
                     break;
+                }
 
                 case NetworkTransport.Solana:
                     provider =
-                        created.getProvider<SolanaWalletProvider>("solana");
+                        created.getProvider<SolanaWalletProvider>(namespace);
                     break;
 
                 case NetworkTransport.Tron:
-                    provider = created.getProvider<TronConnector>("tron");
+                    provider = created.getProvider<TronConnector>(namespace);
                     break;
             }
 

--- a/src/context/Web3.tsx
+++ b/src/context/Web3.tsx
@@ -12,7 +12,11 @@ import {
     Contract,
     type InterfaceAbi,
     JsonRpcSigner,
+    type TypedDataDomain,
+    TypedDataEncoder,
+    type TypedDataField,
     Wallet,
+    getAddress,
 } from "ethers";
 import log from "loglevel";
 import type { Accessor, JSXElement, Setter } from "solid-js";
@@ -47,6 +51,7 @@ import { getContracts } from "../utils/boltzClient";
 import type { HardwareSigner } from "../utils/hardware/HardwareSigner";
 import LedgerSigner from "../utils/hardware/LedgerSigner";
 import TrezorSigner from "../utils/hardware/TrezorSigner";
+import { isIos } from "../utils/helper";
 import {
     createAssetProvider,
     getRpcUrls,
@@ -389,6 +394,43 @@ const Web3SignerProvider = (props: {
         ) as unknown as Signer;
         nextSigner.rdns = rdns;
 
+        if (
+            rdns === walletConnectRdns &&
+            isIos() &&
+            WalletConnectProvider.isTrustWallet()
+        ) {
+            nextSigner.signTypedData = (async (
+                domain: TypedDataDomain,
+                types: Record<string, TypedDataField[]>,
+                value: Record<string, unknown>,
+            ) => {
+                const chainId =
+                    domain.chainId === null || domain.chainId === undefined
+                        ? undefined
+                        : Number(domain.chainId);
+                const normalizedChainId =
+                    chainId !== undefined && Number.isFinite(chainId)
+                        ? chainId
+                        : undefined;
+                const payload = TypedDataEncoder.getPayload(
+                    domain,
+                    types,
+                    value,
+                ) as { domain: { chainId?: number | string } };
+                if (normalizedChainId !== undefined) {
+                    payload.domain.chainId = normalizedChainId;
+                }
+
+                return (await WalletConnectProvider.requestRawEvm(
+                    {
+                        method: "eth_signTypedData_v4",
+                        params: [getAddress(address), JSON.stringify(payload)],
+                    },
+                    normalizedChainId,
+                )) as string;
+            }) as typeof nextSigner.signTypedData;
+        }
+
         return nextSigner;
     };
 
@@ -563,6 +605,19 @@ const Web3SignerProvider = (props: {
             configureHardwareProvider(activeSigner.rdns, { asset });
             await refreshConnectedSigner(
                 hardwareProvider,
+                activeSigner.rdns,
+                sanitizedChainId,
+            );
+            return;
+        }
+
+        if (
+            activeSigner?.rdns === walletConnectRdns &&
+            WalletConnectProvider.isTrustWallet()
+        ) {
+            WalletConnectProvider.setEvmChainId(assetConfig.network.chainId);
+            await refreshConnectedSigner(
+                rawProvider(),
                 activeSigner.rdns,
                 sanitizedChainId,
             );

--- a/src/utils/WalletConnectProvider.ts
+++ b/src/utils/WalletConnectProvider.ts
@@ -1,11 +1,33 @@
 import type { TronConnector } from "@reown/appkit-adapter-tron";
 import type { Provider as SolanaWalletProvider } from "@reown/appkit-utils/solana";
 import type { BrowserProvider } from "ethers";
+import log from "loglevel";
 import type { Setter } from "solid-js";
 
+import { config } from "../config";
 import { NetworkTransport } from "../configs/base";
 import type { EIP1193Provider } from "../consts/Types";
 import type { DictKey } from "../i18n/i18n";
+import { createProvider } from "./provider";
+
+export type RawEvmProvider = {
+    request: (
+        request: {
+            method: string;
+            params?: Array<unknown>;
+        },
+        chain?: string,
+        expiry?: number,
+    ) => Promise<unknown>;
+    setDefaultChain?: (caipChainId: string) => void;
+    session?: {
+        peer?: {
+            metadata?: {
+                name?: string;
+            };
+        };
+    };
+};
 
 export type WalletConnectAccount = {
     address: string;
@@ -38,6 +60,31 @@ class WalletConnectProvider implements EIP1193Provider {
         Record<NetworkTransport, WalletConnectRuntimeProvider>
     > = {};
 
+    // cached EVM session state for local `eth_chainId` / `eth_accounts`
+    private static evmChainId: string | undefined;
+    private static rawEvmProvider: RawEvmProvider | undefined;
+    private static evmAddress: string | undefined;
+
+    // read-only methods we route straight to JSON-RPC instead of the WC relay
+    private static readonly evmReadOnlyMethods: ReadonlySet<string> = new Set([
+        "eth_call",
+        "eth_estimateGas",
+        "eth_gasPrice",
+        "eth_maxPriorityFeePerGas",
+        "eth_feeHistory",
+        "eth_blockNumber",
+        "eth_getBalance",
+        "eth_getCode",
+        "eth_getTransactionByHash",
+        "eth_getTransactionCount",
+        "eth_getTransactionReceipt",
+    ]);
+
+    private static evmReadOnlyRpcChainId: string | undefined;
+    private static evmReadOnlyRpc:
+        | { send: (method: string, params: unknown[]) => Promise<unknown> }
+        | undefined;
+
     constructor() {}
 
     public static initialize = (
@@ -50,6 +97,101 @@ class WalletConnectProvider implements EIP1193Provider {
 
     public static getRequestedTransport = (): NetworkTransport =>
         WalletConnectProvider.requestedTransport;
+
+    public static setEvmChainId = (chainId: number | undefined) => {
+        if (chainId === undefined) {
+            WalletConnectProvider.evmChainId = undefined;
+            return;
+        }
+        WalletConnectProvider.evmChainId = `0x${chainId.toString(16)}`;
+        WalletConnectProvider.syncDefaultChain();
+    };
+
+    public static setRawEvmProvider = (
+        provider: RawEvmProvider | undefined,
+    ) => {
+        WalletConnectProvider.rawEvmProvider = provider;
+        WalletConnectProvider.syncDefaultChain();
+    };
+
+    public static isTrustWallet = () => {
+        const walletName =
+            WalletConnectProvider.rawEvmProvider?.session?.peer?.metadata?.name;
+        return walletName?.trim().toLowerCase() === "trust wallet";
+    };
+
+    public static requestRawEvm = async (
+        request: { method: string; params?: Array<unknown> },
+        chainId?: number,
+    ) => {
+        const provider = WalletConnectProvider.rawEvmProvider;
+        if (provider === undefined) {
+            throw new Error("wallet connect provider not initialized");
+        }
+
+        if (chainId !== undefined) {
+            WalletConnectProvider.setEvmChainId(chainId);
+        }
+
+        return await provider.request(
+            request,
+            chainId !== undefined ? `eip155:${chainId}` : undefined,
+        );
+    };
+
+    // reuse a JSON-RPC provider for the cached EVM chain when available
+    private static getEvmReadOnlyRpc = () => {
+        const chainIdHex = WalletConnectProvider.evmChainId;
+        if (chainIdHex === undefined) {
+            return undefined;
+        }
+        if (
+            WalletConnectProvider.evmReadOnlyRpc !== undefined &&
+            WalletConnectProvider.evmReadOnlyRpcChainId === chainIdHex
+        ) {
+            return WalletConnectProvider.evmReadOnlyRpc;
+        }
+        const chainId = parseInt(chainIdHex, 16);
+        const rpcUrls = Object.values(config.assets ?? {}).find(
+            (asset) =>
+                asset?.network?.transport === NetworkTransport.Evm &&
+                asset.network.chainId === chainId,
+        )?.network?.rpcUrls;
+        if (rpcUrls === undefined || rpcUrls.length === 0) {
+            return undefined;
+        }
+        try {
+            WalletConnectProvider.evmReadOnlyRpc = createProvider(rpcUrls);
+            WalletConnectProvider.evmReadOnlyRpcChainId = chainIdHex;
+            return WalletConnectProvider.evmReadOnlyRpc;
+        } catch (error) {
+            log.warn(
+                "WalletConnectProvider: failed to create read-only RPC provider",
+                error,
+            );
+            return undefined;
+        }
+    };
+
+    private static syncDefaultChain = () => {
+        const provider = WalletConnectProvider.rawEvmProvider;
+        const chainIdHex = WalletConnectProvider.evmChainId;
+        if (
+            provider === undefined ||
+            chainIdHex === undefined ||
+            provider.setDefaultChain === undefined
+        ) {
+            return;
+        }
+        try {
+            provider.setDefaultChain(`eip155:${parseInt(chainIdHex, 16)}`);
+        } catch (error) {
+            log.warn(
+                "WalletConnectProvider: setDefaultChain threw, continuing without explicit routing",
+                error,
+            );
+        }
+    };
 
     public static getSolanaProvider = (): SolanaWalletProvider => {
         const provider =
@@ -82,6 +224,10 @@ class WalletConnectProvider implements EIP1193Provider {
     ) => {
         if (address !== undefined && provider !== undefined) {
             WalletConnectProvider.providers[transport] = provider;
+        }
+
+        if (transport === NetworkTransport.Evm) {
+            WalletConnectProvider.evmAddress = address;
         }
 
         if (WalletConnectProvider.accountRequestResolver !== undefined) {
@@ -126,6 +272,30 @@ class WalletConnectProvider implements EIP1193Provider {
                         reject,
                     };
                 });
+            }
+        }
+
+        if (
+            request.method === "eth_chainId" &&
+            WalletConnectProvider.evmChainId !== undefined
+        ) {
+            return WalletConnectProvider.evmChainId as never;
+        }
+
+        if (
+            request.method === "eth_accounts" &&
+            WalletConnectProvider.evmAddress !== undefined
+        ) {
+            return [WalletConnectProvider.evmAddress] as never;
+        }
+
+        if (WalletConnectProvider.evmReadOnlyMethods.has(request.method)) {
+            const rpc = WalletConnectProvider.getEvmReadOnlyRpc();
+            if (rpc !== undefined) {
+                return (await rpc.send(
+                    request.method,
+                    (request.params ?? []) as unknown[],
+                )) as never;
             }
         }
 


### PR DESCRIPTION
Fixes:
- the `eth_signTypedData_v4` payload formatting which was being rejected by TrustWallet:
```
error Transaction failed {
  "__error": true,
  "name": "Error",
  "message": "could not coalesce error (
    error={
      \"code\": \"UNKNOWN_ERROR\",
      \"message\": \"could not coalesce error (
        error={
          \\\"code\\\": -32000,
          \\\"message\\\": \\\"The string did not match the expected pattern.\\\"
        },
        payload={
          \\\"id\\\": 2,
          \\\"jsonrpc\\\": \\\"2.0\\\",
          \\\"method\\\": \\\"eth_signTypedData_v4\\\",
          ...
        }
      )\"
    }
  )"
}
```
- sends Trust Wallet signing requests through the WalletConnect provider, fixing:
```
could not coalesce error
(error={ "code": -32601, "message": "Method not found" }, code=UNKNOWN_ERROR)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better typed-data signing for Trust Wallet on iOS via WalletConnect.

* **Improvements**
  * More reliable EVM session handling with persisted chain/address state and safer clearing when provider or chain info is unavailable.
  * Dynamic network detection for EVM, Solana, and Tron instead of hardcoded network names.
  * Routing of certain read-only EVM RPC calls to cached JSON‑RPC senders for improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->