### PR TITLE
feat: make rescue support refunding USDT/USDC on Arbitrum

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -473,6 +473,8 @@ const dict = {
         swaps_found: "Scanning swaps ({{ count }} found)",
         claim_scan_required:
             "To claim this swap, go back and scan with your rescue file uploaded.",
+        refund_scan_required:
+            "To refund this balance, go back and scan with your rescue file uploaded.",
         invalid_rescue_key_evm:
             "This rescue key is not associated with this swap. Please try again using a different rescue key.",
         error_occurred: "An error occurred: {{ error }}",
@@ -481,7 +483,7 @@ const dict = {
             'If you sent funds into a Boltz swap on an EVM chain, use "Refund Swap"; if you were receiving funds from an EVM chain, use "Resume Swap" to rescue a swap that is not available in this browser’s swap history.',
         evm_rescue_refund_title: "Refund Swap",
         evm_rescue_refund_explainer:
-            "Connect your wallet to scan for EVM swaps that have expired and can be refunded. If you sent USDT0 or TBTC into a Boltz swap, use your Rescue Key to find it. Rescue Key is not necessary to refund RBTC.",
+            "Connect your wallet to scan for EVM swaps that have expired and can be refunded. If you sent USDT0, USDC, or TBTC into a Boltz swap, use your Rescue Key to find it. Rescue Key is not necessary to refund RBTC.",
         start_scanning: "Start scanning",
         stop_scanning: "Stop scanning",
         evm_rescue_resume_title: "Resume Swap",
@@ -986,6 +988,8 @@ const dict = {
         swaps_found: "Scanne Swaps ({{ count }} gefunden)",
         claim_scan_required:
             "Um diesen Swap zu claimen, gehe zurück und scanne mit hochgeladener Rescue-Datei.",
+        refund_scan_required:
+            "Um dieses Guthaben zu erstatten, gehe zurück und scanne mit hochgeladener Rescue-Datei.",
         invalid_rescue_key_evm:
             "Dieser Rettungsschlüssel ist nicht mit diesem Swap verbunden. Bitte versuche es erneut mit einem anderen Rettungsschlüssel.",
         error_occurred: "Ein Fehler ist aufgetreten: {{ error }}",
@@ -993,7 +997,7 @@ const dict = {
             'Wenn du Guthaben in einen Boltz-Swap auf einer EVM-Chain gesendet hast, nutze "Swap erstatten"; wenn du Guthaben von einer EVM-Chain empfangen hast, nutze "Swap fortsetzen", um einen Swap zu retten, der nicht im Verlauf dieses Browsers verfügbar ist.',
         evm_rescue_refund_title: "Swap erstatten",
         evm_rescue_refund_explainer:
-            "Verbinde dein Wallet, um nach EVM-Swaps zu suchen, die abgelaufen sind und erstattet werden können. Wenn du USDT0 oder TBTC in einen Boltz-Swap gesendet hast, nutze deinen Rettungsschlüssel, um ihn zu finden. Für die Rückerstattung von RBTC ist kein Rettungsschlüssel erforderlich.",
+            "Verbinde dein Wallet, um nach EVM-Swaps zu suchen, die abgelaufen sind und erstattet werden können. Wenn du USDT0, USDC oder TBTC in einen Boltz-Swap gesendet hast, nutze deinen Rettungsschlüssel, um ihn zu finden. Für die Rückerstattung von RBTC ist kein Rettungsschlüssel erforderlich.",
         start_scanning: "Scannen starten",
         stop_scanning: "Scannen stoppen",
         evm_rescue_resume_title: "Swap fortsetzen",
@@ -1495,6 +1499,8 @@ const dict = {
         swaps_found: "Escaneando intercambios ({{ count }} encontrados)",
         claim_scan_required:
             "Para reclamar este intercambio, vuelve y escanea con tu archivo de rescate cargado.",
+        refund_scan_required:
+            "Para reembolsar este saldo, vuelve y escanea con tu archivo de rescate cargado.",
         invalid_rescue_key_evm:
             "Esta clave de rescate no está asociada con este intercambio. Por favor, intenta de nuevo usando una clave de rescate diferente.",
         error_occurred: "Ocurrió un error: {{ error }}",
@@ -1502,7 +1508,7 @@ const dict = {
             'Si enviaste fondos a un intercambio de Boltz en una cadena EVM, usa "Reembolsar intercambio"; si estabas recibiendo fondos desde una cadena EVM, usa "Reanudar intercambio" para rescatar un intercambio que no está disponible en el historial de este navegador.',
         evm_rescue_refund_title: "Reembolsar intercambio",
         evm_rescue_refund_explainer:
-            "Conecta tu monedero para buscar intercambios EVM que hayan expirado y puedan reembolsarse. Si enviaste USDT0 o TBTC a un intercambio de Boltz, usa tu clave de rescate para encontrarlo. No se necesita la clave de rescate para reembolsar RBTC.",
+            "Conecta tu monedero para buscar intercambios EVM que hayan expirado y puedan reembolsarse. Si enviaste USDT0, USDC o TBTC a un intercambio de Boltz, usa tu clave de rescate para encontrarlo. No se necesita la clave de rescate para reembolsar RBTC.",
         start_scanning: "Iniciar escaneo",
         stop_scanning: "Detener escaneo",
         evm_rescue_resume_title: "Reanudar intercambio",
@@ -2000,6 +2006,8 @@ const dict = {
         swaps_found: "Buscando trocas ({{ count }} encontradas)",
         claim_scan_required:
             "Para reivindicar esta troca, volte e escaneie com o arquivo de resgate carregado.",
+        refund_scan_required:
+            "Para reembolsar este saldo, volte e escaneie com o arquivo de resgate carregado.",
         invalid_rescue_key_evm:
             "Esta chave de resgate não está associada a esta troca. Por favor, tente novamente usando uma chave de resgate diferente.",
         error_occurred: "Ocorreu um erro: {{ error }}",
@@ -2007,7 +2015,7 @@ const dict = {
             'Se você enviou fundos para uma troca da Boltz em uma rede EVM, use "Reembolsar troca"; se estava recebendo fundos de uma rede EVM, use "Continuar troca" para resgatar uma troca que não está disponível no histórico deste navegador.',
         evm_rescue_refund_title: "Reembolsar troca",
         evm_rescue_refund_explainer:
-            "Conecte sua carteira para procurar trocas em EVM que expiraram e podem ser reembolsadas. Se você enviou USDT0 ou TBTC para uma troca da Boltz, use sua chave de resgate para encontrá-la. A chave de resgate não é necessária para reembolsar RBTC.",
+            "Conecte sua carteira para procurar trocas em EVM que expiraram e podem ser reembolsadas. Se você enviou USDT0, USDC ou TBTC para uma troca da Boltz, use sua chave de resgate para encontrá-la. A chave de resgate não é necessária para reembolsar RBTC.",
         start_scanning: "Iniciar varredura",
         stop_scanning: "Parar varredura",
         evm_rescue_resume_title: "Continuar troca",
@@ -2456,6 +2464,8 @@ const dict = {
         failed: "失败",
         swaps_found: "正在扫描交换（已找到 {{ count }} 个）",
         claim_scan_required: "要领取此交换，请返回并在上传救援文件后进行扫描。",
+        refund_scan_required:
+            "要退还此余额，请返回并在上传救援文件后进行扫描。",
         invalid_rescue_key_evm:
             "此救援密钥与此交换不关联。请使用其他救援密钥重试。",
         error_occurred: "发生错误：{{ error }}",
@@ -2463,7 +2473,7 @@ const dict = {
             "如果你向 EVM 链上的 Boltz 交换发送了资金，请使用“退还交换”；如果你正在从 EVM 链接收资金，请使用“继续交换”，以救援一个未在此浏览器交换历史中显示的交换。",
         evm_rescue_refund_title: "退还交换",
         evm_rescue_refund_explainer:
-            "连接你的钱包以扫描已过期且可退款的 EVM 交换。如果你向 Boltz 交换发送了 USDT0 或 TBTC，请使用你的救援密钥来找到该交换。退还 RBTC 不需要救援密钥。",
+            "连接你的钱包以扫描已过期且可退款的 EVM 交换。如果你向 Boltz 交换发送了 USDT0、USDC 或 TBTC，请使用你的救援密钥来找到该交换。退还 RBTC 不需要救援密钥。",
         start_scanning: "开始扫描",
         stop_scanning: "停止扫描",
         evm_rescue_resume_title: "继续交换",
@@ -2955,6 +2965,8 @@ const dict = {
         swaps_found: "スワップをスキャン中（{{ count }} 件見つかりました）",
         claim_scan_required:
             "このスワップを請求するには、レスキューファイルをアップロードして戻り、スキャンしてください。",
+        refund_scan_required:
+            "この残高を返金するには、レスキューファイルをアップロードして戻り、スキャンしてください。",
         invalid_rescue_key_evm:
             "このレスキューキーはこのスワップに関連付けられていません。別のレスキューキーを使用してもう一度お試しください。",
         error_occurred: "エラーが発生しました：{{ error }}",
@@ -2962,7 +2974,7 @@ const dict = {
             "EVM チェーン上の Boltz スワップに資金を送金した場合は「スワップを返金」を使用し、EVM チェーンから資金を受け取っていた場合は「スワップを再開」を使用して、このブラウザのスワップ履歴にないスワップを救済してください。",
         evm_rescue_refund_title: "スワップを返金",
         evm_rescue_refund_explainer:
-            "ウォレットを接続して、期限切れで返金可能な EVM スワップをスキャンします。USDT0 または TBTC を Boltz スワップに送金した場合は、レスキューキーを使ってそのスワップを見つけてください。RBTC の返金にはレスキューキーは不要です。",
+            "ウォレットを接続して、期限切れで返金可能な EVM スワップをスキャンします。USDT0、USDC または TBTC を Boltz スワップに送金した場合は、レスキューキーを使ってそのスワップを見つけてください。RBTC の返金にはレスキューキーは不要です。",
         start_scanning: "スキャンを開始",
         stop_scanning: "スキャンを停止",
         evm_rescue_resume_title: "スワップを再開",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,7 @@ import { Web3SignerProvider } from "./context/Web3";
 import ClaimRescue from "./pages/ClaimRescue";
 import Create from "./pages/Create";
 import Error from "./pages/Error";
+import GasAbstractionSweepRescue from "./pages/GasAbstractionSweepRescue";
 import Hero from "./pages/Hero";
 import History from "./pages/History";
 import NotFound from "./pages/NotFound";
@@ -126,6 +127,10 @@ const cleanup = render(
             <Route path="/swapbox" component={Create} />
             <Route path="/swap/:id" component={Pay} />
             <Route path="/swap/:id/claim" component={ClaimRescue} />
+            <Route
+                path="/swap/rescue/evm/gas-abstraction/:asset/:address/:action"
+                component={GasAbstractionSweepRescue}
+            />
             <Route
                 path="/swap/rescue/evm/:asset/:txHash/:action"
                 component={RescueEvm}

--- a/src/pages/GasAbstractionSweepRescue.tsx
+++ b/src/pages/GasAbstractionSweepRescue.tsx
@@ -1,0 +1,154 @@
+import { useParams } from "@solidjs/router";
+import BigNumber from "bignumber.js";
+import { getAddress } from "ethers";
+import type { Wallet } from "ethers";
+import { Match, Show, Switch, createResource, createSignal } from "solid-js";
+
+import BlockExplorer from "../components/BlockExplorer";
+import ContractTransaction from "../components/ContractTransaction";
+import LoadingSpinner from "../components/LoadingSpinner";
+import SettingsCog from "../components/settings/SettingsCog";
+import SettingsMenu from "../components/settings/SettingsMenu";
+import type { AssetType } from "../consts/Assets";
+import { RskRescueMode } from "../consts/Enums";
+import { useGlobalContext } from "../context/Global";
+import { useRescueContext } from "../context/Rescue";
+import { createTokenContract } from "../context/Web3";
+import { useWeb3Signer } from "../context/Web3";
+import { formatAmount, formatDenomination } from "../utils/denomination";
+import { formatError } from "../utils/errors";
+import { sweepGasAbstractionToken } from "../utils/gasAbstractionSweep";
+import { cropString } from "../utils/helper";
+
+type SweepData = {
+    amount: bigint;
+    signer: Wallet;
+};
+
+const GasAbstractionSweepRescue = () => {
+    const params = useParams<{
+        asset: string;
+        address: string;
+        action: RskRescueMode;
+    }>();
+    const { t, denomination, separator } = useGlobalContext();
+    const { rescueFile } = useRescueContext();
+    const { signer, getGasAbstractionSigner } = useWeb3Signer();
+    const [refundTxId, setRefundTxId] = createSignal<string>();
+
+    const [sweepData] = createResource<SweepData>(async () => {
+        if (signer() === undefined || rescueFile() === undefined) {
+            return undefined;
+        }
+
+        if (params.action !== RskRescueMode.Refund) {
+            throw new Error(`unsupported action: ${params.action}`);
+        }
+
+        const gasSigner = getGasAbstractionSigner(params.asset, rescueFile());
+        if (getAddress(gasSigner.address) !== getAddress(params.address)) {
+            throw new Error(t("invalid_rescue_key_evm"));
+        }
+
+        const token = createTokenContract(params.asset, gasSigner);
+        return {
+            amount: await token.balanceOf(gasSigner.address),
+            signer: gasSigner,
+        };
+    });
+
+    const amount = (data: SweepData) =>
+        formatAmount(
+            new BigNumber(data.amount.toString()),
+            denomination(),
+            separator(),
+            params.asset,
+        );
+
+    const sweep = async () => {
+        const currentSigner = signer();
+        const currentSweepData = sweepData();
+
+        if (currentSigner === undefined || currentSweepData === undefined) {
+            return;
+        }
+
+        setRefundTxId(
+            await sweepGasAbstractionToken({
+                asset: params.asset as AssetType,
+                amount: currentSweepData.amount,
+                destination: await currentSigner.getAddress(),
+                signer: currentSweepData.signer,
+            }),
+        );
+    };
+
+    return (
+        <div class="frame">
+            <Show
+                when={signer() !== undefined}
+                fallback={<h2>{t("no_wallet")}</h2>}>
+                <SettingsCog />
+                <SettingsMenu />
+                <h2 class="frame-title" style={{ "margin-bottom": "6px" }}>
+                    {t("refund")} {cropString(params.address, 15, 5)}
+                </h2>
+                <hr />
+                <Switch>
+                    <Match when={rescueFile() === undefined}>
+                        <h3>{t("refund_scan_required")}</h3>
+                    </Match>
+                    <Match when={sweepData.state === "pending"}>
+                        <LoadingSpinner />
+                    </Match>
+                    <Match when={sweepData.state === "errored"}>
+                        <h2>{t("error")}</h2>
+                        <h3>{formatError(sweepData.error)}</h3>
+                    </Match>
+                    <Match when={sweepData.state === "ready"}>
+                        <Show
+                            when={sweepData()}
+                            keyed
+                            fallback={<LoadingSpinner />}>
+                            {(data) => (
+                                <Switch>
+                                    <Match when={data.amount === 0n}>
+                                        <h3>
+                                            {t("connected_wallet_no_swaps")}
+                                        </h3>
+                                    </Match>
+                                    <Match when={refundTxId() === undefined}>
+                                        <p>
+                                            {t("refund")} {amount(data)}{" "}
+                                            {formatDenomination(
+                                                denomination(),
+                                                params.asset,
+                                            )}
+                                        </p>
+                                        <ContractTransaction
+                                            asset={params.asset}
+                                            signerOverride={() => data.signer}
+                                            onClick={sweep}
+                                            buttonText={t("refund")}
+                                        />
+                                    </Match>
+                                    <Match when={refundTxId() !== undefined}>
+                                        <p>{t("refunded")}</p>
+                                        <hr />
+                                        <BlockExplorer
+                                            typeLabel={"refund_tx"}
+                                            asset={params.asset}
+                                            txId={refundTxId()}
+                                        />
+                                    </Match>
+                                </Switch>
+                            )}
+                        </Show>
+                    </Match>
+                </Switch>
+            </Show>
+        </div>
+    );
+};
+
+export default GasAbstractionSweepRescue;

--- a/src/pages/GasAbstractionSweepRescue.tsx
+++ b/src/pages/GasAbstractionSweepRescue.tsx
@@ -2,7 +2,14 @@ import { useParams } from "@solidjs/router";
 import BigNumber from "bignumber.js";
 import { getAddress } from "ethers";
 import type { Wallet } from "ethers";
-import { Match, Show, Switch, createResource, createSignal } from "solid-js";
+import {
+    Match,
+    Show,
+    Switch,
+    createMemo,
+    createResource,
+    createSignal,
+} from "solid-js";
 
 import BlockExplorer from "../components/BlockExplorer";
 import ContractTransaction from "../components/ContractTransaction";
@@ -13,17 +20,24 @@ import type { AssetType } from "../consts/Assets";
 import { RskRescueMode } from "../consts/Enums";
 import { useGlobalContext } from "../context/Global";
 import { useRescueContext } from "../context/Rescue";
-import { createTokenContract } from "../context/Web3";
-import { useWeb3Signer } from "../context/Web3";
+import { createTokenContract, useWeb3Signer } from "../context/Web3";
 import { formatAmount, formatDenomination } from "../utils/denomination";
 import { formatError } from "../utils/errors";
-import { sweepGasAbstractionToken } from "../utils/gasAbstractionSweep";
+import {
+    gasAbstractionSweepAssets,
+    getGasAbstractionSweepDisplayAmount,
+    sweepGasAbstractionToken,
+} from "../utils/gasAbstractionSweep";
 import { cropString } from "../utils/helper";
 
 type SweepData = {
+    asset: AssetType;
     amount: bigint;
     signer: Wallet;
 };
+
+const isSweepableAsset = (asset: string): asset is AssetType =>
+    (gasAbstractionSweepAssets as readonly string[]).includes(asset);
 
 const GasAbstractionSweepRescue = () => {
     const params = useParams<{
@@ -36,46 +50,67 @@ const GasAbstractionSweepRescue = () => {
     const { signer, getGasAbstractionSigner } = useWeb3Signer();
     const [refundTxId, setRefundTxId] = createSignal<string>();
 
-    const [sweepData] = createResource<SweepData>(async () => {
-        if (signer() === undefined || rescueFile() === undefined) {
-            return undefined;
+    const sweepSource = createMemo(() => {
+        const currentSigner = signer();
+        const currentRescueFile = rescueFile();
+        if (currentSigner === undefined || currentRescueFile === undefined) {
+            return false;
         }
+        return { rescueFile: currentRescueFile };
+    });
 
+    const [sweepData] = createResource(sweepSource, async (source) => {
+        if (!isSweepableAsset(params.asset)) {
+            throw new Error(`unsupported asset: ${params.asset}`);
+        }
         if (params.action !== RskRescueMode.Refund) {
             throw new Error(`unsupported action: ${params.action}`);
         }
 
-        const gasSigner = getGasAbstractionSigner(params.asset, rescueFile());
+        const gasSigner = getGasAbstractionSigner(
+            params.asset,
+            source.rescueFile,
+        );
         if (getAddress(gasSigner.address) !== getAddress(params.address)) {
             throw new Error(t("invalid_rescue_key_evm"));
         }
 
         const token = createTokenContract(params.asset, gasSigner);
         return {
+            asset: params.asset,
             amount: await token.balanceOf(gasSigner.address),
             signer: gasSigner,
-        };
+        } satisfies SweepData;
     });
 
     const amount = (data: SweepData) =>
         formatAmount(
-            new BigNumber(data.amount.toString()),
+            new BigNumber(
+                getGasAbstractionSweepDisplayAmount({
+                    asset: data.asset,
+                    amount: data.amount,
+                }).toString(),
+            ),
             denomination(),
             separator(),
-            params.asset,
+            data.asset,
         );
 
     const sweep = async () => {
         const currentSigner = signer();
         const currentSweepData = sweepData();
 
-        if (currentSigner === undefined || currentSweepData === undefined) {
+        if (
+            currentSigner === undefined ||
+            currentSweepData === undefined ||
+            !isSweepableAsset(params.asset)
+        ) {
             return;
         }
 
         setRefundTxId(
             await sweepGasAbstractionToken({
-                asset: params.asset as AssetType,
+                asset: params.asset,
                 amount: currentSweepData.amount,
                 destination: await currentSigner.getAddress(),
                 signer: currentSweepData.signer,
@@ -118,18 +153,15 @@ const GasAbstractionSweepRescue = () => {
                                         </h3>
                                     </Match>
                                     <Match when={refundTxId() === undefined}>
-                                        <p>
-                                            {t("refund")} {amount(data)}{" "}
-                                            {formatDenomination(
-                                                denomination(),
-                                                params.asset,
-                                            )}
-                                        </p>
                                         <ContractTransaction
                                             asset={params.asset}
                                             signerOverride={() => data.signer}
                                             onClick={sweep}
                                             buttonText={t("refund")}
+                                            promptText={`${t("refund")} ${amount(data)} ${formatDenomination(
+                                                denomination(),
+                                                data.asset,
+                                            )}`}
                                         />
                                     </Match>
                                     <Match when={refundTxId() !== undefined}>

--- a/src/pages/RescueExternal.tsx
+++ b/src/pages/RescueExternal.tsx
@@ -1,4 +1,5 @@
 import { useNavigate, useParams, useSearchParams } from "@solidjs/router";
+import BigNumber from "bignumber.js";
 import { computeAddress } from "ethers";
 import log from "loglevel";
 import type { Accessor } from "solid-js";
@@ -34,7 +35,16 @@ import SwapListLogs from "../components/SwapListLogs";
 import SettingsCog from "../components/settings/SettingsCog";
 import SettingsMenu from "../components/settings/SettingsMenu";
 import { config } from "../config";
-import { type AssetType, BTC, LBTC, RBTC, TBTC } from "../consts/Assets";
+import {
+    type AssetType,
+    BTC,
+    LBTC,
+    RBTC,
+    TBTC,
+    USDC,
+    USDT0,
+    getAssetDisplaySymbol,
+} from "../consts/Assets";
 import { RskRescueMode } from "../consts/Enums";
 import { paginationLimit } from "../consts/Pagination";
 import { useGlobalContext } from "../context/Global";
@@ -48,9 +58,14 @@ import "../style/tabs.scss";
 import { type RestorableSwap, getRestorableSwaps } from "../utils/boltzClient";
 import type { LogRefundData, SwapContract } from "../utils/contractLogs";
 import { scanLockupEvents } from "../utils/contractLogs";
+import { formatAmount, formatDenomination } from "../utils/denomination";
 import { rescueFileTypes } from "../utils/download";
 import { formatError } from "../utils/errors";
-import { isMobile } from "../utils/helper";
+import {
+    type GasAbstractionSweep,
+    getSweepableGasAbstractionBalances,
+} from "../utils/gasAbstractionSweep";
+import { cropString, isMobile } from "../utils/helper";
 import {
     RescueAction,
     createRescueList,
@@ -344,6 +359,70 @@ type EvmScanTarget = {
     contract: SwapContract;
 };
 
+const GasAbstractionSweepItem = (props: { sweep: GasAbstractionSweep }) => {
+    const navigate = useNavigate();
+    const { t, denomination, separator } = useGlobalContext();
+
+    const amount = createMemo(() =>
+        formatAmount(
+            new BigNumber(props.sweep.amount.toString()),
+            denomination(),
+            separator(),
+            props.sweep.asset,
+        ),
+    );
+
+    return (
+        <div
+            class="swaplist-item"
+            onClick={() =>
+                navigate(
+                    `/swap/rescue/evm/gas-abstraction/${props.sweep.asset}/${props.sweep.signer.address}/${RskRescueMode.Refund}`,
+                )
+            }>
+            <a class="btn-small hidden-mobile" href="#">
+                {t("view")}
+            </a>
+            <span class="swaplist-asset swaplist-asset-single">
+                <span data-asset={getAssetDisplaySymbol(props.sweep.asset)} />
+            </span>
+            <span class="swaplist-asset-id">
+                {t("id")}:&nbsp;
+                <span class="monospace">
+                    {cropString(props.sweep.signer.address, 15, 5)}
+                </span>
+            </span>
+            <span class="swaplist-asset-date">
+                {t("balance")}:&nbsp;
+                <span class="monospace">
+                    {amount()}{" "}
+                    {formatDenomination(denomination(), props.sweep.asset)}
+                </span>
+            </span>
+        </div>
+    );
+};
+
+const GasAbstractionSweepList = (props: {
+    balances: Accessor<GasAbstractionSweep[]>;
+}) => (
+    <Show when={props.balances().length > 0}>
+        <div class="swaplist">
+            <hr />
+            <For each={props.balances()}>
+                {(sweep, index) => (
+                    <>
+                        <GasAbstractionSweepItem sweep={sweep} />
+                        <Show when={index() < props.balances().length - 1}>
+                            <hr />
+                        </Show>
+                    </>
+                )}
+            </For>
+        </div>
+    </Show>
+);
+
 const getEvmScanTargets = (
     getEtherSwap: (asset: string) => SwapContract,
     getErc20Swap: (asset: string) => SwapContract,
@@ -390,7 +469,8 @@ export const RescueEvm = (props: { mode?: string }) => {
     const navigate = useNavigate();
     const params = useParams();
     const [searchParams] = useSearchParams();
-    const { signer, getEtherSwap, getErc20Swap } = useWeb3Signer();
+    const { signer, getEtherSwap, getErc20Swap, getGasAbstractionSigner } =
+        useWeb3Signer();
     const {
         setEvmRescuableSwaps,
         setRescueFile: setContextRescueFile,
@@ -409,6 +489,9 @@ export const RescueEvm = (props: { mode?: string }) => {
     const [logRefundableSwaps, setLogRefundableSwaps] = createSignal<
         LogRefundData[] | undefined
     >(undefined);
+    const [sweepableBalances, setSweepableBalances] = createSignal<
+        GasAbstractionSweep[]
+    >([]);
     const [refundScanProgress, setRefundScanProgress] = createSignal<
         string | undefined
     >(undefined);
@@ -430,6 +513,7 @@ export const RescueEvm = (props: { mode?: string }) => {
         setIsScanning(false);
         setRefundScanProgress(undefined);
         setUnmatchedSwaps(0);
+        setSweepableBalances([]);
     };
 
     type ScanProgress = {
@@ -566,6 +650,7 @@ export const RescueEvm = (props: { mode?: string }) => {
         setIsScanning(true);
         setLogRefundableSwaps([]);
         setEvmRescuableSwaps([]);
+        setSweepableBalances([]);
         setUnmatchedSwaps(0);
         setRefundScanProgress(
             t("logs_scan_progress", {
@@ -578,6 +663,18 @@ export const RescueEvm = (props: { mode?: string }) => {
 
         const signerAddress = await currentSigner.getAddress();
         const rescueFile = uploadedRescueFile();
+        const sweepBalances =
+            action === RskRescueMode.Refund && rescueFile !== undefined
+                ? getSweepableGasAbstractionBalances({
+                      destination: signerAddress,
+                      rescueFile,
+                      getGasAbstractionSigner,
+                  }).then((balances) => {
+                      if (!signal.aborted) {
+                          setSweepableBalances(balances);
+                      }
+                  })
+                : Promise.resolve();
 
         const targets = getEvmScanTargets(
             getEtherSwap as (a: string) => SwapContract,
@@ -586,22 +683,25 @@ export const RescueEvm = (props: { mode?: string }) => {
             rescueFile !== undefined,
         );
         const scanProgress = createScanProgress();
-        await Promise.all(
-            targets.map((target) =>
-                runSingleScan(
-                    target,
-                    signerAddress,
-                    action,
-                    scanProgress,
-                    signal,
-                    rescueFile?.mnemonic,
+        try {
+            await Promise.all([
+                ...targets.map((target) =>
+                    runSingleScan(
+                        target,
+                        signerAddress,
+                        action,
+                        scanProgress,
+                        signal,
+                        rescueFile?.mnemonic,
+                    ),
                 ),
-            ),
-        );
-
-        if (!signal.aborted) {
-            setIsScanning(false);
-            setRefundScanProgress(undefined);
+                sweepBalances,
+            ]);
+        } finally {
+            if (!signal.aborted) {
+                setIsScanning(false);
+                setRefundScanProgress(undefined);
+            }
         }
     };
 
@@ -647,6 +747,7 @@ export const RescueEvm = (props: { mode?: string }) => {
             }
             setLogRefundableSwaps(undefined);
             setUploadedRescueFile(undefined);
+            setSweepableBalances([]);
             setUnmatchedSwaps(0);
         }
     });
@@ -694,6 +795,7 @@ export const RescueEvm = (props: { mode?: string }) => {
                     !isScanning() &&
                     logRefundableSwaps() !== undefined &&
                     logRefundableSwaps().length === 0 &&
+                    sweepableBalances().length === 0 &&
                     unmatchedSwaps() === 0
                 }>
                 <h3>{t("connected_wallet_no_swaps")}</h3>
@@ -799,6 +901,8 @@ export const RescueEvm = (props: { mode?: string }) => {
                     />
                 </Show>
 
+                <GasAbstractionSweepList balances={sweepableBalances} />
+
                 <Show when={scanFinished()}>
                     <button
                         class="btn btn-light"
@@ -873,7 +977,10 @@ const RescueExternal = () => {
         name: "Bitcoin / Liquid",
         values: [BTC, LBTC],
     };
-    const tabEvm = { name: "EVM", values: ["EVM", RBTC, TBTC, "RSK"] };
+    const tabEvm = {
+        name: "EVM",
+        values: ["EVM", RBTC, TBTC, USDT0, USDC, "RSK"],
+    };
     const validTypes = evmAvailable
         ? [...tabBtc.values, ...tabEvm.values]
         : [...tabBtc.values];

--- a/src/pages/RescueExternal.tsx
+++ b/src/pages/RescueExternal.tsx
@@ -63,6 +63,7 @@ import { rescueFileTypes } from "../utils/download";
 import { formatError } from "../utils/errors";
 import {
     type GasAbstractionSweep,
+    getGasAbstractionSweepDisplayAmount,
     getSweepableGasAbstractionBalances,
 } from "../utils/gasAbstractionSweep";
 import { cropString, isMobile } from "../utils/helper";
@@ -365,7 +366,9 @@ const GasAbstractionSweepItem = (props: { sweep: GasAbstractionSweep }) => {
 
     const amount = createMemo(() =>
         formatAmount(
-            new BigNumber(props.sweep.amount.toString()),
+            new BigNumber(
+                getGasAbstractionSweepDisplayAmount(props.sweep).toString(),
+            ),
             denomination(),
             separator(),
             props.sweep.asset,

--- a/src/utils/gasAbstractionSweep.ts
+++ b/src/utils/gasAbstractionSweep.ts
@@ -9,11 +9,13 @@ import {
     getTokenAddress,
 } from "../consts/Assets";
 import { createTokenContract } from "../context/Web3";
+import { getDecimals } from "./denomination";
 import {
     erc20TransferInterface,
     sendPopulatedTransaction,
 } from "./evmTransaction";
 import type { RescueFile } from "./rescueFile";
+import { assetAmountToSats } from "./rootstock";
 import { GasAbstractionType } from "./swapCreator";
 
 export const gasAbstractionSweepAssets = [TBTC, USDT0, USDC] as const;
@@ -24,6 +26,12 @@ export type GasAbstractionSweep = {
     destination: string;
     signer: Wallet;
 };
+
+export const getGasAbstractionSweepDisplayAmount = ({
+    asset,
+    amount,
+}: Pick<GasAbstractionSweep, "asset" | "amount">): bigint =>
+    getDecimals(asset).isErc20 ? amount : assetAmountToSats(amount, asset);
 
 type TokenContract = {
     balanceOf: (address: string) => Promise<bigint>;

--- a/src/utils/gasAbstractionSweep.ts
+++ b/src/utils/gasAbstractionSweep.ts
@@ -1,0 +1,99 @@
+import type { Wallet } from "ethers";
+import log from "loglevel";
+
+import {
+    type AssetType,
+    TBTC,
+    USDC,
+    USDT0,
+    getTokenAddress,
+} from "../consts/Assets";
+import { createTokenContract } from "../context/Web3";
+import {
+    erc20TransferInterface,
+    sendPopulatedTransaction,
+} from "./evmTransaction";
+import type { RescueFile } from "./rescueFile";
+import { GasAbstractionType } from "./swapCreator";
+
+export const gasAbstractionSweepAssets = [TBTC, USDT0, USDC] as const;
+
+export type GasAbstractionSweep = {
+    asset: AssetType;
+    amount: bigint;
+    destination: string;
+    signer: Wallet;
+};
+
+type TokenContract = {
+    balanceOf: (address: string) => Promise<bigint>;
+};
+
+export const getSweepableGasAbstractionBalances = async ({
+    assets = gasAbstractionSweepAssets,
+    destination,
+    rescueFile,
+    getGasAbstractionSigner,
+    createToken = createTokenContract,
+}: {
+    assets?: readonly AssetType[];
+    destination: string;
+    rescueFile: RescueFile;
+    getGasAbstractionSigner: (asset: string, rescueFile?: RescueFile) => Wallet;
+    createToken?: (asset: string, signer: Wallet) => TokenContract;
+}): Promise<GasAbstractionSweep[]> => {
+    const balances = await Promise.all(
+        assets.map(async (asset) => {
+            try {
+                const signer = getGasAbstractionSigner(asset, rescueFile);
+                const token = createToken(asset, signer);
+                const amount = await token.balanceOf(signer.address);
+
+                if (amount === 0n) {
+                    return undefined;
+                }
+
+                return {
+                    asset,
+                    amount,
+                    destination,
+                    signer,
+                };
+            } catch (error) {
+                log.warn(`failed to inspect gas abstraction balance`, {
+                    asset,
+                    error,
+                });
+                return undefined;
+            }
+        }),
+    );
+
+    return balances.filter(
+        (balance): balance is GasAbstractionSweep => balance !== undefined,
+    );
+};
+
+export const sweepGasAbstractionToken = async (
+    sweep: GasAbstractionSweep,
+    sendTransaction = sendPopulatedTransaction,
+): Promise<string> => {
+    const transactionHash = await sendTransaction(
+        GasAbstractionType.Signer,
+        sweep.signer,
+        {
+            to: getTokenAddress(sweep.asset),
+            data: erc20TransferInterface.encodeFunctionData("transfer", [
+                sweep.destination,
+                sweep.amount,
+            ]),
+        },
+    );
+
+    if (!sweep.signer.provider) {
+        throw new Error("Missing provider: cannot confirm transaction");
+    }
+
+    await sweep.signer.provider.waitForTransaction(transactionHash, 1);
+    return transactionHash;
+};

--- a/tests/components/AssetSelect.spec.tsx
+++ b/tests/components/AssetSelect.spec.tsx
@@ -4,7 +4,15 @@ import SelectAsset from "../../src/components/AssetSelect";
 import NetworkSelect from "../../src/components/NetworkSelect";
 import type * as ConfigModule from "../../src/config";
 import { config } from "../../src/config";
-import { BTC, LBTC, LN, RBTC, TBTC, USDT0 } from "../../src/consts/Assets";
+import {
+    BTC,
+    LBTC,
+    LN,
+    RBTC,
+    TBTC,
+    USDC,
+    USDT0,
+} from "../../src/consts/Assets";
 import { AssetSelection, Side } from "../../src/consts/Enums";
 import i18n from "../../src/i18n/i18n";
 import {
@@ -226,6 +234,7 @@ describe("AssetSelect", () => {
             `select-${RBTC}`,
             `select-${TBTC}`,
             `select-${USDT0}`,
+            `select-${USDC}`,
         ]);
     });
 

--- a/tests/pages/GasAbstractionSweepRescue.spec.tsx
+++ b/tests/pages/GasAbstractionSweepRescue.spec.tsx
@@ -1,0 +1,355 @@
+import type * as SolidRouter from "@solidjs/router";
+import { render, screen, waitFor } from "@solidjs/testing-library";
+import { userEvent } from "@testing-library/user-event";
+import type { Wallet } from "ethers";
+import type { Accessor } from "solid-js";
+import { createEffect, createSignal } from "solid-js";
+import { describe, expect, test, vi } from "vitest";
+
+import { TBTC, USDC, USDT0 } from "../../src/consts/Assets";
+import { RskRescueMode } from "../../src/consts/Enums";
+import type * as RescueContextModule from "../../src/context/Rescue";
+import type * as Web3Module from "../../src/context/Web3";
+import type * as GasAbstractionSweepModule from "../../src/utils/gasAbstractionSweep";
+import type { RescueFile } from "../../src/utils/rescueFile";
+import { contextWrapper } from "../helper";
+
+// `useParams` is mocked per-test by reassigning `paramsMock`. The mock factory
+// is hoisted, so this signal lives at module scope.
+const { paramsMock } = vi.hoisted(() => ({
+    paramsMock: {
+        current: {} as {
+            asset: string;
+            address: string;
+            action: RskRescueMode;
+        },
+    },
+}));
+
+vi.mock("@solidjs/router", async () => {
+    const actual = await vi.importActual<typeof SolidRouter>("@solidjs/router");
+    return {
+        ...actual,
+        useParams: () => paramsMock.current,
+    };
+});
+
+const [signer, setSigner] = createSignal<Wallet | undefined>(undefined);
+const [rescueFile, setRescueFile] = createSignal<RescueFile | undefined>(
+    undefined,
+);
+
+const getGasAbstractionSigner =
+    vi.fn<(asset: string, rescueFile?: RescueFile) => Wallet>();
+const balanceOf = vi.fn<(address: string) => Promise<bigint>>();
+const sweepGasAbstractionToken = vi.fn<() => Promise<string>>();
+
+vi.mock("../../src/context/Web3", async () => {
+    const actual = await vi.importActual<typeof Web3Module>(
+        "../../src/context/Web3",
+    );
+    return {
+        ...actual,
+        useWeb3Signer: () => ({
+            signer,
+            getGasAbstractionSigner,
+        }),
+        createTokenContract: () => ({ balanceOf }),
+    };
+});
+
+vi.mock("../../src/context/Rescue", async () => {
+    const actual = await vi.importActual<typeof RescueContextModule>(
+        "../../src/context/Rescue",
+    );
+    return {
+        ...actual,
+        useRescueContext: () => ({ rescueFile }),
+    };
+});
+
+vi.mock("../../src/utils/gasAbstractionSweep", async () => {
+    const actual = await vi.importActual<typeof GasAbstractionSweepModule>(
+        "../../src/utils/gasAbstractionSweep",
+    );
+    return {
+        ...actual,
+        sweepGasAbstractionToken,
+    };
+});
+
+const lastContractTxProps: { current: ContractTxProps | undefined } = {
+    current: undefined,
+};
+type ContractTxProps = {
+    asset: string;
+    signerOverride?: Accessor<Wallet>;
+    onClick: () => Promise<unknown>;
+    buttonText: string;
+    promptText?: string;
+};
+vi.mock("../../src/components/ContractTransaction", () => ({
+    default: (props: ContractTxProps) => {
+        createEffect(() => {
+            lastContractTxProps.current = {
+                asset: props.asset,
+                signerOverride: props.signerOverride,
+                onClick: props.onClick,
+                buttonText: props.buttonText,
+                promptText: props.promptText,
+            };
+        });
+        return (
+            <div data-testid="contract-transaction">
+                <p data-testid="prompt-text">{props.promptText}</p>
+                <button
+                    data-testid="contract-tx-button"
+                    onClick={() => void props.onClick()}>
+                    {props.buttonText}
+                </button>
+            </div>
+        );
+    },
+}));
+
+vi.mock("../../src/components/BlockExplorer", () => ({
+    default: (props: { txId: string }) => (
+        <a data-testid="block-explorer" href={`#${props.txId}`}>
+            {props.txId}
+        </a>
+    ),
+}));
+vi.mock("../../src/components/settings/SettingsCog", () => ({
+    default: () => null,
+}));
+vi.mock("../../src/components/settings/SettingsMenu", () => ({
+    default: () => null,
+}));
+
+const { default: GasAbstractionSweepRescue } =
+    await import("../../src/pages/GasAbstractionSweepRescue");
+const i18n = (await import("../../src/i18n/i18n")).default;
+
+const validAddress = "0x0000000000000000000000000000000000000001";
+const otherAddress = "0x0000000000000000000000000000000000000002";
+
+const makeWallet = (address: string) =>
+    ({
+        address,
+        getAddress: () => Promise.resolve(address),
+    }) as unknown as Wallet;
+
+const renderPage = () =>
+    render(() => <GasAbstractionSweepRescue />, { wrapper: contextWrapper });
+
+const resetState = () => {
+    setSigner(undefined);
+    setRescueFile(undefined);
+    paramsMock.current = {
+        asset: USDT0,
+        address: validAddress,
+        action: RskRescueMode.Refund,
+    };
+    getGasAbstractionSigner.mockReset();
+    balanceOf.mockReset();
+    sweepGasAbstractionToken.mockReset();
+    lastContractTxProps.current = undefined;
+};
+
+describe("GasAbstractionSweepRescue", () => {
+    test("shows the no-wallet fallback when the signer is undefined", async () => {
+        resetState();
+        setRescueFile({ mnemonic: "test" } as RescueFile);
+
+        renderPage();
+
+        expect(await screen.findByText(i18n.en.no_wallet)).toBeInTheDocument();
+    });
+
+    test("prompts to scan with the rescue file when none is loaded", async () => {
+        resetState();
+        setSigner(makeWallet(validAddress));
+
+        renderPage();
+
+        expect(
+            await screen.findByText(i18n.en.refund_scan_required),
+        ).toBeInTheDocument();
+    });
+
+    test("re-runs the resource when the signer arrives after mount", async () => {
+        resetState();
+        setRescueFile({ mnemonic: "test" } as RescueFile);
+        getGasAbstractionSigner.mockReturnValue(makeWallet(validAddress));
+        balanceOf.mockResolvedValue(0n);
+
+        renderPage();
+
+        // initial render: signer undefined → no_wallet fallback
+        expect(await screen.findByText(i18n.en.no_wallet)).toBeInTheDocument();
+        expect(getGasAbstractionSigner).not.toHaveBeenCalled();
+
+        setSigner(makeWallet(validAddress));
+
+        // resource fetches once the source signal becomes truthy
+        await waitFor(() =>
+            expect(getGasAbstractionSigner).toHaveBeenCalledWith(
+                USDT0,
+                expect.objectContaining({ mnemonic: "test" }),
+            ),
+        );
+        expect(
+            await screen.findByText(i18n.en.connected_wallet_no_swaps),
+        ).toBeInTheDocument();
+    });
+
+    test("errors when the URL asset is not sweepable", async () => {
+        resetState();
+        paramsMock.current.asset = "BTC";
+        setSigner(makeWallet(validAddress));
+        setRescueFile({ mnemonic: "test" } as RescueFile);
+
+        renderPage();
+
+        expect(
+            await screen.findByText(/unsupported asset: BTC/),
+        ).toBeInTheDocument();
+        expect(getGasAbstractionSigner).not.toHaveBeenCalled();
+    });
+
+    test("errors when the URL action is not refund", async () => {
+        resetState();
+        paramsMock.current.action = "claim" as RskRescueMode;
+        setSigner(makeWallet(validAddress));
+        setRescueFile({ mnemonic: "test" } as RescueFile);
+
+        renderPage();
+
+        expect(
+            await screen.findByText(/unsupported action: claim/),
+        ).toBeInTheDocument();
+        expect(getGasAbstractionSigner).not.toHaveBeenCalled();
+    });
+
+    test("errors when the rescue-derived address does not match the URL", async () => {
+        resetState();
+        getGasAbstractionSigner.mockReturnValue(makeWallet(otherAddress));
+        setSigner(makeWallet(validAddress));
+        setRescueFile({ mnemonic: "test" } as RescueFile);
+
+        renderPage();
+
+        expect(
+            await screen.findByText(i18n.en.invalid_rescue_key_evm),
+        ).toBeInTheDocument();
+        expect(balanceOf).not.toHaveBeenCalled();
+    });
+
+    test("renders the no-balance message when the rescue address is empty", async () => {
+        resetState();
+        getGasAbstractionSigner.mockReturnValue(makeWallet(validAddress));
+        balanceOf.mockResolvedValue(0n);
+        setSigner(makeWallet(validAddress));
+        setRescueFile({ mnemonic: "test" } as RescueFile);
+
+        renderPage();
+
+        expect(
+            await screen.findByText(i18n.en.connected_wallet_no_swaps),
+        ).toBeInTheDocument();
+        expect(screen.queryByTestId("contract-transaction")).toBeNull();
+    });
+
+    test.each([
+        {
+            asset: USDT0,
+            balance: 1_000_000n,
+            expectedAmountFragment: "1",
+        },
+        {
+            asset: USDC,
+            balance: 1_000_000n,
+            expectedAmountFragment: "1",
+        },
+        {
+            asset: TBTC,
+            balance: 1_000_000_000_000_000_000n,
+            expectedAmountFragment: "1",
+        },
+    ])(
+        "renders a refund prompt for the full balance ($asset)",
+        async ({ asset, balance, expectedAmountFragment }) => {
+            resetState();
+            paramsMock.current.asset = asset;
+            const gasSigner = makeWallet(validAddress);
+            getGasAbstractionSigner.mockReturnValue(gasSigner);
+            balanceOf.mockResolvedValue(balance);
+            setSigner(makeWallet(otherAddress));
+            setRescueFile({ mnemonic: "test" } as RescueFile);
+
+            renderPage();
+
+            const prompt = await screen.findByTestId("prompt-text");
+            // Prompt starts with the localized "Refund" verb and embeds the
+            // formatted balance.
+            expect(prompt.textContent).toMatch(
+                new RegExp(`^${i18n.en.refund} ${expectedAmountFragment}`),
+            );
+            expect(lastContractTxProps.current?.signerOverride?.()).toBe(
+                gasSigner,
+            );
+            expect(lastContractTxProps.current?.asset).toBe(asset);
+        },
+    );
+
+    test("clicking refund sweeps to the connected wallet and shows the explorer link", async () => {
+        resetState();
+        const user = userEvent.setup();
+        const gasSigner = makeWallet(validAddress);
+        const connectedWallet = makeWallet(otherAddress);
+        getGasAbstractionSigner.mockReturnValue(gasSigner);
+        balanceOf.mockResolvedValue(2_500_000n);
+        sweepGasAbstractionToken.mockResolvedValue("0xdeadbeef");
+        setSigner(connectedWallet);
+        setRescueFile({ mnemonic: "test" } as RescueFile);
+
+        renderPage();
+
+        const button = await screen.findByTestId("contract-tx-button");
+        await user.click(button);
+
+        await waitFor(() => {
+            expect(sweepGasAbstractionToken).toHaveBeenCalledWith({
+                asset: USDT0,
+                amount: 2_500_000n,
+                destination: otherAddress,
+                signer: gasSigner,
+            });
+        });
+
+        expect(await screen.findByText(i18n.en.refunded)).toBeInTheDocument();
+        expect(await screen.findByTestId("block-explorer")).toHaveTextContent(
+            "0xdeadbeef",
+        );
+    });
+
+    test("does not call sweepGasAbstractionToken when the asset becomes invalid mid-flight", async () => {
+        resetState();
+        getGasAbstractionSigner.mockReturnValue(makeWallet(validAddress));
+        balanceOf.mockResolvedValue(1n);
+        setSigner(makeWallet(otherAddress));
+        setRescueFile({ mnemonic: "test" } as RescueFile);
+
+        renderPage();
+        await screen.findByTestId("contract-transaction");
+
+        // Simulate a stale render where params.asset somehow becomes invalid
+        // before the user clicks (e.g. router params mutated). The guard in
+        // sweep() must prevent the call.
+        paramsMock.current.asset = "BTC";
+
+        await lastContractTxProps.current!.onClick();
+
+        expect(sweepGasAbstractionToken).not.toHaveBeenCalled();
+    });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -8,11 +8,12 @@ import { config as mainnetConfig } from "../src/configs/mainnet";
 log.setLevel("error");
 
 // Tests run against the regtest config, which intentionally omits TBTC and
-// USDT0 (they're mainnet-only assets). Inject them from the mainnet config so
+// USDT0 and USDC (they're mainnet-only assets). Inject them from the mainnet config so
 // tests that read their shape (token decimals, bridge metadata, etc.) work.
 if (runtimeConfig.assets && mainnetConfig.assets) {
     runtimeConfig.assets.TBTC ??= mainnetConfig.assets.TBTC;
     runtimeConfig.assets.USDT0 ??= mainnetConfig.assets.USDT0;
+    runtimeConfig.assets.USDC ??= mainnetConfig.assets.USDC;
 }
 
 // Replace jsdom's fetch with axios-based fetch to fix AbortController compatibility

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -7,9 +7,9 @@ import { config as mainnetConfig } from "../src/configs/mainnet";
 
 log.setLevel("error");
 
-// Tests run against the regtest config, which intentionally omits TBTC and
-// USDT0 and USDC (they're mainnet-only assets). Inject them from the mainnet config so
-// tests that read their shape (token decimals, bridge metadata, etc.) work.
+// Tests run against the regtest config, which intentionally omits TBTC,
+// USDT0, and USDC (they're mainnet-only assets). Inject them from the mainnet
+// config so tests that read their shape (token decimals, bridge metadata, etc.) work.
 if (runtimeConfig.assets && mainnetConfig.assets) {
     runtimeConfig.assets.TBTC ??= mainnetConfig.assets.TBTC;
     runtimeConfig.assets.USDT0 ??= mainnetConfig.assets.USDT0;

--- a/tests/utils/gasAbstractionSweep.spec.ts
+++ b/tests/utils/gasAbstractionSweep.spec.ts
@@ -2,16 +2,49 @@ import type { TransactionRequest, Wallet } from "ethers";
 import { describe, expect, test, vi } from "vitest";
 
 import { config } from "../../src/config";
-import { USDC, USDT0 } from "../../src/consts/Assets";
+import { type AssetType, TBTC, USDC, USDT0 } from "../../src/consts/Assets";
 import { erc20TransferInterface } from "../../src/utils/evmTransaction";
 import type { sendPopulatedTransaction } from "../../src/utils/evmTransaction";
 import {
+    getGasAbstractionSweepDisplayAmount,
     getSweepableGasAbstractionBalances,
     sweepGasAbstractionToken,
 } from "../../src/utils/gasAbstractionSweep";
 import { GasAbstractionType } from "../../src/utils/swapCreator";
 
 describe("gas abstraction sweep", () => {
+    test.each([
+        {
+            asset: TBTC,
+            amount: 1_000_000_000_000_000_000n,
+            expected: 100_000_000n,
+        },
+        {
+            asset: USDT0,
+            amount: 1_000_000n,
+            expected: 1_000_000n,
+        },
+        {
+            asset: USDC,
+            amount: 1_000_000n,
+            expected: 1_000_000n,
+        },
+    ] satisfies {
+        asset: AssetType;
+        amount: bigint;
+        expected: bigint;
+    }[])(
+        "normalizes $asset sweep balances for display",
+        ({ asset, amount, expected }) => {
+            expect(
+                getGasAbstractionSweepDisplayAmount({
+                    asset,
+                    amount,
+                }),
+            ).toBe(expected);
+        },
+    );
+
     test("returns only non-zero token balances", async () => {
         const signerByAsset = new Map<string, Wallet>();
         const getGasAbstractionSigner = vi.fn((asset: string) => {

--- a/tests/utils/gasAbstractionSweep.spec.ts
+++ b/tests/utils/gasAbstractionSweep.spec.ts
@@ -1,0 +1,116 @@
+import type { TransactionRequest, Wallet } from "ethers";
+import { describe, expect, test, vi } from "vitest";
+
+import { config } from "../../src/config";
+import { USDC, USDT0 } from "../../src/consts/Assets";
+import { erc20TransferInterface } from "../../src/utils/evmTransaction";
+import type { sendPopulatedTransaction } from "../../src/utils/evmTransaction";
+import {
+    getSweepableGasAbstractionBalances,
+    sweepGasAbstractionToken,
+} from "../../src/utils/gasAbstractionSweep";
+import { GasAbstractionType } from "../../src/utils/swapCreator";
+
+describe("gas abstraction sweep", () => {
+    test("returns only non-zero token balances", async () => {
+        const signerByAsset = new Map<string, Wallet>();
+        const getGasAbstractionSigner = vi.fn((asset: string) => {
+            const signer = {
+                address: `0x${asset.padEnd(40, "0")}`,
+            } as unknown as Wallet;
+            signerByAsset.set(asset, signer);
+            return signer;
+        });
+        const createToken = vi.fn((asset: string) => ({
+            balanceOf: vi.fn(() =>
+                Promise.resolve(asset === USDT0 ? 123n : 0n),
+            ),
+        }));
+
+        const balances = await getSweepableGasAbstractionBalances({
+            assets: [USDT0, USDC],
+            destination: "0xdestination",
+            rescueFile: { mnemonic: "test test test" },
+            getGasAbstractionSigner,
+            createToken,
+        });
+
+        expect(balances).toEqual([
+            {
+                asset: USDT0,
+                amount: 123n,
+                destination: "0xdestination",
+                signer: signerByAsset.get(USDT0),
+            },
+        ]);
+        expect(getGasAbstractionSigner).toHaveBeenCalledWith(USDT0, {
+            mnemonic: "test test test",
+        });
+        expect(createToken).toHaveBeenCalledWith(
+            USDT0,
+            signerByAsset.get(USDT0),
+        );
+    });
+
+    test("sends an ERC20 transfer from the gas abstraction signer", async () => {
+        const waitForTransaction = vi.fn();
+        const signer = {
+            address: "0xsigner",
+            provider: {
+                waitForTransaction,
+            },
+        } as unknown as Wallet;
+        const sendTransaction = vi.fn<typeof sendPopulatedTransaction>(() =>
+            Promise.resolve("0xtx"),
+        );
+
+        const txHash = await sweepGasAbstractionToken(
+            {
+                asset: USDT0,
+                amount: 456n,
+                destination: "0x000000000000000000000000000000000000dEaD",
+                signer,
+            },
+            sendTransaction,
+        );
+
+        const transaction = sendTransaction.mock
+            .calls[0][2] as TransactionRequest;
+        const expectedData = erc20TransferInterface.encodeFunctionData(
+            "transfer",
+            ["0x000000000000000000000000000000000000dEaD", 456n],
+        );
+
+        expect(txHash).toBe("0xtx");
+        expect(sendTransaction).toHaveBeenCalledWith(
+            GasAbstractionType.Signer,
+            signer,
+            expect.objectContaining({
+                to: config.assets.USDT0.token.address,
+            }),
+        );
+        expect(transaction.data).toBe(expectedData);
+        expect(waitForTransaction).toHaveBeenCalledWith("0xtx", 1);
+    });
+
+    test("throws when the transaction cannot be confirmed", async () => {
+        const signer = {
+            address: "0xsigner",
+        } as unknown as Wallet;
+        const sendTransaction = vi.fn<typeof sendPopulatedTransaction>(() =>
+            Promise.resolve("0xtx"),
+        );
+
+        await expect(
+            sweepGasAbstractionToken(
+                {
+                    asset: USDT0,
+                    amount: 456n,
+                    destination: "0x000000000000000000000000000000000000dEaD",
+                    signer,
+                },
+                sendTransaction,
+            ),
+        ).rejects.toThrow("Missing provider: cannot confirm transaction");
+    });
+});


### PR DESCRIPTION
Closes #1402 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gas-abstraction sweep refund flow added to EVM rescue UI with a dedicated rescue route/page for sweeping refundable tokens.
  * USDC added as a supported asset for rescue/refund alongside USDT0 and TBTC.
  * Scan UI now surfaces sweepable balances and shows a sweep list when balances are found.
  * New localized message prompting users to rescan with their uploaded rescue file.

* **Tests**
  * Added tests for sweep balance detection, display normalization, and sweep transaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->