### PR TITLE
docs: add llms.txt and expose raw .md on docs urls

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,6 +1,16 @@
+import { copyFile, mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { defineConfig } from "vitepress";
 
 const docsRoot = "https://docs.boltz.exchange";
+const siteUrl = "https://web.docs.boltz.exchange";
+
+const sidebarItems = [
+    { text: "🖥️ Run from Source", link: "/index" },
+    { text: "📲 Install as App", link: "/pwa" },
+    { text: "🔍 URL Parameters", link: "/urlParams" },
+    { text: "🏠 Docs Home", link: docsRoot, target: "_self" },
+];
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -16,16 +26,7 @@ export default defineConfig({
             },
         },
         nav: [{ text: "🏠 Docs Home", link: docsRoot, target: "_self" }],
-        sidebar: [
-            {
-                items: [
-                    { text: "🖥️ Run from Source", link: "/index" },
-                    { text: "📲 Install as App", link: "/pwa" },
-                    { text: "🔍 URL Parameters", link: "/urlParams" },
-                    { text: "🏠 Docs Home", link: docsRoot, target: "_self" },
-                ],
-            },
-        ],
+        sidebar: [{ items: sidebarItems }],
         socialLinks: [
             {
                 icon: "github",
@@ -35,4 +36,25 @@ export default defineConfig({
     },
     // Ignore dead links to localhost
     ignoreDeadLinks: [/https?:\/\/localhost/],
+
+    async buildEnd(siteConfig) {
+        await Promise.all(
+            siteConfig.pages.map(async (page) => {
+                const src = join(siteConfig.srcDir, page);
+                const dest = join(siteConfig.outDir, page);
+                await mkdir(dirname(dest), { recursive: true });
+                await copyFile(src, dest);
+            }),
+        );
+
+        const links = sidebarItems
+            .filter((item) => item.link.startsWith("/"))
+            .map((item) => `- [${item.text}](${siteUrl}${item.link}.md)`)
+            .join("\n");
+
+        await writeFile(
+            join(siteConfig.outDir, "llms.txt"),
+            `# Boltz Web App\n\n> Boltz Web App Docs\n\n## Docs\n\n${links}\n`,
+        );
+    },
 });


### PR DESCRIPTION
VitePress's `buildEnd` now copies each source page into the build output as `<page>.md` next to `<page>.html`, and writes an `llms.txt` index at the docs root, so LLM crawlers, agents and coding tools can easily fetch the raw markdown directly via e.g. https://web.docs.boltz.exchange/urlParams.md.
