### PR TITLE
Revert "chore: enable stablecoin swaps on Tor (#1419)"

### DIFF
--- a/src/context/Create.tsx
+++ b/src/context/Create.tsx
@@ -12,13 +12,16 @@ import {
 import type { Accessor, JSX, Setter } from "solid-js";
 
 import { config } from "../config";
+import { isTor } from "../configs/base";
 import {
     type AssetType,
     BTC,
     LBTC,
     LN,
+    TBTC,
     assets,
     isBitcoinOnlyPair,
+    isBridgeAsset,
 } from "../consts/Assets";
 import { type AssetSelection, Side, UrlParam } from "../consts/Enums";
 import type { DictKey } from "../i18n/i18n";
@@ -135,7 +138,9 @@ const setDestination = (
 };
 
 const isValidAsset = (asset: string) =>
-    urlParamIsSet(asset) && assets.includes(asset);
+    urlParamIsSet(asset) &&
+    assets.includes(asset) &&
+    !(isTor() && (asset === TBTC || isBridgeAsset(asset)));
 
 const parseAmount = (amount: string): BigNumber | undefined => {
     if (!urlParamIsSet(amount)) {

--- a/src/utils/Pair.ts
+++ b/src/utils/Pair.ts
@@ -3,15 +3,17 @@ import { ZeroAddress } from "ethers";
 import log from "loglevel";
 
 import { config } from "../config";
-import { BridgeKind, CctpReceiveMode } from "../configs/base";
+import { BridgeKind, CctpReceiveMode, isTor } from "../configs/base";
 import {
     AssetKind,
     BTC,
     LN,
+    TBTC,
     USDC,
     getAssetBridge,
     getCanonicalAsset,
     getRouteViaAsset,
+    isBridgeAsset,
     isEvmAsset,
 } from "../consts/Assets";
 import { SwapPosition, SwapType } from "../consts/Enums";
@@ -156,6 +158,17 @@ export default class Pair {
             config.assets[to]?.disabled === true
         ) {
             log.info(`Pair ${from} -> ${to} contains disabled asset`);
+            return;
+        }
+
+        if (
+            isTor() &&
+            (from === TBTC ||
+                to === TBTC ||
+                isBridgeAsset(from) ||
+                isBridgeAsset(to))
+        ) {
+            log.info("TBTC and bridged pairs are disabled on Tor");
             return;
         }
 

--- a/src/utils/selectableAsset.ts
+++ b/src/utils/selectableAsset.ts
@@ -1,4 +1,6 @@
 import { config } from "../config";
+import { isTor } from "../configs/base";
+import { TBTC, isBridgeAsset } from "../consts/Assets";
 import { Side } from "../consts/Enums";
 
 export const canSendAsset = (asset: string) =>
@@ -10,4 +12,10 @@ export const isAssetDisabled = (asset: string) =>
 export const canSelectAsset = (
     selectedSide: Side | string | null | undefined,
     asset: string,
-) => selectedSide !== Side.Send || canSendAsset(asset);
+) => {
+    if (isTor() && (asset === TBTC || isBridgeAsset(asset))) {
+        return false;
+    }
+
+    return selectedSide !== Side.Send || canSendAsset(asset);
+};


### PR DESCRIPTION
This reverts commit 245545eafcd90d0993848d105099ff57551d5ea3.

Still broken

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- TBTC and bridge assets are now restricted and fully blocked when users access the application through a Tor connection. These assets are no longer available for selection as transaction inputs and cannot be used in any swap operations or included in trading pair route configurations while running in Tor mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->