### PR TITLE
feat: separate swap button errors in "grey" and "red"

### DIFF
--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -3,7 +3,7 @@ import BigNumber from "bignumber.js";
 import type { Wallet } from "ethers";
 import log from "loglevel";
 import type { Accessor } from "solid-js";
-import { createEffect, createSignal, on } from "solid-js";
+import { createEffect, createMemo, createSignal, on } from "solid-js";
 
 import {
     BTC,
@@ -67,6 +67,15 @@ import { getMagicRoutingHintSavedFees } from "./OptimizedRoute";
 
 // In milliseconds
 const invoiceFetchTimeout = 25_000;
+
+const userErrorLabelKeys = new Set<DictKey>([
+    "invalid_pair",
+    "invalid_send_asset",
+    "maximum_amount",
+    "invalid_0_amount",
+    "min_amount_destination",
+    "max_amount_destination",
+]);
 
 const buildBridgeDetail = (
     asset: string,
@@ -225,9 +234,19 @@ const CreateButton = () => {
 
     const [buttonDisable, setButtonDisable] = createSignal(false);
     const [loading, setLoading] = createSignal(false);
-    const [buttonClass, setButtonClass] = createSignal("btn");
     const [buttonLabel, setButtonLabel] = createSignal<ButtonLabelParams>({
         key: "create_swap",
+    });
+    const pairsLoading = () => online() && pairs() === undefined;
+    const invalidPairState = () => pairs() !== undefined && !pair().isRoutable;
+    const buttonClass = createMemo(() => {
+        if (!online()) {
+            return "btn btn-danger";
+        }
+        if (!pairsLoading() && userErrorLabelKeys.has(buttonLabel().key)) {
+            return "btn btn-error";
+        }
+        return "btn";
     });
     const [originalDestination, setOriginalDestination] = createSignal<
         string | undefined
@@ -255,10 +274,6 @@ const CreateButton = () => {
         hasBolt12Offer: Boolean(bolt12Offer()),
     });
 
-    createEffect(() => {
-        setButtonClass(!online() ? "btn btn-danger" : "btn");
-    });
-
     createEffect(
         on(
             [
@@ -280,6 +295,9 @@ const CreateButton = () => {
                 setButtonDisable(false);
                 if (!online()) {
                     setButtonLabel({ key: "api_offline" });
+                    return;
+                }
+                if (pairs() === undefined) {
                     return;
                 }
                 if (!pair().isRoutable) {
@@ -831,6 +849,7 @@ const CreateButton = () => {
             class={buttonClass()}
             disabled={
                 !online() ||
+                pairsLoading() ||
                 !(valid() || validWayToFetchInvoice()) ||
                 buttonDisable() ||
                 loading() ||
@@ -843,7 +862,11 @@ const CreateButton = () => {
                     lnurl() === "")
             }
             onClick={buttonClick}>
-            {loading() || bolt12Loading() || quoteLoading() ? (
+            {(pairsLoading() ||
+                loading() ||
+                bolt12Loading() ||
+                quoteLoading()) &&
+            !invalidPairState() ? (
                 <LoadingSpinner class="inner-spinner" />
             ) : (
                 getButtonLabel(buttonLabel())

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -434,12 +434,18 @@ hr.spacer {
         background-color: var(--color-secondary-200);
     }
 }
-.btn-danger {
+.btn.btn-danger,
+.btn.btn-danger:disabled,
+.btn.btn-danger:disabled:hover,
+.btn.btn-error,
+.btn.btn-error:disabled,
+.btn.btn-error:disabled:hover {
     background-color: var(--color-error-700);
     color: var(--color-text);
 }
 @media (hover: hover) {
-    .btn-danger:hover {
+    .btn-danger:hover,
+    .btn-error:hover {
         background: var(--color-secondary-200);
     }
 }

--- a/tests/components/CreateButton.spec.tsx
+++ b/tests/components/CreateButton.spec.tsx
@@ -436,6 +436,36 @@ describe("CreateButton", () => {
         expect(btn.disabled).toBeTruthy();
     });
 
+    test("should apply btn-error class for maximum_amount", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <CreateButton />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        globalSignals.setOnline(true);
+        signals.setSendAmount(BigNumber(250_000));
+        signals.setReceiveAmount(BigNumber(200_000));
+        signals.setMinimum(50_000);
+        signals.setMaximum(200_000);
+        signals.setAmountValid(false);
+        signals.setInvoice(invoice);
+        signals.setInvoiceValid(true);
+        setPairAssets(LBTC, LN);
+
+        const btn = (await screen.findByText(
+            i18n.en.maximum_amount
+                .replace("{{ amount }}", "200 000")
+                .replace("{{ denomination }}", "sats"),
+        )) as HTMLButtonElement;
+        expect(btn.classList.contains("btn-error")).toBe(true);
+        expect(btn.classList.contains("btn-danger")).toBe(false);
+    });
+
     test("should be enabled with create_swap label", async () => {
         render(
             () => (
@@ -447,7 +477,7 @@ describe("CreateButton", () => {
             { wrapper: contextWrapper },
         );
         globalSignals.setOnline(true);
-        signals.setValid(true);
+        setPairAssets(LBTC, BTC);
         signals.setAmountValid(true);
         signals.setAddressValid(true);
         signals.setOnchainAddress(
@@ -558,6 +588,7 @@ describe("CreateButton", () => {
         signals.setInvoiceError("invalid_0_amount");
         expect(btn.disabled).toBeTruthy();
         expect(btn.textContent).toEqual(i18n.en.invalid_0_amount);
+        expect(btn.classList.contains("btn-error")).toBe(true);
         signals.setAmountValid(false);
         expect(btn.disabled).toBeTruthy();
         expect(btn.textContent).toEqual(i18n.en.invalid_0_amount);
@@ -665,6 +696,37 @@ describe("CreateButton", () => {
             expect(btn.disabled).toBe(true);
             expect(btn.textContent).toBe(i18n.en.invalid_send_asset);
         });
+        expect(btn.classList.contains("btn-error")).toBe(true);
+        expect(btn.classList.contains("btn-danger")).toBe(false);
+    });
+
+    test("should show btn-error for invalid pairs with sendable assets", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <CreateButton />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        globalSignals.setOnline(true);
+        signals.setSendAmount(BigNumber(100_000));
+        signals.setAmountValid(true);
+        signals.setInvoice(invoice);
+        signals.setInvoiceValid(true);
+        setPairAssetsWithPairs(usdt0Pairs, "USDT0-POL", "USDT0-CFX");
+
+        const btn = (await screen.findByTestId(
+            "create-swap-button",
+        )) as HTMLButtonElement;
+
+        await waitFor(() => {
+            expect(btn.textContent).toBe(i18n.en.invalid_pair);
+        });
+        expect(btn.classList.contains("btn-error")).toBe(true);
+        expect(btn.classList.contains("btn-danger")).toBe(false);
     });
 
     test("should not show a loading spinner for invalid pairs", async () => {
@@ -742,6 +804,8 @@ describe("CreateButton", () => {
         )) as HTMLButtonElement;
         expect(errorBtn).not.toBeUndefined();
         expect(errorBtn.disabled).toBeTruthy();
+        expect(errorBtn.classList.contains("btn-error")).toBe(true);
+        expect(errorBtn.classList.contains("btn-danger")).toBe(false);
     });
 
     test("should apply btn-error class only for user-error labels", async () => {
@@ -840,5 +904,7 @@ describe("CreateButton", () => {
         )) as HTMLButtonElement;
         expect(errorBtn).not.toBeUndefined();
         expect(errorBtn.disabled).toBeTruthy();
+        expect(errorBtn.classList.contains("btn-error")).toBe(true);
+        expect(errorBtn.classList.contains("btn-danger")).toBe(false);
     });
 });

--- a/tests/components/CreateButton.spec.tsx
+++ b/tests/components/CreateButton.spec.tsx
@@ -6,6 +6,8 @@ import CreateButton, {
 } from "../../src/components/CreateButton";
 import type * as ConfigModule from "../../src/config";
 import { BTC, LBTC, LN, RBTC, TBTC, USDT0 } from "../../src/consts/Assets";
+import { useCreateContext } from "../../src/context/Create";
+import { useGlobalContext } from "../../src/context/Global";
 import i18n from "../../src/i18n/i18n";
 import * as rifSigner from "../../src/rif/Signer";
 import Pair from "../../src/utils/Pair";
@@ -20,6 +22,7 @@ import {
     globalSignals,
     signals,
 } from "../helper";
+import { pairs as testPairs } from "../pairs";
 
 vi.mock("../../src/config", async () => {
     const actual =
@@ -152,6 +155,56 @@ describe("CreateButton", () => {
         render(() => <CreateButton />, {
             wrapper: contextWrapper,
         });
+    });
+
+    test("should show a loading spinner while pairs are loading", async () => {
+        render(() => <CreateButton />, {
+            wrapper: contextWrapper,
+        });
+
+        const btn = (await screen.findByTestId(
+            "create-swap-button",
+        )) as HTMLButtonElement;
+        expect(btn.disabled).toBeTruthy();
+        expect(btn.classList.contains("btn-danger")).toBe(false);
+        expect(btn.classList.contains("btn-error")).toBe(false);
+
+        expect(await screen.findByTestId("loading-spinner")).not.toBeNull();
+        expect(screen.queryByText(i18n.en.invalid_pair)).toBeNull();
+    });
+
+    test("should clear spinner and show label once pairs load", async () => {
+        let global: ReturnType<typeof useGlobalContext> | undefined;
+        let create: ReturnType<typeof useCreateContext> | undefined;
+        const Capture = () => {
+            global = useGlobalContext();
+            create = useCreateContext();
+            return null;
+        };
+
+        render(
+            () => (
+                <>
+                    <Capture />
+                    <CreateButton />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        expect(await screen.findByTestId("loading-spinner")).not.toBeNull();
+
+        global!.setPairs(testPairs);
+        global!.setRegularPairs(testPairs);
+        create!.setMinimum(50_000);
+
+        const btn = (await screen.findByText(
+            i18n.en.minimum_amount
+                .replace("{{ amount }}", "50 000")
+                .replace("{{ denomination }}", "sats"),
+        )) as HTMLButtonElement;
+        expect(btn).not.toBeUndefined();
+        expect(screen.queryByTestId("loading-spinner")).toBeNull();
     });
 
     test("should use rif relay gas abstraction for low-balance RBTC claims", async () => {
@@ -614,6 +667,35 @@ describe("CreateButton", () => {
         });
     });
 
+    test("should not show a loading spinner for invalid pairs", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <CreateButton />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        globalSignals.setOnline(true);
+        signals.setSendAmount(BigNumber(100_000));
+        signals.setAmountValid(true);
+        signals.setInvoice(invoice);
+        signals.setInvoiceValid(true);
+        setPairAssetsWithPairs(usdt0Pairs, "USDT0-CFX", LN);
+        signals.setQuoteLoading(true);
+
+        const btn = (await screen.findByTestId(
+            "create-swap-button",
+        )) as HTMLButtonElement;
+
+        await waitFor(() => {
+            expect(btn.textContent).toBe(i18n.en.invalid_send_asset);
+        });
+        expect(screen.queryByTestId("loading-spinner")).toBeNull();
+    });
+
     test("should be disabled with LNURL min amount error", async () => {
         vi.stubGlobal(
             "fetch",
@@ -660,6 +742,56 @@ describe("CreateButton", () => {
         )) as HTMLButtonElement;
         expect(errorBtn).not.toBeUndefined();
         expect(errorBtn.disabled).toBeTruthy();
+    });
+
+    test("should apply btn-error class only for user-error labels", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <CreateButton />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        const btn = (await screen.findByTestId(
+            "create-swap-button",
+        )) as HTMLButtonElement;
+
+        // Default in-progress state (initial load shows minimum_amount): no
+        // btn-error class should be applied.
+        globalSignals.setOnline(true);
+        signals.setMinimum(50_000);
+        await waitFor(() => {
+            expect(btn.textContent).toBe(
+                i18n.en.minimum_amount
+                    .replace("{{ amount }}", "50 000")
+                    .replace("{{ denomination }}", "sats"),
+            );
+        });
+        expect(btn.classList.contains("btn-error")).toBe(false);
+        expect(btn.classList.contains("btn-danger")).toBe(false);
+
+        // User-error state: invalid send asset triggers btn-error.
+        signals.setSendAmount(BigNumber(100_000));
+        signals.setAmountValid(true);
+        signals.setInvoice(invoice);
+        signals.setInvoiceValid(true);
+        setPairAssetsWithPairs(usdt0Pairs, "USDT0-CFX", LN);
+        await waitFor(() => {
+            expect(btn.textContent).toBe(i18n.en.invalid_send_asset);
+        });
+        expect(btn.classList.contains("btn-error")).toBe(true);
+        expect(btn.classList.contains("btn-danger")).toBe(false);
+
+        // Offline takes precedence over user-error: btn-danger, not btn-error.
+        globalSignals.setOnline(false);
+        await waitFor(() => {
+            expect(btn.textContent).toBe(i18n.en.api_offline);
+        });
+        expect(btn.classList.contains("btn-danger")).toBe(true);
+        expect(btn.classList.contains("btn-error")).toBe(false);
     });
 
     test("should be disabled with LNURL max amount error", async () => {

--- a/tests/pages/Create.spec.tsx
+++ b/tests/pages/Create.spec.tsx
@@ -185,7 +185,11 @@ describe("Create", () => {
                 },
             );
 
-            const currentPair = signals.pair();
+            globalSignals.setPairs(pairs);
+            globalSignals.setRegularPairs(pairs);
+
+            const currentPair = new Pair(pairs, LN, BTC, pairs);
+            signals.setPair(currentPair);
             let resolveQuote: ((amount: BigNumber) => void) | undefined;
             const quotePromise = new Promise<BigNumber>((resolve) => {
                 resolveQuote = resolve;


### PR DESCRIPTION
I had several support cases recently where folks just overlooked edge case errors in the swap button and opened a ticket because they didn't get what's wrong. This PR introduces a new "red" error category for edge case errors (e.g. `Invalid Pair`). It critically avoids showing the red error for regular flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button state handling during pair data loading
  * Better error state detection and display
  * Prevented invalid pair states from showing loading indicators

* **Style**
  * Enhanced button styling for offline and error states
  * Improved visual consistency for disabled button states

* **Tests**
  * Expanded test coverage for button behavior during loading and error scenarios
  * Added validation for offline and error state styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->