### PR TITLE
fix: oft native balance check

### DIFF
--- a/src/components/SendToBridge.tsx
+++ b/src/components/SendToBridge.tsx
@@ -260,9 +260,11 @@ const SendToBridge = (props: {
             bridgeDriver().getSourceTokenBalance(bridgeRoute, walletAddress),
             bridgeDriver().getSourceNativeBalance(bridgeRoute, walletAddress),
         ]);
-        const requiredNativeBalance = bridgeDriver().getBufferedNativeFee(
-            msgFee[0],
-        );
+        const requiredNativeBalance =
+            await bridgeDriver().getTransportRequiredNativeBalance(
+                bridgeRoute,
+                msgFee,
+            );
         const hasEnoughTokenBalance = balance >= tokenAmount;
         const hasEnoughNativeBalanceForMsgFee =
             nativeBalance >= requiredNativeBalance;
@@ -291,7 +293,11 @@ const SendToBridge = (props: {
             bridgeDriver().getSourceTokenBalance(bridgeRoute, walletAddress),
             bridgeDriver().getSourceNativeBalance(bridgeRoute, walletAddress),
         ]);
-        const requiredNativeBalance = msgFee[0];
+        const requiredNativeBalance =
+            await bridgeDriver().getTransportRequiredNativeBalance(
+                bridgeRoute,
+                msgFee,
+            );
         const hasEnoughTokenBalance = balance >= props.amount;
         const hasEnoughNativeBalanceForMsgFee =
             nativeBalance >= requiredNativeBalance;

--- a/src/utils/bridge/CctpBridgeDriver.ts
+++ b/src/utils/bridge/CctpBridgeDriver.ts
@@ -395,10 +395,6 @@ export class CctpBridgeDriver extends BridgeDriver {
         );
     };
 
-    public getBufferedNativeFee = (nativeFee: bigint): bigint => {
-        return nativeFee;
-    };
-
     public getSourceTokenBalance = async (
         route: BridgeRoute,
         ownerAddress: string,

--- a/src/utils/bridge/OftBridgeDriver.ts
+++ b/src/utils/bridge/OftBridgeDriver.ts
@@ -31,6 +31,7 @@ import {
     getOftTransactionSender,
     getOftTransport,
     getQuotedOftContract,
+    getRequiredSolanaOftNativeBalance,
     getSolanaOftTokenBalance,
     getTronOftTokenBalance,
     isExecutorNativeAmountExceedsCapError,
@@ -254,8 +255,23 @@ export class OftBridgeDriver extends BridgeDriver {
         return getSolanaOftGuidFromLogs(args.logMessages);
     };
 
-    public getBufferedNativeFee = (nativeFee: bigint): bigint => {
-        return getBufferedOftNativeFee(nativeFee);
+    public getTransportRequiredNativeBalance = async (
+        route: BridgeRoute,
+        msgFee: BridgeMsgFee,
+    ): Promise<bigint> => {
+        const transport = this.getTransport(route.sourceAsset);
+
+        switch (transport) {
+            case NetworkTransport.Solana:
+                return await getRequiredSolanaOftNativeBalance(
+                    route.sourceAsset,
+                    msgFee[0],
+                );
+            case NetworkTransport.Tron:
+                return msgFee[0];
+            case NetworkTransport.Evm:
+                return getBufferedOftNativeFee(msgFee[0]);
+        }
     };
 
     public getSourceTokenBalance = async (

--- a/src/utils/bridge/driver.ts
+++ b/src/utils/bridge/driver.ts
@@ -210,7 +210,13 @@ export abstract class BridgeDriver {
         logMessages: string[];
     }) => string | undefined;
 
-    public abstract getBufferedNativeFee: (nativeFee: bigint) => bigint;
+    public getTransportRequiredNativeBalance = (
+        route: BridgeRoute,
+        msgFee: BridgeMsgFee,
+    ): Promise<bigint> => {
+        void route;
+        return Promise.resolve(msgFee[0]);
+    };
 
     public abstract getSourceTokenBalance: (
         route: BridgeRoute,

--- a/tests/utils/bridge/testDriver.ts
+++ b/tests/utils/bridge/testDriver.ts
@@ -46,7 +46,6 @@ export class TestBridgeDriver extends BridgeDriver {
         void args;
         return undefined;
     };
-    public getBufferedNativeFee = (nativeFee: bigint) => nativeFee;
     public getSourceTokenBalance = notImplemented("getSourceTokenBalance");
     public getSourceNativeBalance = notImplemented("getSourceNativeBalance");
     public getTransactionSender = notImplemented("getTransactionSender");

--- a/tests/utils/oft.spec.ts
+++ b/tests/utils/oft.spec.ts
@@ -36,6 +36,8 @@ const {
     clearOftDeployments,
 } = await import("../../src/utils/oft/oft");
 const { getOftContract } = await import("../../src/utils/oft/registry");
+const { OftBridgeDriver } =
+    await import("../../src/utils/bridge/OftBridgeDriver");
 const { getSolanaOftGuidFromLogs: getSolanaOftSentEventFromTransaction } =
     await import("../../src/utils/oft/solana");
 const { getSolanaRentExemptMinimumBalance, shouldCreateSolanaTokenAccount } =
@@ -274,6 +276,20 @@ describe("oft", () => {
             "USDT0-SOL",
             165,
         );
+    });
+
+    test("should expose the Solana OFT native balance requirement through the bridge driver", async () => {
+        vi.mocked(getSolanaRentExemptMinimumBalance).mockResolvedValue(
+            2_039_280n,
+        );
+
+        const driver = new OftBridgeDriver();
+        await expect(
+            driver.getTransportRequiredNativeBalance(getOftRoute("USDT0-SOL"), [
+                1_000_000n,
+                0n,
+            ]),
+        ).resolves.toBe(2_039_280n);
     });
 
     test("should resolve legacy mesh assets by configured endpoint id", async () => {


### PR DESCRIPTION
regression from driver refactor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated native balance validation logic for bridge transactions to use dynamic calculation per blockchain transport, replacing precomputed values. This affects validation checks before sending transactions on Solana and Tron networks.

* **Tests**
  * Added test coverage for OFT bridge driver native balance calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->