### PR TITLE
chore: add fallback ETH L1 RPCs

### DIFF
--- a/src/configs/rpcs.ts
+++ b/src/configs/rpcs.ts
@@ -45,7 +45,11 @@ export const cornRpcUrls = prependEnv(import.meta.env.VITE_CORN_RPC_ENDPOINT, [
 
 export const ethereumRpcUrls = prependEnv(
     import.meta.env.VITE_ETHEREUM_RPC_ENDPOINT,
-    ["https://ethereum-rpc.publicnode.com"],
+    [
+        "https://ethereum-rpc.publicnode.com",
+        "https://mainnet.gateway.tenderly.co",
+        "https://eth.api.pocket.network",
+    ],
 );
 
 export const flareRpcUrls = prependEnv(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the default Ethereum RPC endpoint fallback set from a single endpoint to multiple options for increased network coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->