### PR TITLE
fix: preserve amounts when pasting address during quote fetch

### DIFF
--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -360,6 +360,7 @@ const Create = () => {
             denomination(),
         );
 
+        setReceiveAmount(satAmount);
         loadingGuard(async (isCurrent) => {
             if (satAmount.isZero()) {
                 setAmountChanged(Side.Receive);
@@ -376,7 +377,6 @@ const Create = () => {
             if (!isCurrent()) {
                 return;
             }
-            setReceiveAmount(satAmount);
             setSendAmount(sendAmount);
             validateAmount();
         });
@@ -408,6 +408,7 @@ const Create = () => {
             denomination(),
         );
 
+        setSendAmount(satAmount);
         loadingGuard(async (isCurrent) => {
             const newReceiveAmount = await pair().calculateReceiveAmount(
                 satAmount,
@@ -419,7 +420,6 @@ const Create = () => {
             if (!isCurrent()) {
                 return;
             }
-            setSendAmount(satAmount);
             setReceiveAmount(newReceiveAmount);
             validateAmount();
         });

--- a/tests/pages/Create.spec.tsx
+++ b/tests/pages/Create.spec.tsx
@@ -350,74 +350,92 @@ describe("Create", () => {
         }
     });
 
-    test("should preserve the typed send amount when destination changes during a pending quote", async () => {
-        vi.useFakeTimers();
+    test.each([
+        {
+            side: "send",
+            inputTestId: "sendAmount",
+            quoteMethod: "calculateReceiveAmount",
+            counterAmount: 90_000,
+        },
+        {
+            side: "receive",
+            inputTestId: "receiveAmount",
+            quoteMethod: "calculateSendAmount",
+            counterAmount: 110_000,
+        },
+    ] as const)(
+        "should preserve the typed $side amount when destination changes during a pending quote",
+        async ({ inputTestId, quoteMethod, counterAmount }) => {
+            vi.useFakeTimers();
 
-        try {
-            render(
-                () => (
-                    <>
-                        <TestComponent />
-                        <Create />
-                    </>
-                ),
-                {
-                    wrapper: contextWrapper,
-                },
-            );
+            try {
+                render(
+                    () => (
+                        <>
+                            <TestComponent />
+                            <Create />
+                        </>
+                    ),
+                    {
+                        wrapper: contextWrapper,
+                    },
+                );
 
-            const currentPair = signals.pair();
-            let resolveFirstQuote: ((amount: BigNumber) => void) | undefined;
-            const firstQuote = new Promise<BigNumber>((resolve) => {
-                resolveFirstQuote = resolve;
-            });
+                setPairAssets(LN, BTC);
 
-            Object.defineProperty(currentPair, "needsNetworkForQuote", {
-                configurable: true,
-                get: () => true,
-            });
-            currentPair.calculateReceiveAmount = vi
-                .fn()
-                .mockImplementationOnce(() => firstQuote)
-                .mockImplementation(() => Promise.resolve(BigNumber(90_000)))
-                .mockName("calculateReceiveAmount");
+                const currentPair = signals.pair();
+                let resolveFirstQuote:
+                    | ((amount: BigNumber) => void)
+                    | undefined;
+                const firstQuote = new Promise<BigNumber>((resolve) => {
+                    resolveFirstQuote = resolve;
+                });
 
-            fireEvent.input(await screen.findByTestId("sendAmount"), {
-                target: { value: "100000" },
-            });
+                Object.defineProperty(currentPair, "needsNetworkForQuote", {
+                    configurable: true,
+                    get: () => true,
+                });
+                currentPair[quoteMethod] = vi
+                    .fn()
+                    .mockImplementationOnce(() => firstQuote)
+                    .mockImplementation(() =>
+                        Promise.resolve(BigNumber(counterAmount)),
+                    )
+                    .mockName(quoteMethod);
 
-            await flushQuoteDebounce();
+                fireEvent.input(await screen.findByTestId(inputTestId), {
+                    target: { value: "100000" },
+                });
 
-            await waitFor(() => {
-                expect(
-                    currentPair.calculateReceiveAmount,
-                ).toHaveBeenCalledTimes(1);
-            });
+                await flushQuoteDebounce();
 
-            fireEvent.input(await screen.findByTestId("onchainAddress"), {
-                target: {
-                    value: "bcrt1q0zjymfy94ctjdegxascl8l253p0ppl5fzz46qm",
-                },
-            });
+                await waitFor(() => {
+                    expect(currentPair[quoteMethod]).toHaveBeenCalledTimes(1);
+                });
 
-            await flushQuoteDebounce();
+                fireEvent.input(await screen.findByTestId("onchainAddress"), {
+                    target: {
+                        value: "bcrt1q0zjymfy94ctjdegxascl8l253p0ppl5fzz46qm",
+                    },
+                });
 
-            await waitFor(() => {
-                expect(
-                    currentPair.calculateReceiveAmount,
-                ).toHaveBeenCalledTimes(2);
-            });
+                await flushQuoteDebounce();
 
-            const latestCall = vi
-                .mocked(currentPair.calculateReceiveAmount)
-                .mock.calls.at(-1);
-            expect(latestCall?.[0]?.toString()).toBe("100000");
+                await waitFor(() => {
+                    expect(currentPair[quoteMethod]).toHaveBeenCalledTimes(2);
+                });
 
-            resolveFirstQuote?.(BigNumber(90_000));
-        } finally {
-            vi.useRealTimers();
-        }
-    });
+                const latestCall = vi
+                    .mocked(currentPair[quoteMethod])
+                    .mock.calls.at(-1);
+                expect(latestCall?.[0]?.toString()).toBe("100000");
+
+                resolveFirstQuote?.(BigNumber(counterAmount));
+            } finally {
+                vi.useRealTimers();
+            }
+        },
+    );
 
     test("should block creation when a routed quote resolves to zero", async () => {
         vi.useFakeTimers();

--- a/tests/pages/Create.spec.tsx
+++ b/tests/pages/Create.spec.tsx
@@ -350,6 +350,75 @@ describe("Create", () => {
         }
     });
 
+    test("should preserve the typed send amount when destination changes during a pending quote", async () => {
+        vi.useFakeTimers();
+
+        try {
+            render(
+                () => (
+                    <>
+                        <TestComponent />
+                        <Create />
+                    </>
+                ),
+                {
+                    wrapper: contextWrapper,
+                },
+            );
+
+            const currentPair = signals.pair();
+            let resolveFirstQuote: ((amount: BigNumber) => void) | undefined;
+            const firstQuote = new Promise<BigNumber>((resolve) => {
+                resolveFirstQuote = resolve;
+            });
+
+            Object.defineProperty(currentPair, "needsNetworkForQuote", {
+                configurable: true,
+                get: () => true,
+            });
+            currentPair.calculateReceiveAmount = vi
+                .fn()
+                .mockImplementationOnce(() => firstQuote)
+                .mockImplementation(() => Promise.resolve(BigNumber(90_000)))
+                .mockName("calculateReceiveAmount");
+
+            fireEvent.input(await screen.findByTestId("sendAmount"), {
+                target: { value: "100000" },
+            });
+
+            await flushQuoteDebounce();
+
+            await waitFor(() => {
+                expect(
+                    currentPair.calculateReceiveAmount,
+                ).toHaveBeenCalledTimes(1);
+            });
+
+            fireEvent.input(await screen.findByTestId("onchainAddress"), {
+                target: {
+                    value: "bcrt1q0zjymfy94ctjdegxascl8l253p0ppl5fzz46qm",
+                },
+            });
+
+            await flushQuoteDebounce();
+
+            await waitFor(() => {
+                expect(
+                    currentPair.calculateReceiveAmount,
+                ).toHaveBeenCalledTimes(2);
+            });
+
+            const latestCall = vi
+                .mocked(currentPair.calculateReceiveAmount)
+                .mock.calls.at(-1);
+            expect(latestCall?.[0]?.toString()).toBe("100000");
+
+            resolveFirstQuote?.(BigNumber(90_000));
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     test("should block creation when a routed quote resolves to zero", async () => {
         vi.useFakeTimers();
 
@@ -868,7 +937,7 @@ describe("Create", () => {
 
         fireEvent.input(sendInput, { target: { value: "123456" } });
 
-        expect(sendInput.value).toBe("123456");
+        expect(sendInput.value).toBe("123 456");
     });
 
     test("should keep send amount at zero when receive amount is zero", async () => {


### PR DESCRIPTION
Closes #1375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Send amount field now updates immediately when edited, providing faster visual feedback.

* **Tests**
  * Added a unit test ensuring send amounts are preserved when destination or background quote recalculations occur.
  * Updated end-to-end tests to tighten numeric expectations for send-amount assertions across multiple swap flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->