### PR TITLE
fix: network badge background size

### DIFF
--- a/src/style/asset.scss
+++ b/src/style/asset.scss
@@ -19,7 +19,7 @@
         height: 18px;
         border-radius: 50%;
         background-image: $icon;
-        background-size: 24px 24px;
+        background-size: 18px 18px;
         background-repeat: no-repeat;
         background-position: center;
         background-color: $bg-color;


### PR DESCRIPTION
Before:
<img width="467" height="196" alt="image" src="https://github.com/user-attachments/assets/cb4b6837-71e8-45fa-a287-4d7678fae2ea" />

After:
<img width="467" height="196" alt="image" src="https://github.com/user-attachments/assets/58e50c5b-d43c-451e-80df-d70eea825580" />

And others look much better too imo, compare:
<img width="467" height="196" alt="image" src="https://github.com/user-attachments/assets/1ae9490d-f0da-4b0d-8a8c-1ee3238bfffb" />
<img width="467" height="196" alt="image" src="https://github.com/user-attachments/assets/1140672c-3c9d-4c47-920b-1c96e16f601d" />

With now:
<img width="467" height="196" alt="image" src="https://github.com/user-attachments/assets/ab994d9f-c1e5-404a-9eba-1cc55f26dadf" />
<img width="467" height="196" alt="image" src="https://github.com/user-attachments/assets/457d777f-5933-4926-b428-f260e5f5310a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized badge icon sizing for improved visual presentation. Network badge background images are now scaled more precisely to enhance design consistency and overall interface appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->