### PR TITLE
fix: wait for tx confirmation for oft eta

### DIFF
--- a/src/components/WaitForBridge.tsx
+++ b/src/components/WaitForBridge.tsx
@@ -5,7 +5,7 @@ import { BridgeKind } from "../configs/base";
 import { useGlobalContext } from "../context/Global";
 import { bridgeRegistry } from "../utils/bridge";
 import { formatError } from "../utils/errors";
-import { getOftTransactionConfirmationTimestamp } from "../utils/oft/oft";
+import { waitForOftTransactionConfirmationTimestamp } from "../utils/oft/oft";
 import { computeOftEtaSeconds } from "../utils/oftEta";
 import type { BridgeDetail } from "../utils/swapCreator";
 import BlockExplorer from "./BlockExplorer";
@@ -65,24 +65,43 @@ const WaitForOft = (props: {
         const txHash = props.txHash;
         const sourceAsset = props.sourceAsset;
 
-        getOftTransactionConfirmationTimestamp(sourceAsset, txHash)
+        const updateRemainingFromConfirmation = (
+            confirmationTimeSecs: number,
+        ) => {
+            const elapsedSecs = Date.now() / 1_000 - confirmationTimeSecs;
+            const remainingSecs = Math.max(Math.ceil(eta - elapsedSecs), 0);
+            setRemaining(remainingSecs);
+        };
+
+        const controller = new AbortController();
+        setRemaining(undefined);
+
+        waitForOftTransactionConfirmationTimestamp(sourceAsset, txHash, {
+            signal: controller.signal,
+        })
             .then((confirmationTimeSecs) => {
-                if (confirmationTimeSecs === undefined) {
-                    setRemaining(Math.ceil(eta));
+                if (
+                    controller.signal.aborted ||
+                    confirmationTimeSecs === undefined
+                ) {
                     return;
                 }
 
-                const elapsedSecs = Date.now() / 1_000 - confirmationTimeSecs;
-                setRemaining(Math.max(Math.ceil(eta - elapsedSecs), 0));
+                updateRemainingFromConfirmation(confirmationTimeSecs);
             })
             .catch((e) => {
+                if (controller.signal.aborted) {
+                    return;
+                }
+
                 log.warn("Failed to fetch OFT tx confirmation time", {
                     sourceAsset,
                     txHash,
                     error: formatError(e),
                 });
-                setRemaining(Math.ceil(eta));
             });
+
+        onCleanup(() => controller.abort());
     });
 
     const timer = setInterval(() => {

--- a/src/utils/oft/oft.ts
+++ b/src/utils/oft/oft.ts
@@ -739,3 +739,79 @@ export const getOftTransactionConfirmationTimestamp = async (
         }
     }
 };
+
+const oftConfirmationPollInterval = 5_000;
+
+const sleep = (ms: number, signal?: AbortSignal): Promise<void> =>
+    new Promise((resolve, reject) => {
+        if (signal?.aborted) {
+            reject(signal.reason);
+            return;
+        }
+
+        const timeout = setTimeout(() => {
+            signal?.removeEventListener("abort", onAbort);
+            resolve();
+        }, ms);
+        const onAbort = () => {
+            clearTimeout(timeout);
+            reject(signal?.reason);
+        };
+        signal?.addEventListener("abort", onAbort, { once: true });
+    });
+
+const isAbortError = (error: unknown, signal?: AbortSignal): boolean =>
+    signal?.aborted === true ||
+    (error instanceof Error && error.name === "AbortError");
+
+export const waitForOftTransactionConfirmationTimestamp = async (
+    sourceAsset: string,
+    txHash: string,
+    options: {
+        signal?: AbortSignal;
+        intervalMs?: number;
+    } = {},
+): Promise<number | undefined> => {
+    const intervalMs = options.intervalMs ?? oftConfirmationPollInterval;
+
+    while (!options.signal?.aborted) {
+        let confirmationTimestamp: number | undefined;
+        try {
+            confirmationTimestamp =
+                await getOftTransactionConfirmationTimestamp(
+                    sourceAsset,
+                    txHash,
+                );
+        } catch (error) {
+            if (isAbortError(error, options.signal)) {
+                return undefined;
+            }
+
+            log.warn("OFT confirmation polling request failed; retrying", {
+                sourceAsset,
+                txHash,
+                error,
+            });
+        }
+
+        if (options.signal?.aborted) {
+            return undefined;
+        }
+
+        if (confirmationTimestamp !== undefined) {
+            return confirmationTimestamp;
+        }
+
+        try {
+            await sleep(intervalMs, options.signal);
+        } catch (error) {
+            if (isAbortError(error, options.signal)) {
+                return undefined;
+            }
+
+            throw error;
+        }
+    }
+
+    return undefined;
+};

--- a/tests/components/WaitForBridge.spec.tsx
+++ b/tests/components/WaitForBridge.spec.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from "@solidjs/testing-library";
+
+import WaitForBridge from "../../src/components/WaitForBridge";
+import { BridgeKind } from "../../src/configs/base";
+import { SwapPosition } from "../../src/consts/Enums";
+import { waitForOftTransactionConfirmationTimestamp } from "../../src/utils/oft/oft";
+
+const mockTranslations = vi.hoisted(() => ({
+    waiting_for_oft: "Waiting for OFT",
+    oft_eta: "Estimated arrival in about {{ time }}",
+    oft_eta_day_unit: "{{ value }}d",
+    oft_eta_hour_unit: "{{ value }}h",
+    oft_eta_minute_unit: "{{ value }}m",
+    oft_eta_second_unit: "{{ value }}s",
+    oft_arriving_soon: "Arriving soon...",
+    oft_transfer_in_progress: "Transfer in progress",
+}));
+
+vi.mock("../../src/context/Global", () => ({
+    useGlobalContext: () => ({
+        t: (key: string, params?: Record<string, string | number>) => {
+            let text =
+                mockTranslations[key as keyof typeof mockTranslations] ?? key;
+
+            for (const [name, value] of Object.entries(params ?? {})) {
+                text = text.replace(`{{ ${name} }}`, String(value));
+            }
+
+            return text;
+        },
+    }),
+}));
+
+vi.mock("../../src/utils/oft/oft", () => ({
+    waitForOftTransactionConfirmationTimestamp: vi.fn(),
+}));
+
+describe("WaitForBridge", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-04-27T15:00:00Z"));
+        vi.mocked(waitForOftTransactionConfirmationTimestamp).mockReset();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    test("waits for OFT transaction confirmation before starting the ETA", async () => {
+        let confirmTransaction: ((timestamp: number) => void) | undefined;
+        vi.mocked(
+            waitForOftTransactionConfirmationTimestamp,
+        ).mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    confirmTransaction = resolve;
+                }),
+        );
+
+        render(() => (
+            <WaitForBridge
+                bridge={{
+                    kind: BridgeKind.Oft,
+                    position: SwapPosition.Pre,
+                    sourceAsset: "USDT0-ETH",
+                    destinationAsset: "USDT0",
+                }}
+                transactionHash="tx-hash"
+            />
+        ));
+
+        await waitFor(() =>
+            expect(
+                waitForOftTransactionConfirmationTimestamp,
+            ).toHaveBeenCalledTimes(1),
+        );
+        expect(
+            screen.getByText(mockTranslations.oft_transfer_in_progress),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText(/Estimated arrival/u),
+        ).not.toBeInTheDocument();
+
+        confirmTransaction?.(Date.now() / 1_000);
+        await Promise.resolve();
+
+        await screen.findByText(/Estimated arrival/u);
+        expect(
+            vi.mocked(waitForOftTransactionConfirmationTimestamp),
+        ).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable confirmation waits for OFT transfers: respects cancellations, avoids stale or incorrect ETA updates, and prevents state changes after leaving the screen.
* **Tests**
  * Added unit tests for the confirmation-wait flow and ETA display to guard against regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->