### PR TITLE
fix: refunding of linked commitments

### DIFF
--- a/src/components/RefundButton.tsx
+++ b/src/components/RefundButton.tsx
@@ -39,7 +39,6 @@ import {
 } from "../context/Web3";
 import {
     encodeDexQuote,
-    getEipRefundSignature,
     quoteDexAmountIn,
     quoteDexAmountOut,
 } from "../utils/boltzClient";
@@ -49,7 +48,7 @@ import {
     calculateAmountWithSlippage,
 } from "../utils/calculate";
 import {
-    getCommitmentRefundSignature,
+    getEvmRefundCooperativeSignature,
     isEmptyPreimageHash,
 } from "../utils/commitment";
 import { validateAddress } from "../utils/compat";
@@ -655,37 +654,18 @@ export const RefundEvm = (props: {
                                 currentRefundData.preimageHash,
                             );
 
-                            let signatureHex: string;
-                            if (isCommitmentLockup) {
-                                const commitmentTxHash =
-                                    props.lockupTxHash ??
-                                    props.commitmentLockupTxHash;
-                                if (commitmentTxHash === undefined) {
-                                    throw new Error(
-                                        "commitment lockup transaction hash is required",
-                                    );
-                                }
-                                signatureHex =
-                                    await getCommitmentRefundSignature({
-                                        chainSymbol: props.asset,
-                                        transactionHash: commitmentTxHash,
-                                        logIndex: currentRefundData.logIndex,
-                                        signer: currentTransactionSigner,
-                                    });
-                            } else {
-                                if (props.swapId === undefined) {
-                                    throw new Error(
-                                        "swap id is required for cooperative refunds",
-                                    );
-                                }
-
-                                const { signature } =
-                                    await getEipRefundSignature(
-                                        props.swapId,
-                                        props.swapType ?? SwapType.Submarine,
-                                    );
-                                signatureHex = signature;
-                            }
+                            const signatureHex =
+                                await getEvmRefundCooperativeSignature({
+                                    isCommitmentLockup,
+                                    asset: props.asset,
+                                    swapId: props.swapId,
+                                    swapType: props.swapType,
+                                    commitmentTxHash:
+                                        props.lockupTxHash ??
+                                        props.commitmentLockupTxHash,
+                                    logIndex: currentRefundData.logIndex,
+                                    signer: currentTransactionSigner,
+                                });
                             const decSignature = Signature.from(signatureHex);
 
                             if (currentContractKind === AssetKind.ERC20) {

--- a/src/utils/commitment.ts
+++ b/src/utils/commitment.ts
@@ -2,8 +2,10 @@ import type { ERC20Swap } from "boltz-core/typechain/ERC20Swap";
 import type { Wallet } from "ethers";
 import log from "loglevel";
 
+import { SwapType } from "../consts/Enums";
 import type { Signer } from "../context/Web3";
 import {
+    getEipRefundSignature,
     postCommitmentRefundSignature,
     postCommitmentSignature,
 } from "./boltzClient";
@@ -208,5 +210,68 @@ export const getCommitmentRefundSignature = async ({
         logIndex,
     });
 
+    return signature;
+};
+
+type GetEvmRefundCooperativeSignatureParams = {
+    isCommitmentLockup: boolean;
+    asset: string;
+    swapId?: string;
+    swapType?: SwapType;
+    commitmentTxHash?: string;
+    logIndex?: number;
+    signer: Signer | Wallet;
+};
+
+export const getEvmRefundCooperativeSignature = async ({
+    isCommitmentLockup,
+    asset,
+    swapId,
+    swapType,
+    commitmentTxHash,
+    logIndex,
+    signer,
+}: GetEvmRefundCooperativeSignatureParams): Promise<string> => {
+    const fetchUnlinked = () => {
+        if (commitmentTxHash === undefined) {
+            throw new Error("commitment lockup transaction hash is required");
+        }
+        return getCommitmentRefundSignature({
+            chainSymbol: asset,
+            transactionHash: commitmentTxHash,
+            logIndex,
+            signer,
+        });
+    };
+
+    if (isCommitmentLockup) {
+        // Try the swap refund path first: a commitment funded with positive
+        // slippage links to the swap, and /commitment/refund then errors with
+        // "linked commitment cannot be marked as refunded".
+        if (swapId !== undefined) {
+            try {
+                const { signature } = await getEipRefundSignature(
+                    swapId,
+                    swapType ?? SwapType.Submarine,
+                );
+                return signature;
+            } catch (linkedRefundError) {
+                log.warn(
+                    "linked commitment refund signature failed, falling back to unlinked endpoint",
+                    linkedRefundError,
+                );
+                return await fetchUnlinked();
+            }
+        }
+        return await fetchUnlinked();
+    }
+
+    if (swapId === undefined) {
+        throw new Error("swap id is required for cooperative refunds");
+    }
+    const { signature } = await getEipRefundSignature(
+        swapId,
+        swapType ?? SwapType.Submarine,
+    );
     return signature;
 };

--- a/tests/utils/commitment.spec.ts
+++ b/tests/utils/commitment.spec.ts
@@ -1,17 +1,21 @@
 const mockPostCommitmentSignature = vi.fn();
 const mockPostCommitmentRefundSignature = vi.fn();
+const mockGetEipRefundSignature = vi.fn();
 
 vi.mock("../../src/utils/boltzClient", () => ({
     postCommitmentSignature: mockPostCommitmentSignature,
     postCommitmentRefundSignature: mockPostCommitmentRefundSignature,
+    getEipRefundSignature: mockGetEipRefundSignature,
 }));
 
+const { SwapType } = await import("../../src/consts/Enums");
 const {
     emptyPreimageHash,
     isEmptyPreimageHash,
     postCommitmentSignatureForTransaction,
     buildCommitmentRefundAuthMessage,
     getCommitmentRefundSignature,
+    getEvmRefundCooperativeSignature,
 } = await import("../../src/utils/commitment");
 
 describe("commitment", () => {
@@ -205,6 +209,159 @@ describe("commitment", () => {
                 "0xcommitment",
                 "0xauthSig",
                 undefined,
+            );
+        });
+    });
+
+    describe("getEvmRefundCooperativeSignature", () => {
+        const buildSigner = () => ({
+            signMessage: vi.fn().mockResolvedValue("0xauthSig"),
+        });
+
+        test("non-commitment lockup uses the swap refund endpoint", async () => {
+            mockGetEipRefundSignature.mockResolvedValue({
+                signature: "0xswapSig",
+            });
+
+            const signature = await getEvmRefundCooperativeSignature({
+                isCommitmentLockup: false,
+                asset: "RBTC",
+                swapId: "swap-1",
+                swapType: SwapType.Submarine,
+                commitmentTxHash: undefined,
+                signer: buildSigner() as never,
+            });
+
+            expect(signature).toEqual("0xswapSig");
+            expect(mockGetEipRefundSignature).toHaveBeenCalledWith(
+                "swap-1",
+                SwapType.Submarine,
+            );
+            expect(mockPostCommitmentRefundSignature).not.toHaveBeenCalled();
+        });
+
+        test("non-commitment lockup without swapId throws", async () => {
+            await expect(
+                getEvmRefundCooperativeSignature({
+                    isCommitmentLockup: false,
+                    asset: "RBTC",
+                    swapId: undefined,
+                    signer: buildSigner() as never,
+                }),
+            ).rejects.toThrow("swap id is required for cooperative refunds");
+            expect(mockGetEipRefundSignature).not.toHaveBeenCalled();
+        });
+
+        test("commitment lockup with swapId tries the swap refund endpoint first", async () => {
+            mockGetEipRefundSignature.mockResolvedValue({
+                signature: "0xlinkedSig",
+            });
+
+            const signer = buildSigner();
+            const signature = await getEvmRefundCooperativeSignature({
+                isCommitmentLockup: true,
+                asset: "USDC",
+                swapId: "swap-2",
+                swapType: SwapType.Chain,
+                commitmentTxHash: "0xcommitmentTx",
+                logIndex: 1,
+                signer: signer as never,
+            });
+
+            expect(signature).toEqual("0xlinkedSig");
+            expect(mockGetEipRefundSignature).toHaveBeenCalledWith(
+                "swap-2",
+                SwapType.Chain,
+            );
+            // Linked path succeeded so the unlinked endpoint must not be hit.
+            expect(mockPostCommitmentRefundSignature).not.toHaveBeenCalled();
+            expect(signer.signMessage).not.toHaveBeenCalled();
+        });
+
+        test("commitment lockup falls back to the unlinked endpoint when the swap refund fails", async () => {
+            mockGetEipRefundSignature.mockRejectedValue(
+                new Error("not eligible for cooperative refund"),
+            );
+            mockPostCommitmentRefundSignature.mockResolvedValue({
+                signature: "0xunlinkedSig",
+            });
+            const signer = buildSigner();
+
+            const signature = await getEvmRefundCooperativeSignature({
+                isCommitmentLockup: true,
+                asset: "USDC",
+                swapId: "swap-3",
+                swapType: SwapType.Chain,
+                commitmentTxHash: "0xcommitmentTx",
+                logIndex: 2,
+                signer: signer as never,
+            });
+
+            expect(signature).toEqual("0xunlinkedSig");
+            expect(mockGetEipRefundSignature).toHaveBeenCalledWith(
+                "swap-3",
+                SwapType.Chain,
+            );
+            expect(mockPostCommitmentRefundSignature).toHaveBeenCalledWith(
+                "USDC",
+                "0xcommitmentTx",
+                "0xauthSig",
+                2,
+            );
+        });
+
+        test("commitment lockup without swapId calls the unlinked endpoint directly", async () => {
+            mockPostCommitmentRefundSignature.mockResolvedValue({
+                signature: "0xrescueSig",
+            });
+            const signer = buildSigner();
+
+            const signature = await getEvmRefundCooperativeSignature({
+                isCommitmentLockup: true,
+                asset: "USDC",
+                swapId: undefined,
+                commitmentTxHash: "0xcommitmentTx",
+                logIndex: undefined,
+                signer: signer as never,
+            });
+
+            expect(signature).toEqual("0xrescueSig");
+            expect(mockGetEipRefundSignature).not.toHaveBeenCalled();
+            expect(mockPostCommitmentRefundSignature).toHaveBeenCalledWith(
+                "USDC",
+                "0xcommitmentTx",
+                "0xauthSig",
+                undefined,
+            );
+        });
+
+        test("commitment lockup without commitmentTxHash throws", async () => {
+            await expect(
+                getEvmRefundCooperativeSignature({
+                    isCommitmentLockup: true,
+                    asset: "USDC",
+                    swapId: undefined,
+                    commitmentTxHash: undefined,
+                    signer: buildSigner() as never,
+                }),
+            ).rejects.toThrow("commitment lockup transaction hash is required");
+        });
+
+        test("defaults swapType to Submarine when omitted", async () => {
+            mockGetEipRefundSignature.mockResolvedValue({
+                signature: "0xdefaultSig",
+            });
+
+            await getEvmRefundCooperativeSignature({
+                isCommitmentLockup: false,
+                asset: "RBTC",
+                swapId: "swap-4",
+                signer: buildSigner() as never,
+            });
+
+            expect(mockGetEipRefundSignature).toHaveBeenCalledWith(
+                "swap-4",
+                SwapType.Submarine,
             );
         });
     });


### PR DESCRIPTION
Closes https://github.com/BoltzExchange/boltz-web-app/issues/1409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved refund signature generation for EVM cooperative refunds with consolidated logic and enhanced fallback handling
  * Refined support for both linked and unlinked refund paths to ensure more robust transaction processing

* **Tests**
  * Expanded test coverage for cooperative refund signature workflows, including fallback scenarios and parameter validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->