### PR TITLE
feat: improve rescue file upload input with remove action

### DIFF
--- a/e2e/rescue/refundFile.spec.ts
+++ b/e2e/rescue/refundFile.spec.ts
@@ -13,7 +13,7 @@ test.describe("Refund files", () => {
         await page
             .getByRole("button", { name: "Rescue external swap" })
             .click();
-        await page.getByTestId("refundUpload").click();
+        await page.getByText(dict.en.upload_rescue_key).click();
 
         await page
             .getByTestId("refundUpload")

--- a/src/components/BackupVerifyContent.tsx
+++ b/src/components/BackupVerifyContent.tsx
@@ -3,10 +3,10 @@ import QrScanner from "qr-scanner";
 import { Show, createSignal } from "solid-js";
 
 import { useGlobalContext } from "../context/Global";
-import { rescueFileTypes } from "../utils/download";
 import { validateRescueFile } from "../utils/rescueFile";
 import type { RescueFile } from "../utils/rescueFile";
 import LoadingSpinner from "./LoadingSpinner";
+import RescueFileInput from "./RescueFileInput";
 
 type BackupVerifyContentProps = {
     onRetry: () => void;
@@ -79,12 +79,10 @@ const BackupVerifyContent = (props: BackupVerifyContentProps) => {
             }>
             <h2>{t("verify_boltz_rescue_key")}</h2>
             <h4>{t("verify_boltz_rescue_key_subline")}</h4>
-            <input
+            <RescueFileInput
                 required
-                type="file"
                 id="rescueFileUpload"
                 data-testid="rescueFileUpload"
-                accept={rescueFileTypes}
                 disabled={inputProcessing()}
                 onChange={(e) => uploadChange(e)}
             />

--- a/src/components/RescueFileInput.tsx
+++ b/src/components/RescueFileInput.tsx
@@ -1,0 +1,95 @@
+import { IoKey } from "solid-icons/io";
+import { IoClose } from "solid-icons/io";
+import type { ComponentProps } from "solid-js";
+import { Show, createEffect, createSignal, splitProps } from "solid-js";
+
+import { useGlobalContext } from "../context/Global";
+import "../style/rescueFileInput.scss";
+import { rescueFileTypes } from "../utils/download";
+
+type RescueFileInputProps = Omit<
+    ComponentProps<"input">,
+    "type" | "onChange"
+> & {
+    id: string;
+    fileName?: string | null;
+    onChange: (event: Event) => void;
+    onClear?: () => void;
+};
+
+const RescueFileInput = (props: RescueFileInputProps) => {
+    const { t } = useGlobalContext();
+    const [, inputProps] = splitProps(props, [
+        "fileName",
+        "onChange",
+        "onClear",
+    ]);
+    const [selectedFileName, setSelectedFileName] = createSignal<string>();
+    let inputRef: HTMLInputElement | undefined;
+
+    const fileName = () =>
+        props.fileName === undefined ? selectedFileName() : props.fileName;
+
+    createEffect(() => {
+        if (!fileName() && inputRef) {
+            inputRef.value = "";
+        }
+    });
+
+    const handleChange = (event: Event) => {
+        const input = event.currentTarget as HTMLInputElement;
+        setSelectedFileName(input.files?.[0]?.name);
+        props.onChange(event);
+    };
+
+    const clearFile = () => {
+        if (inputRef) {
+            inputRef.value = "";
+        }
+
+        setSelectedFileName(undefined);
+        props.onClear?.();
+    };
+
+    return (
+        <div class="rescue-file-input">
+            <input
+                accept={rescueFileTypes}
+                {...inputProps}
+                type="file"
+                class="rescue-file-input-control"
+                ref={(el) => {
+                    inputRef = el;
+                }}
+                onChange={handleChange}
+            />
+            <label
+                for={inputProps.id}
+                class="rescue-file-input-area"
+                aria-disabled={inputProps.disabled}>
+                <Show
+                    when={fileName()}
+                    fallback={
+                        <span class="rescue-file-input-title">
+                            <IoKey size={14} />
+                            {t("upload_rescue_key")}
+                        </span>
+                    }>
+                    <span class="rescue-file-input-filename">{fileName()}</span>
+                </Show>
+            </label>
+            <Show when={fileName()}>
+                <button
+                    type="button"
+                    class="rescue-file-input-clear"
+                    data-testid="rescueFileInputClear"
+                    disabled={inputProps.disabled}
+                    onClick={clearFile}>
+                    <IoClose />
+                </button>
+            </Show>
+        </div>
+    );
+};
+
+export default RescueFileInput;

--- a/src/components/RescueFileInput.tsx
+++ b/src/components/RescueFileInput.tsx
@@ -9,10 +9,10 @@ import { rescueFileTypes } from "../utils/download";
 
 type RescueFileInputProps = Omit<
     ComponentProps<"input">,
-    "type" | "onChange"
+    "accept" | "type" | "onChange"
 > & {
     id: string;
-    fileName?: string | null;
+    displayFileName?: string;
     onChange: (event: Event) => void;
     onClear?: () => void;
 };
@@ -20,15 +20,14 @@ type RescueFileInputProps = Omit<
 const RescueFileInput = (props: RescueFileInputProps) => {
     const { t } = useGlobalContext();
     const [, inputProps] = splitProps(props, [
-        "fileName",
+        "displayFileName",
         "onChange",
         "onClear",
     ]);
     const [selectedFileName, setSelectedFileName] = createSignal<string>();
     let inputRef: HTMLInputElement | undefined;
 
-    const fileName = () =>
-        props.fileName === undefined ? selectedFileName() : props.fileName;
+    const fileName = () => props.displayFileName ?? selectedFileName() ?? "";
 
     createEffect(() => {
         if (!fileName() && inputRef) {
@@ -54,8 +53,8 @@ const RescueFileInput = (props: RescueFileInputProps) => {
     return (
         <div class="rescue-file-input">
             <input
-                accept={rescueFileTypes}
                 {...inputProps}
+                accept={rescueFileTypes}
                 type="file"
                 class="rescue-file-input-control"
                 ref={(el) => {

--- a/src/components/RescueFileUpload.tsx
+++ b/src/components/RescueFileUpload.tsx
@@ -5,12 +5,12 @@ import { Match, Show, Switch } from "solid-js";
 
 import { useGlobalContext } from "../context/Global";
 import { rescueKeyMode, useRescueContext } from "../context/Rescue";
-import { rescueFileTypes } from "../utils/download";
 import { formatError } from "../utils/errors";
 import { validateRefundFile } from "../utils/refundFile";
 import type { RescueFile } from "../utils/rescueFile";
 import { validateRescueFile } from "../utils/rescueFile";
 import MnemonicInput from "./MnemonicInput";
+import RescueFileInput from "./RescueFileInput";
 
 export enum RescueFileType {
     Rescue,
@@ -147,13 +147,12 @@ const RescueFileUpload = (props: RescueFileUploadProps) => {
             </Show>
             <Switch>
                 <Match when={searchParams.mode !== rescueKeyMode}>
-                    <input
+                    <RescueFileInput
                         required
-                        type="file"
                         id="refundUpload"
                         data-testid="refundUpload"
-                        accept={rescueFileTypes}
                         onChange={(e) => uploadChange(e)}
+                        onClear={handleReset}
                     />
                     <p style={{ margin: "5px 0" }}>{t("or")}</p>
                     <Show when={showMnemonicOption()}>

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -496,6 +496,7 @@ const dict = {
             "Set {{ tokenStandard }} allowance for the swap contract",
         approve_allowance_reset_line:
             "Some {{ tokenStandard }} tokens require resetting the allowance to 0 before setting a new amount. You may need to approve twice.",
+        upload_rescue_key: "Select Rescue Key",
     },
     de: {
         language: "Deutsch",
@@ -1010,6 +1011,7 @@ const dict = {
             "{{ tokenStandard }}-Freigabe für den Swap-Contract festlegen",
         approve_allowance_reset_line:
             "Einige {{ tokenStandard }}-Token verlangen, dass die Freigabe zuerst auf 0 gesetzt wird, bevor ein neuer Betrag gesetzt werden kann. Möglicherweise musst du zweimal freigeben.",
+        upload_rescue_key: "Rettungsschlüssel auswählen",
     },
     es: {
         language: "Español",
@@ -1521,6 +1523,7 @@ const dict = {
             "Configura la asignación de {{ tokenStandard }} para el contrato de intercambio",
         approve_allowance_reset_line:
             "Algunos tokens {{ tokenStandard }} requieren restablecer la asignación a 0 antes de establecer una nueva cantidad. Es posible que debas aprobar dos veces.",
+        upload_rescue_key: "Seleccionar clave de rescate",
     },
     pt: {
         language: "Português",
@@ -2028,6 +2031,7 @@ const dict = {
             "Definir a permissão de {{ tokenStandard }} para o contrato de troca",
         approve_allowance_reset_line:
             "Alguns tokens {{ tokenStandard }} exigem redefinir a permissão para 0 antes de definir um novo valor. Talvez você precise aprovar duas vezes.",
+        upload_rescue_key: "Selecionar chave de resgate",
     },
     zh: {
         language: "中文",
@@ -2485,6 +2489,7 @@ const dict = {
         approve_allowance_line: "为交换合约设置 {{ tokenStandard }} 授权额度",
         approve_allowance_reset_line:
             "某些 {{ tokenStandard }} 代币要求先将授权额度重置为 0，然后才能设置新的额度。你可能需要授权两次。",
+        upload_rescue_key: "选择救援密钥",
     },
     ja: {
         language: "日本語",
@@ -2987,6 +2992,7 @@ const dict = {
             "スワップコントラクトの{{ tokenStandard }}許可額を設定",
         approve_allowance_reset_line:
             "一部の{{ tokenStandard }}トークンでは、新しい金額を設定する前に許可額を0にリセットする必要があります。2回承認が必要になる場合があります。",
+        upload_rescue_key: "レスキューキーを選択",
     },
 };
 

--- a/src/pages/RescueExternal.tsx
+++ b/src/pages/RescueExternal.tsx
@@ -862,7 +862,7 @@ export const RescueEvm = (props: { mode?: string }) => {
                     required
                     id="refundUpload"
                     data-testid="refundUpload"
-                    fileName={uploadedRescueFileName() ?? null}
+                    displayFileName={uploadedRescueFileName() ?? ""}
                     onChange={handleFileUpload}
                     onClear={clearUploadedRescueFile}
                 />

--- a/src/pages/RescueExternal.tsx
+++ b/src/pages/RescueExternal.tsx
@@ -26,6 +26,7 @@ import Pagination, {
     mobileItemsPerPage,
 } from "../components/Pagination";
 import RefundButton from "../components/RefundButton";
+import RescueFileInput from "../components/RescueFileInput";
 import RescueFileUpload, {
     RescueFileError,
     type RescueFileResult,
@@ -65,7 +66,6 @@ import { type RestorableSwap, getRestorableSwaps } from "../utils/boltzClient";
 import type { LogRefundData, SwapContract } from "../utils/contractLogs";
 import { scanLockupEvents } from "../utils/contractLogs";
 import { formatAmount, formatDenomination } from "../utils/denomination";
-import { rescueFileTypes } from "../utils/download";
 import { formatError } from "../utils/errors";
 import {
     type GasAbstractionSweep,
@@ -527,6 +527,8 @@ export const RescueEvm = (props: { mode?: string }) => {
     const [isScanning, setIsScanning] = createSignal(false);
     const [uploadedRescueFile, setUploadedRescueFile] =
         createSignal<RescueFile>();
+    const [uploadedRescueFileName, setUploadedRescueFileName] =
+        createSignal<string>();
     const [rescueFileError, setRescueFileError] = createSignal<string | null>(
         null,
     );
@@ -749,12 +751,21 @@ export const RescueEvm = (props: { mode?: string }) => {
         }
     });
 
+    const clearUploadedRescueFile = () => {
+        setUploadedRescueFile(undefined);
+        setUploadedRescueFileName(undefined);
+        setRescueFileError(null);
+        resetRescueKey();
+    };
+
     const handleFileUpload = async (e: Event) => {
         const input = e.currentTarget as HTMLInputElement;
         const inputFile = input.files?.[0];
         if (!inputFile) {
             return;
         }
+
+        clearUploadedRescueFile();
 
         try {
             const result = await processUploadedFile(inputFile);
@@ -764,8 +775,8 @@ export const RescueEvm = (props: { mode?: string }) => {
             }
 
             const rescueFile = result.data as RescueFile;
-            setRescueFileError(null);
             setUploadedRescueFile(rescueFile);
+            setUploadedRescueFileName(inputFile.name);
             setContextRescueFile(rescueFile);
         } catch (err) {
             log.error("invalid file upload", formatError(err));
@@ -781,6 +792,7 @@ export const RescueEvm = (props: { mode?: string }) => {
             setLogRefundableSwaps(undefined);
             setUploadedRescueFile(undefined);
             setSweepableBalances([]);
+            setUploadedRescueFileName(undefined);
             setUnmatchedSwaps(0);
         }
     });
@@ -846,13 +858,13 @@ export const RescueEvm = (props: { mode?: string }) => {
     const RescueKeyInput = () => (
         <>
             <Show when={!showMnemonicMode()}>
-                <input
+                <RescueFileInput
                     required
-                    type="file"
                     id="refundUpload"
                     data-testid="refundUpload"
-                    accept={rescueFileTypes}
+                    fileName={uploadedRescueFileName() ?? null}
                     onChange={handleFileUpload}
+                    onClear={clearUploadedRescueFile}
                 />
                 <Show when={!uploadedRescueFile()}>
                     <p style={{ margin: "5px 0" }}>{t("or")}</p>

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -1310,10 +1310,6 @@ textarea.invalid {
     }
 }
 
-#refundUpload {
-    margin-top: 7px;
-}
-
 .quote {
     display: flex;
     flex-direction: column;

--- a/src/style/rescueFileInput.scss
+++ b/src/style/rescueFileInput.scss
@@ -1,0 +1,76 @@
+.rescue-file-input {
+    position: relative;
+    width: 100%;
+    margin-top: 0.4375rem;
+}
+
+.rescue-file-input-control {
+    position: absolute;
+    width: 0.0625rem;
+    height: 0.0625rem;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.rescue-file-input-area {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.625rem;
+    padding: 0.375rem 2.75rem;
+    border: 0.0625rem dashed var(--color-white-30);
+    border-radius: 0.625rem;
+    background-color: var(--color-black-20);
+    cursor: pointer;
+}
+
+.rescue-file-input-area:hover,
+.rescue-file-input-control:focus-visible + .rescue-file-input-area {
+    border-color: var(--color-primary);
+}
+
+.rescue-file-input-area[aria-disabled="true"] {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.rescue-file-input-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--color-white-60);
+}
+
+.rescue-file-input-filename {
+    max-width: 100%;
+    overflow: hidden;
+    color: var(--color-white-60);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.rescue-file-input-clear {
+    position: absolute;
+    top: 50%;
+    right: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.625rem;
+    height: 1.625rem;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background-color: var(--color-black-40);
+    color: var(--color-text);
+    cursor: pointer;
+    transform: translateY(-50%);
+}
+
+@media (hover: hover) {
+    .rescue-file-input-clear:hover {
+        background-color: var(--color-primary);
+        color: var(--color-secondary-700);
+    }
+}

--- a/tests/components/RescueFileInput.spec.tsx
+++ b/tests/components/RescueFileInput.spec.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { userEvent } from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import RescueFileInput from "../../src/components/RescueFileInput";
+import i18n from "../../src/i18n/i18n";
+import { contextWrapper } from "../helper";
+
+const placeholderText = i18n.en.upload_rescue_key;
+const clearButtonTestId = "rescueFileInputClear";
+
+const renderInput = (
+    overrides: Partial<Parameters<typeof RescueFileInput>[0]> = {},
+) => {
+    const onChange = overrides.onChange ?? vi.fn();
+    const onClear = overrides.onClear ?? vi.fn();
+
+    const result = render(
+        () => (
+            <RescueFileInput
+                id="rescueFileInput"
+                data-testid="rescueFileInput"
+                {...overrides}
+                onChange={onChange}
+                onClear={onClear}
+            />
+        ),
+        { wrapper: contextWrapper },
+    );
+
+    return {
+        ...result,
+        onChange,
+        onClear,
+        getInput: () =>
+            screen.getByTestId("rescueFileInput") as HTMLInputElement,
+    };
+};
+
+const makeFile = (name = "rescue.json") =>
+    new File([JSON.stringify({})], name, { type: "application/json" });
+
+describe("RescueFileInput", () => {
+    test("renders the placeholder and no clear button when empty", () => {
+        renderInput();
+
+        expect(screen.getByText(placeholderText)).toBeInTheDocument();
+        expect(screen.queryByTestId(clearButtonTestId)).not.toBeInTheDocument();
+    });
+
+    test("forwards required, disabled and accept attributes to the native input", () => {
+        const { getInput } = renderInput({
+            required: true,
+            disabled: true,
+        });
+
+        const input = getInput();
+        expect(input.type).toBe("file");
+        expect(input.required).toBe(true);
+        expect(input.disabled).toBe(true);
+        expect(input.accept).toContain("application/json");
+    });
+
+    test("shows the filename and clear button after a file is uploaded", async () => {
+        const user = userEvent.setup();
+        const { getInput, onChange } = renderInput();
+
+        await user.upload(getInput(), makeFile("rescue.json"));
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(screen.getByText("rescue.json")).toBeInTheDocument();
+        expect(screen.queryByText(placeholderText)).not.toBeInTheDocument();
+        expect(screen.getByTestId(clearButtonTestId)).toBeInTheDocument();
+    });
+
+    test("clicking clear calls onClear, restores the placeholder and resets the input", async () => {
+        const user = userEvent.setup();
+        const { getInput, onClear } = renderInput();
+
+        await user.upload(getInput(), makeFile("rescue.json"));
+        fireEvent.click(screen.getByTestId(clearButtonTestId));
+
+        expect(onClear).toHaveBeenCalledTimes(1);
+        expect(screen.getByText(placeholderText)).toBeInTheDocument();
+        expect(screen.queryByTestId(clearButtonTestId)).not.toBeInTheDocument();
+        expect(getInput().value).toBe("");
+    });
+
+    test("uses the controlled fileName prop when provided", () => {
+        renderInput({ fileName: "external.json" });
+
+        expect(screen.getByText("external.json")).toBeInTheDocument();
+        expect(screen.queryByText(placeholderText)).not.toBeInTheDocument();
+        expect(screen.getByTestId(clearButtonTestId)).toBeInTheDocument();
+    });
+
+    test("hides the clear button in controlled mode when fileName is null", async () => {
+        const user = userEvent.setup();
+        const { getInput } = renderInput({ fileName: null });
+
+        await user.upload(getInput(), makeFile("rescue.json"));
+
+        expect(screen.getByText(placeholderText)).toBeInTheDocument();
+        expect(screen.queryByTestId(clearButtonTestId)).not.toBeInTheDocument();
+    });
+});

--- a/tests/components/RescueFileInput.spec.tsx
+++ b/tests/components/RescueFileInput.spec.tsx
@@ -86,17 +86,17 @@ describe("RescueFileInput", () => {
         expect(getInput().value).toBe("");
     });
 
-    test("uses the controlled fileName prop when provided", () => {
-        renderInput({ fileName: "external.json" });
+    test("uses the displayFileName prop when provided", () => {
+        renderInput({ displayFileName: "external.json" });
 
         expect(screen.getByText("external.json")).toBeInTheDocument();
         expect(screen.queryByText(placeholderText)).not.toBeInTheDocument();
         expect(screen.getByTestId(clearButtonTestId)).toBeInTheDocument();
     });
 
-    test("hides the clear button in controlled mode when fileName is null", async () => {
+    test("hides the clear button in display mode when displayFileName is empty", async () => {
         const user = userEvent.setup();
-        const { getInput } = renderInput({ fileName: null });
+        const { getInput } = renderInput({ displayFileName: "" });
 
         await user.upload(getInput(), makeFile("rescue.json"));
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated the rescue file upload UI into a reusable component used across verification and rescue flows, preserving upload/validation behavior.

* **Style**
  * Added dedicated styling for the rescue file input with clearer visual feedback, hover/focus states, and accessibility cues.

* **Bug Fixes**
  * Avoids running upload processing when no file is selected and ensures clear/reset reliably resets state.

* **New Features**
  * Displays uploaded filename with an optional override and localized "Select Rescue Key" label.

* **Tests**
  * Added unit and e2e coverage for the new input, display, clear, and upload flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->