### PR TITLE
chore: add usdc logo to landing page

### DIFF
--- a/src/pages/Hero.tsx
+++ b/src/pages/Hero.tsx
@@ -8,6 +8,7 @@ import lightning from "../assets/lightning-icon.svg";
 import liquid from "../assets/liquid-icon.svg";
 import rbtc from "../assets/rootstock-icon.svg";
 import tbtc from "../assets/tbtc-icon.svg";
+import usdc from "../assets/usdc.svg";
 import usdt from "../assets/usdt-icon.svg";
 import ExternalLink from "../components/ExternalLink";
 import { config } from "../config";
@@ -107,8 +108,10 @@ export const Hero = () => {
                                 class="padded"
                             />
                             <img src={rbtc} alt="Rootstock Bitcoin" />
+                            <div class="hero-icons-break" />
                             <img src={tbtc} alt="tBTC" class="full-bleed" />
                             <img src={usdt} alt="USDT" class="full-bleed" />
+                            <img src={usdc} alt="USDC" class="full-bleed" />
                         </div>
                     </div>
                 </div>

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -80,10 +80,17 @@ const Privacy: Component = () => {
                 <li>
                     Third-party liquidity protocols and token issuers: Swaps may
                     interact with third-party smart contracts, liquidity
-                    protocols, or cross-chain messaging protocols (e.g.
-                    LayerZero). The respective protocol operators or token
-                    issuers may collect data independently. Boltz has no control
-                    over these third parties' data practices.
+                    protocols, or cross-chain messaging protocols (e.g.{" "}
+                    <ExternalLink href="https://layerzero.network/">
+                        LayerZero
+                    </ExternalLink>
+                    ,{" "}
+                    <ExternalLink href="https://www.circle.com/cross-chain-transfer-protocol">
+                        CCTP
+                    </ExternalLink>
+                    ). The respective protocol operators or token issuers may
+                    collect data independently. Boltz has no control over these
+                    third parties' data practices.
                 </li>
             </ul>
 

--- a/src/style/hero.scss
+++ b/src/style/hero.scss
@@ -60,14 +60,16 @@ h3 {
 }
 
 .hero-boxes {
-    margin: 72px 0 122px;
+    margin: 72px 12px 122px;
     display: flex;
+    align-items: stretch;
+    gap: 24px;
 }
 .hero-box {
-    width: 33.33%;
+    flex: 1 1 0;
+    min-width: 0;
     border-radius: 21px;
     padding: 12px;
-    margin: 12px;
     color: var(--color-text);
     background: var(--color-black-30);
     border: 1px solid var(--color-white-10);
@@ -77,9 +79,10 @@ h3 {
 .hero-icons {
     flex: 1;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: center;
-    gap: 4px;
+    gap: 2px 4px;
 
     img {
         width: 45px;
@@ -95,12 +98,17 @@ h3 {
         }
     }
 }
+.hero-icons-break {
+    flex-basis: 100%;
+    height: 0;
+}
 @media (max-width: 768px) {
     .hero-boxes {
         display: block;
+        margin: 72px 0 122px;
     }
     .hero-box {
-        width: auto;
+        margin: 12px;
     }
 }
 


### PR DESCRIPTION
<img width="1155" height="554" alt="image" src="https://github.com/user-attachments/assets/9f3d941f-e26e-4dc6-8b60-85d822c0ab46" />

Also added CCTP to our Privacy Policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added USDC token icon to the Hero section's asset showcase
  * Replaced plain-text protocol references with interactive external links (LayerZero and CCTP) on the Privacy page

* **Updates**
  * Enhanced Hero section layout with improved card spacing and alignment
  * Refined responsive design for better visual organization across all devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->