### PR TITLE
feat: retrieve missing OFT transfer txHash

### DIFF
--- a/packages/boltz-swaps/src/bridge/index.ts
+++ b/packages/boltz-swaps/src/bridge/index.ts
@@ -8,12 +8,27 @@ export {
 export { OftBridgeDriver } from "./OftBridgeDriver.ts";
 export { BridgeRegistry, bridgeRegistry } from "./registry.ts";
 export {
+    PendingBridgeSendRecoveryStatus,
+    recoverPendingBridgeSend,
+    recoverPendingEvmOftSend,
+    recoverPendingSolanaOftSend,
+    recoverPendingTronOftSend,
+} from "./pendingSend.ts";
+export { PendingBridgeSendKind } from "./types.ts";
+export {
     type LooseRouterCall,
     type RouterCall,
     toRouterCalls,
 } from "./router.ts";
 export { vFromSignature } from "./signature.ts";
 export type { BridgeDetails, SolanaDetails } from "../types.ts";
+export type {
+    PendingBridgeSend,
+    PendingBridgeSendRecoveryResult,
+    PendingEvmOftBridgeSend,
+    PendingSolanaOftBridgeSend,
+    PendingTronOftBridgeSend,
+} from "./pendingSend.ts";
 export type {
     BridgeContract,
     BridgeDirectSendRunner,

--- a/packages/boltz-swaps/src/bridge/pendingSend.ts
+++ b/packages/boltz-swaps/src/bridge/pendingSend.ts
@@ -63,11 +63,7 @@ export type PendingBridgeSendRecoveryResult =
 
 const oftSentEvent = getAbiItem({ abi: oftAbi, name: "OFTSent" });
 
-// Logs may take a few seconds to be indexed after a transaction is mined, so we
-// keep checking briefly even after the sender's nonce has advanced past the
-// latest confirmed nonce captured before the pending send.
-const minedNonceLogIndexGracePeriodMs = 60_000;
-const pendingEvmSendGracePeriodMs = 10 * 60_000;
+const evmSendRecoveryTimeoutMs = 120_000;
 
 const sameAddress = (left: string | null | undefined, right: string) =>
     left !== null &&
@@ -178,23 +174,8 @@ export const recoverPendingEvmOftSend = async (
         }),
     ]);
     const age = Date.now() - pendingSend.createdAt;
-    if (
-        latestNonce > pendingSend.fromNonce &&
-        age > minedNonceLogIndexGracePeriodMs
-    ) {
-        log.warn("Pending EVM OFT send failed to recover", {
-            sender: pendingSend.sender,
-            fromNonce: pendingSend.fromNonce,
-            latestNonce,
-        });
-        return { status: PendingBridgeSendRecoveryStatus.Failed };
-    }
-
-    if (
-        pendingNonce <= pendingSend.fromNonce &&
-        age > pendingEvmSendGracePeriodMs
-    ) {
-        log.warn("Pending EVM OFT send expired without nonce advancement", {
+    if (age > evmSendRecoveryTimeoutMs) {
+        log.warn("Pending EVM OFT send recovery timed out", {
             sender: pendingSend.sender,
             fromNonce: pendingSend.fromNonce,
             latestNonce,

--- a/packages/boltz-swaps/src/bridge/pendingSend.ts
+++ b/packages/boltz-swaps/src/bridge/pendingSend.ts
@@ -65,18 +65,13 @@ const oftSentEvent = getAbiItem({ abi: oftAbi, name: "OFTSent" });
 
 const evmSendRecoveryTimeoutMs = 120_000;
 
-const sameAddress = (left: string | null | undefined, right: string) =>
-    left !== null &&
-    left !== undefined &&
-    left.toLowerCase() === right.toLowerCase();
-
-const sameHex = (left: string | null | undefined, right: string) =>
+const sameEvmString = (left: string | null | undefined, right: string) =>
     left !== null &&
     left !== undefined &&
     left.toLowerCase() === right.toLowerCase();
 
 const isOftSentLog = (event: Log, oftContractAddress: string) => {
-    if (event.address.toLowerCase() !== oftContractAddress.toLowerCase()) {
+    if (!sameEvmString(event.address, oftContractAddress)) {
         return false;
     }
     try {
@@ -130,9 +125,9 @@ export const recoverPendingEvmOftSend = async (
         }
         if (
             transaction.nonce >= pendingSend.fromNonce &&
-            sameAddress(transaction.from, pendingSend.sender) &&
-            sameAddress(transaction.to, pendingSend.transactionTo) &&
-            sameHex(transaction.input, pendingSend.calldata) &&
+            sameEvmString(transaction.from, pendingSend.sender) &&
+            sameEvmString(transaction.to, pendingSend.transactionTo) &&
+            sameEvmString(transaction.input, pendingSend.calldata) &&
             receipt.logs.some((entry) =>
                 isOftSentLog(entry, pendingSend.oftContractAddress),
             )

--- a/packages/boltz-swaps/src/bridge/pendingSend.ts
+++ b/packages/boltz-swaps/src/bridge/pendingSend.ts
@@ -1,0 +1,325 @@
+import {
+    type Hex,
+    type Log,
+    type PublicClient,
+    decodeEventLog,
+    getAbiItem,
+    getAddress,
+} from "viem";
+
+import { getLogger } from "../logger.ts";
+import { oftAbi } from "../oft/evm.ts";
+import { getSolanaConnection } from "../solana/index.ts";
+import {
+    getTronTransaction,
+    getTronTransactionInfo,
+    isFailedTronTransaction,
+} from "../tron/index.ts";
+import { PendingBridgeSendKind } from "./types.ts";
+
+export type PendingEvmOftBridgeSend = {
+    kind: PendingBridgeSendKind.EvmOft;
+    createdAt: number;
+    sender: string;
+    fromNonce: number;
+    fromBlock: number;
+    oftContractAddress: string;
+    transactionTo: string;
+    calldata: string;
+};
+
+export type PendingSolanaOftBridgeSend = {
+    kind: PendingBridgeSendKind.SolanaOft;
+    sourceAsset: string;
+    lastValidBlockHeight: number;
+    signature: string;
+};
+
+export type PendingTronOftBridgeSend = {
+    kind: PendingBridgeSendKind.TronOft;
+    createdAt: number;
+    sourceAsset: string;
+    txHash: string;
+};
+
+export type PendingBridgeSend =
+    | PendingEvmOftBridgeSend
+    | PendingSolanaOftBridgeSend
+    | PendingTronOftBridgeSend;
+
+export enum PendingBridgeSendRecoveryStatus {
+    Recovered = "recovered",
+    Failed = "failed",
+    Pending = "pending",
+}
+
+export type PendingBridgeSendRecoveryResult =
+    | {
+          status: PendingBridgeSendRecoveryStatus.Recovered;
+          transactionHash: string;
+      }
+    | { status: PendingBridgeSendRecoveryStatus.Failed }
+    | { status: PendingBridgeSendRecoveryStatus.Pending };
+
+const oftSentEvent = getAbiItem({ abi: oftAbi, name: "OFTSent" });
+
+// Logs may take a few seconds to be indexed after a transaction is mined, so we
+// keep checking briefly even after the sender's nonce has advanced past the
+// latest confirmed nonce captured before the pending send.
+const minedNonceLogIndexGracePeriodMs = 60_000;
+const pendingEvmSendGracePeriodMs = 10 * 60_000;
+
+const sameAddress = (left: string | null | undefined, right: string) =>
+    left !== null &&
+    left !== undefined &&
+    left.toLowerCase() === right.toLowerCase();
+
+const sameHex = (left: string | null | undefined, right: string) =>
+    left !== null &&
+    left !== undefined &&
+    left.toLowerCase() === right.toLowerCase();
+
+const isOftSentLog = (event: Log, oftContractAddress: string) => {
+    if (event.address.toLowerCase() !== oftContractAddress.toLowerCase()) {
+        return false;
+    }
+    try {
+        decodeEventLog({
+            abi: oftAbi,
+            eventName: "OFTSent",
+            data: event.data as Hex,
+            topics: event.topics as [Hex, ...Hex[]],
+        });
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+export const recoverPendingEvmOftSend = async (
+    pendingSend: PendingEvmOftBridgeSend,
+    provider: PublicClient,
+): Promise<PendingBridgeSendRecoveryResult> => {
+    const log = getLogger();
+    const logs = await provider.getLogs({
+        address: getAddress(pendingSend.oftContractAddress),
+        fromBlock: BigInt(pendingSend.fromBlock),
+        toBlock: "latest",
+        event: oftSentEvent,
+        args: { fromAddress: getAddress(pendingSend.sender) },
+    });
+    log.info("Checking pending EVM OFT send", {
+        sender: pendingSend.sender,
+        fromNonce: pendingSend.fromNonce,
+        fromBlock: pendingSend.fromBlock,
+        logs: logs.length,
+    });
+
+    const matches = new Set<string>();
+    for (const event of logs) {
+        if (event.transactionHash === null) {
+            continue;
+        }
+        const transactionHash = event.transactionHash;
+        const [transaction, receipt] = await Promise.all([
+            provider.getTransaction({ hash: transactionHash }),
+            provider.getTransactionReceipt({ hash: transactionHash }),
+        ]);
+        if (
+            transaction === null ||
+            receipt === null ||
+            receipt.status !== "success"
+        ) {
+            continue;
+        }
+        if (
+            transaction.nonce >= pendingSend.fromNonce &&
+            sameAddress(transaction.from, pendingSend.sender) &&
+            sameAddress(transaction.to, pendingSend.transactionTo) &&
+            sameHex(transaction.input, pendingSend.calldata) &&
+            receipt.logs.some((entry) =>
+                isOftSentLog(entry, pendingSend.oftContractAddress),
+            )
+        ) {
+            matches.add(transactionHash);
+        }
+    }
+    const matchedTransactionHashes = [...matches];
+
+    if (matchedTransactionHashes.length === 1) {
+        log.info("Recovered pending EVM OFT send", {
+            sender: pendingSend.sender,
+            fromNonce: pendingSend.fromNonce,
+            transactionHash: matchedTransactionHashes[0],
+        });
+        return {
+            status: PendingBridgeSendRecoveryStatus.Recovered,
+            transactionHash: matchedTransactionHashes[0],
+        };
+    }
+
+    if (matchedTransactionHashes.length > 1) {
+        log.warn("Found multiple matching pending bridge sends", {
+            sender: pendingSend.sender,
+            fromNonce: pendingSend.fromNonce,
+            matches: matchedTransactionHashes,
+        });
+        return { status: PendingBridgeSendRecoveryStatus.Pending };
+    }
+
+    const [latestNonce, pendingNonce] = await Promise.all([
+        provider.getTransactionCount({
+            address: getAddress(pendingSend.sender),
+            blockTag: "latest",
+        }),
+        provider.getTransactionCount({
+            address: getAddress(pendingSend.sender),
+            blockTag: "pending",
+        }),
+    ]);
+    const age = Date.now() - pendingSend.createdAt;
+    if (
+        latestNonce > pendingSend.fromNonce &&
+        age > minedNonceLogIndexGracePeriodMs
+    ) {
+        log.warn("Pending EVM OFT send failed to recover", {
+            sender: pendingSend.sender,
+            fromNonce: pendingSend.fromNonce,
+            latestNonce,
+        });
+        return { status: PendingBridgeSendRecoveryStatus.Failed };
+    }
+
+    if (
+        pendingNonce <= pendingSend.fromNonce &&
+        age > pendingEvmSendGracePeriodMs
+    ) {
+        log.warn("Pending EVM OFT send expired without nonce advancement", {
+            sender: pendingSend.sender,
+            fromNonce: pendingSend.fromNonce,
+            latestNonce,
+            pendingNonce,
+        });
+        return { status: PendingBridgeSendRecoveryStatus.Failed };
+    }
+
+    return { status: PendingBridgeSendRecoveryStatus.Pending };
+};
+
+export const recoverPendingSolanaOftSend = async (
+    pendingSend: PendingSolanaOftBridgeSend,
+): Promise<PendingBridgeSendRecoveryResult> => {
+    const log = getLogger();
+    const connection = await getSolanaConnection(pendingSend.sourceAsset);
+    const status = (
+        await connection.getSignatureStatuses([pendingSend.signature], {
+            searchTransactionHistory: true,
+        })
+    ).value[0];
+    if (status !== null) {
+        if (status.err !== null) {
+            log.warn("Pending Solana OFT send failed on-chain", {
+                sourceAsset: pendingSend.sourceAsset,
+                signature: pendingSend.signature,
+                error: status.err,
+            });
+            return { status: PendingBridgeSendRecoveryStatus.Failed };
+        }
+
+        log.info("Recovered pending Solana OFT send", {
+            sourceAsset: pendingSend.sourceAsset,
+            signature: pendingSend.signature,
+        });
+        return {
+            status: PendingBridgeSendRecoveryStatus.Recovered,
+            transactionHash: pendingSend.signature,
+        };
+    }
+
+    const currentBlockHeight = await connection.getBlockHeight("confirmed");
+    if (currentBlockHeight > pendingSend.lastValidBlockHeight) {
+        log.warn("Pending Solana OFT send blockhash expired", {
+            sourceAsset: pendingSend.sourceAsset,
+            signature: pendingSend.signature,
+            currentBlockHeight,
+            lastValidBlockHeight: pendingSend.lastValidBlockHeight,
+        });
+        return { status: PendingBridgeSendRecoveryStatus.Failed };
+    }
+
+    return { status: PendingBridgeSendRecoveryStatus.Pending };
+};
+
+export const recoverPendingTronOftSend = async (
+    pendingSend: PendingTronOftBridgeSend,
+): Promise<PendingBridgeSendRecoveryResult> => {
+    const log = getLogger();
+    const [transaction, transactionInfo] = await Promise.all([
+        getTronTransaction(pendingSend.sourceAsset, pendingSend.txHash),
+        getTronTransactionInfo(pendingSend.sourceAsset, pendingSend.txHash),
+    ]);
+
+    if (transactionInfo !== undefined) {
+        if (
+            transactionInfo.result === "FAILED" ||
+            (transactionInfo.receipt !== undefined &&
+                isFailedTronTransaction(transactionInfo))
+        ) {
+            log.warn("Pending Tron OFT send failed on-chain", {
+                sourceAsset: pendingSend.sourceAsset,
+                txHash: pendingSend.txHash,
+            });
+            return { status: PendingBridgeSendRecoveryStatus.Failed };
+        }
+
+        log.info("Recovered pending Tron OFT send from transaction info", {
+            sourceAsset: pendingSend.sourceAsset,
+            txHash: pendingSend.txHash,
+        });
+        return {
+            status: PendingBridgeSendRecoveryStatus.Recovered,
+            transactionHash: pendingSend.txHash,
+        };
+    }
+
+    if (transaction !== undefined) {
+        log.info("Recovered pending Tron OFT send from transaction", {
+            sourceAsset: pendingSend.sourceAsset,
+            txHash: pendingSend.txHash,
+        });
+        return {
+            status: PendingBridgeSendRecoveryStatus.Recovered,
+            transactionHash: pendingSend.txHash,
+        };
+    }
+
+    return { status: PendingBridgeSendRecoveryStatus.Pending };
+};
+
+export const recoverPendingBridgeSend = async (
+    pendingSend: PendingBridgeSend,
+    provider?: PublicClient,
+): Promise<PendingBridgeSendRecoveryResult> => {
+    switch (pendingSend.kind) {
+        case PendingBridgeSendKind.EvmOft:
+            if (provider === undefined) {
+                throw new Error(
+                    "EVM pending bridge send recovery needs an RPC provider",
+                );
+            }
+            return await recoverPendingEvmOftSend(pendingSend, provider);
+
+        case PendingBridgeSendKind.SolanaOft:
+            return await recoverPendingSolanaOftSend(pendingSend);
+
+        case PendingBridgeSendKind.TronOft:
+            return await recoverPendingTronOftSend(pendingSend);
+
+        default: {
+            const exhaustiveCheck: never = pendingSend;
+            throw new Error(
+                `Unsupported pending bridge send: ${String(exhaustiveCheck)}`,
+            );
+        }
+    }
+};

--- a/packages/boltz-swaps/src/bridge/types.ts
+++ b/packages/boltz-swaps/src/bridge/types.ts
@@ -30,6 +30,12 @@ import type { BridgeRoute } from "./route.ts";
 export type { BridgeTransaction };
 export type { BridgeRoute };
 
+export enum PendingBridgeSendKind {
+    EvmOft = "evm-oft",
+    SolanaOft = "solana-oft",
+    TronOft = "tron-oft",
+}
+
 export type BridgeNativeDrop = {
     amount: bigint;
     receiver: string;

--- a/packages/boltz-swaps/src/oft/directSend.ts
+++ b/packages/boltz-swaps/src/oft/directSend.ts
@@ -234,9 +234,7 @@ export const sendOftDirect = async ({
 };
 
 // Builds the same transaction as `sendOftDirect`, but returns a request the
-// caller can sign and broadcast itself. The caller persists the populated call
-// so the resulting tx hash can be recovered if the page is closed before the
-// wallet returns.
+// caller can sign and broadcast itself.
 export const populateOftDirectSendTransaction = ({
     target,
     sendParam,

--- a/packages/boltz-swaps/src/oft/directSend.ts
+++ b/packages/boltz-swaps/src/oft/directSend.ts
@@ -1,8 +1,18 @@
-import { type PublicClient, getAddress, getContract, parseAbi } from "viem";
+import {
+    type PublicClient,
+    encodeFunctionData,
+    getAddress,
+    getContract,
+} from "viem";
 
 import { getBoltzSwapsConfig, requireTokenConfig } from "../config.ts";
 import type { Signer } from "../interfaces/signer.ts";
-import { createEvmOftContract, toViemSendParam } from "./evm.ts";
+import {
+    createEvmOftContract,
+    oftAbi,
+    tempoOftWrapperAbi,
+    toViemSendParam,
+} from "./evm.ts";
 import { getBufferedOftNativeFee } from "./oft.ts";
 import {
     type OftContract,
@@ -44,10 +54,6 @@ type TempoOftWrapperInstance = {
         maxNativeFee: bigint,
     ) => Promise<OftDirectSendTransaction>;
 };
-
-const tempoOftWrapperAbi = parseAbi([
-    "function sendOFT(address oft, address feeToken, (uint32 dstEid, bytes32 to, uint256 amountLD, uint256 minAmountLD, bytes extraOptions, bytes composeMsg, bytes oftCmd) sendParam, uint256 maxNativeFee) returns ((bytes32 guid, uint64 nonce, (uint256 nativeFee, uint256 lzTokenFee) fee), (uint256 amountSentLD, uint256 amountReceivedLD))",
-]);
 
 const tempoChainName = "tempo";
 const tempoWrapperContractName = "TempoOFTWrapper";
@@ -217,6 +223,65 @@ export const sendOftDirect = async ({
                 sendParam,
                 msgFee[0],
             );
+
+        default: {
+            const exhaustiveCheck: never = target;
+            throw new Error(
+                `Unhandled OFT direct send target: ${String(exhaustiveCheck)}`,
+            );
+        }
+    }
+};
+
+// Builds the same transaction as `sendOftDirect`, but returns a request the
+// caller can sign and broadcast itself. The caller persists the populated call
+// so the resulting tx hash can be recovered if the page is closed before the
+// wallet returns.
+export const populateOftDirectSendTransaction = ({
+    target,
+    sendParam,
+    msgFee,
+    refundAddress,
+}: {
+    target: OftDirectSendTarget;
+    sendParam: SendParam;
+    msgFee: MsgFee;
+    refundAddress: string;
+}) => {
+    switch (target.kind) {
+        case OftDirectSendTargetKind.Oft:
+            return {
+                to: getAddress(target.executionContract.address),
+                value: msgFee[0],
+                data: encodeFunctionData({
+                    abi: oftAbi,
+                    functionName: "send",
+                    args: [
+                        toViemSendParam(sendParam),
+                        {
+                            nativeFee: msgFee[0],
+                            lzTokenFee: msgFee[1],
+                        },
+                        getAddress(refundAddress),
+                    ],
+                }),
+            };
+
+        case OftDirectSendTargetKind.TempoWrapper:
+            return {
+                to: getAddress(target.executionContract.address),
+                value: 0n,
+                data: encodeFunctionData({
+                    abi: tempoOftWrapperAbi,
+                    functionName: "sendOFT",
+                    args: [
+                        getAddress(target.oftContract.address),
+                        getAddress(target.feeTokenAddress),
+                        toViemSendParam(sendParam),
+                        msgFee[0],
+                    ],
+                }),
+            };
 
         default: {
             const exhaustiveCheck: never = target;

--- a/packages/boltz-swaps/src/oft/evm.ts
+++ b/packages/boltz-swaps/src/oft/evm.ts
@@ -48,6 +48,10 @@ export const oftAbi = parseAbi([
     "event OFTReceived(bytes32 indexed guid, uint32 srcEid, address indexed toAddress, uint256 amountReceivedLD)",
 ]);
 
+export const tempoOftWrapperAbi = parseAbi([
+    "function sendOFT(address oft, address feeToken, (uint32 dstEid, bytes32 to, uint256 amountLD, uint256 minAmountLD, bytes extraOptions, bytes composeMsg, bytes oftCmd) sendParam, uint256 maxNativeFee) returns ((bytes32 guid, uint64 nonce, (uint256 nativeFee, uint256 lzTokenFee) fee), (uint256 amountSentLD, uint256 amountReceivedLD))",
+]);
+
 const requireHex = (value: string, field: string): Hex => {
     if (!isHex(value, { strict: true })) {
         throw new Error(`invalid ${field}`);

--- a/packages/boltz-swaps/src/oft/solana.ts
+++ b/packages/boltz-swaps/src/oft/solana.ts
@@ -1,17 +1,22 @@
 import type { Umi } from "@metaplex-foundation/umi";
 import type { WalletAdapter as UmiWalletAdapter } from "@metaplex-foundation/umi-signer-wallet-adapters";
 import type { Provider as SolanaWalletProvider } from "@reown/appkit-utils/solana";
-import { hex } from "@scure/base";
+import { base58, hex } from "@scure/base";
 import type {
     AccountMeta,
     AddressLookupTableAccount,
     Connection,
+    SendOptions,
+    Transaction,
     TransactionInstruction,
+    VersionedTransaction,
 } from "@solana/web3.js";
 
+import type { PendingSolanaOftBridgeSend } from "../bridge/pendingSend.ts";
+import { PendingBridgeSendKind } from "../bridge/types.ts";
 import { getCachedValue } from "../cache.ts";
 import { getBoltzSwapsConfig } from "../config.ts";
-import { formatError } from "../errors.ts";
+import { formatError, isWalletRejectionError } from "../errors.ts";
 import { prefix0x } from "../evm/prefix0x.ts";
 import { getLogger } from "../logger.ts";
 import {
@@ -30,7 +35,12 @@ import {
     NetworkTransport,
 } from "../types.ts";
 import { decodeBase64 } from "../util/base64.ts";
-import type { MsgFee, OftTransportClient, SendParam } from "./types.ts";
+import type {
+    MsgFee,
+    OftTransportClient,
+    PendingBridgeSendCallbacks,
+    SendParam,
+} from "./types.ts";
 
 type SolanaOftModules = Awaited<ReturnType<(typeof lazySolanaOft)["get"]>>;
 
@@ -511,6 +521,24 @@ const createTransaction = async (
     };
 };
 
+const getSignedTransactionSignature = (
+    signedTransaction: Transaction | VersionedTransaction,
+): string => {
+    const signature = signedTransaction.signatures[0];
+    const bytes =
+        signature instanceof Uint8Array ? signature : signature?.signature;
+    // Solana initialises signature slots to 64 zero bytes; a wallet that
+    // returns the transaction unsigned would leave them that way.
+    if (
+        bytes === undefined ||
+        bytes === null ||
+        bytes.every((byte) => byte === 0)
+    ) {
+        throw new Error("Solana wallet did not return a transaction signature");
+    }
+    return base58.encode(bytes);
+};
+
 const simulateTransactionReturn = async <T>(
     context: Context,
     instructions: TransactionInstruction[],
@@ -685,6 +713,7 @@ const sendLegacyMesh = async (
     context: Context,
     sendParam: SendParam,
     msgFee: MsgFee,
+    pendingSendCallbacks?: PendingBridgeSendCallbacks,
 ): Promise<BridgeTransaction> => {
     const { modules } = context;
     const signerAddress = context.walletAdapter?.publicKey?.toBase58();
@@ -735,16 +764,107 @@ const sendLegacyMesh = async (
         );
     }
 
-    try {
+    const sendOptions: SendOptions = {
+        skipPreflight: true,
+        preflightCommitment: "confirmed",
+    };
+    const sendWithWallet = async (): Promise<BridgeTransaction> => {
         const signature = await walletProvider.signAndSendTransaction(
             transaction,
-            {
-                skipPreflight: true,
-                preflightCommitment: "confirmed",
-            },
+            sendOptions,
         );
         return {
             hash: signature,
+            details: {
+                solana: {
+                    blockhash: latestBlockhash.blockhash,
+                },
+            },
+        };
+    };
+
+    const signTransaction =
+        walletProvider.signTransaction?.bind(walletProvider);
+    if (signTransaction === undefined) {
+        getLogger().warn("Falling back to wallet-managed Solana OFT send", {
+            sourceAsset: asset,
+            sender: signerAddress,
+            reason: "Connected Solana wallet does not support signing transactions without broadcasting",
+        });
+        return await sendWithWallet();
+    }
+
+    try {
+        let signature: string;
+        let serializedSignedTransaction: Uint8Array;
+        try {
+            const signedTransaction = await signTransaction(transaction);
+            signature = getSignedTransactionSignature(signedTransaction);
+            serializedSignedTransaction = signedTransaction.serialize();
+        } catch (error) {
+            if (isWalletRejectionError(error)) {
+                throw error;
+            }
+
+            getLogger().warn("Falling back to wallet-managed Solana OFT send", {
+                sourceAsset: asset,
+                sender: signerAddress,
+                reason: formatError(error),
+            });
+            return await sendWithWallet();
+        }
+
+        const pendingSend: PendingSolanaOftBridgeSend = {
+            kind: PendingBridgeSendKind.SolanaOft,
+            sourceAsset: asset,
+            lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+            signature,
+        };
+        getLogger().info("Signed pending Solana OFT send", {
+            sourceAsset: asset,
+            sender: signerAddress,
+            signature,
+        });
+
+        const rawTransaction = Buffer.from(serializedSignedTransaction);
+        const encodedTransaction = rawTransaction.toString("base64");
+
+        getLogger().info("Broadcasting pending Solana OFT send...", {
+            sourceAsset: asset,
+            sender: signerAddress,
+            encodedTransaction,
+        });
+        const broadcastSignature =
+            await context.connection.sendEncodedTransaction(
+                encodedTransaction,
+                sendOptions,
+            );
+        await pendingSendCallbacks?.persist(pendingSend);
+
+        // The RPC derives the signature from the bytes we sent so it should
+        // always match the one we computed locally; re-persist if it ever
+        // doesn't so recovery looks for the right one.
+        if (broadcastSignature !== signature) {
+            getLogger().warn(
+                "Solana RPC returned a different broadcast signature",
+                {
+                    expected: signature,
+                    broadcastSignature,
+                },
+            );
+            await pendingSendCallbacks?.persist({
+                ...pendingSend,
+                signature: broadcastSignature,
+            });
+        }
+        getLogger().info("Broadcast pending Solana OFT send", {
+            sourceAsset: asset,
+            sender: signerAddress,
+            signature: broadcastSignature,
+        });
+
+        return {
+            hash: broadcastSignature,
             details: {
                 solana: {
                     blockhash: latestBlockhash.blockhash,
@@ -819,12 +939,13 @@ export const createSolanaOftContract = (
             await quoteOft(await contextPromise, sendParam),
         quoteSend: async (sendParam, payInLzToken) =>
             await quoteSend(await contextPromise, sendParam, payInLzToken),
-        send: async (sendParam, msgFee) =>
+        send: async (sendParam, msgFee, _refundAddress, overrides) =>
             await sendLegacyMesh(
                 contextConfig.asset,
                 await contextPromise,
                 sendParam,
                 msgFee,
+                overrides?.pendingSendCallbacks,
             ),
     };
 };

--- a/packages/boltz-swaps/src/oft/tron.ts
+++ b/packages/boltz-swaps/src/oft/tron.ts
@@ -11,9 +11,12 @@ import {
     maxUint256,
 } from "viem";
 
+import type { PendingTronOftBridgeSend } from "../bridge/pendingSend.ts";
+import { PendingBridgeSendKind } from "../bridge/types.ts";
 import { getTokenAddress } from "../config.ts";
 import { prefix0x } from "../evm/prefix0x.ts";
 import { erc20Abi } from "../generated/evm-abis.ts";
+import { getLogger } from "../logger.ts";
 import {
     type TronSignedTransaction,
     type TronTransactionInfo,
@@ -31,7 +34,9 @@ import type {
     OftFeeDetail,
     OftLimit,
     OftReceipt,
+    OftSendOverrides,
     OftSentEvent,
+    PendingBridgeSendCallbacks,
     SendParam,
 } from "./types.ts";
 
@@ -111,6 +116,14 @@ const normalizeTronSignedTransaction = (
         return response.result;
     }
     return response;
+};
+
+const getTronTransactionHash = (transaction: TronSignedTransaction): string => {
+    const txId = transaction.txID;
+    if (typeof txId !== "string" || txId === "") {
+        throw new Error("Tron transaction does not include a transaction ID");
+    }
+    return txId;
 };
 
 const signTronTransaction = async (
@@ -356,10 +369,7 @@ const submitSignedTronTransaction = async (
     client: TronWebClient,
     signedTransaction: TronSignedTransaction,
 ): Promise<BridgeTransaction> => {
-    const transactionHash = signedTransaction.txID;
-    if (transactionHash === undefined || transactionHash === "") {
-        throw new Error("Tron wallet did not return a transaction ID");
-    }
+    const transactionHash = getTronTransactionHash(signedTransaction);
 
     const broadcast = await client.trx.sendRawTransaction(signedTransaction);
     if (broadcast.result !== true) {
@@ -554,6 +564,7 @@ const sendTronOft = async (params: {
     sendParam: SendParam;
     msgFee: MsgFee;
     refundAddress: string;
+    pendingSendCallbacks?: PendingBridgeSendCallbacks;
 }): Promise<BridgeTransaction> => {
     const { client, transaction } = await buildTronSmartContractTransaction({
         sourceAsset: params.sourceAsset,
@@ -572,14 +583,34 @@ const sendTronOft = async (params: {
         errorContext: "Tron OFT send transaction",
         callValue: params.msgFee[0],
     });
-
     const signedTransaction = await signTronTransaction(
         params.walletProvider as WalletConnectTronConnector,
         params.refundAddress,
         transaction,
     );
+    const transactionHash = getTronTransactionHash(signedTransaction);
 
-    return await submitSignedTronTransaction(client, signedTransaction);
+    const log = getLogger();
+    log.info("Broadcasting pending Tron OFT send...", {
+        sourceAsset: params.sourceAsset,
+        sender: params.refundAddress,
+        txHash: transactionHash,
+    });
+    const sentTransaction = await submitSignedTronTransaction(
+        client,
+        signedTransaction,
+    );
+
+    const txToPersist: PendingTronOftBridgeSend = {
+        kind: PendingBridgeSendKind.TronOft,
+        createdAt: Date.now(),
+        sourceAsset: params.sourceAsset,
+        txHash: sentTransaction.hash,
+    };
+    await params.pendingSendCallbacks?.persist(txToPersist);
+    log.info("Persisted pending Tron OFT send", txToPersist);
+
+    return sentTransaction;
 };
 
 export const createTronOftContract = (params: CreateTronOftContractParams) => ({
@@ -594,6 +625,7 @@ export const createTronOftContract = (params: CreateTronOftContractParams) => ({
         sendParam: SendParam,
         msgFee: MsgFee,
         refundAddress: string,
+        overrides?: OftSendOverrides,
     ): Promise<BridgeTransaction> => {
         if (params.walletProvider === undefined) {
             throw new Error(
@@ -608,6 +640,7 @@ export const createTronOftContract = (params: CreateTronOftContractParams) => ({
             sendParam,
             msgFee,
             refundAddress,
+            pendingSendCallbacks: overrides?.pendingSendCallbacks,
         });
     },
 });

--- a/packages/boltz-swaps/src/oft/types.ts
+++ b/packages/boltz-swaps/src/oft/types.ts
@@ -2,6 +2,7 @@ import type { Provider as SolanaWalletProvider } from "@reown/appkit-utils/solan
 import type { TronConnector } from "@reown/appkit-utils/tron";
 import type { Abi, PublicClient } from "viem";
 
+import type { PendingBridgeSend } from "../bridge/pendingSend.ts";
 import type { BridgeRoute } from "../bridge/route.ts";
 import type { Signer } from "../interfaces/signer.ts";
 import type { BridgeTransaction, NetworkTransport } from "../types.ts";
@@ -34,6 +35,15 @@ export type OftQuoteOptions = {
 export type OftLimit = [bigint, bigint];
 export type OftFeeDetail = [bigint, string];
 export type OftReceipt = [bigint, bigint];
+
+export type PendingBridgeSendCallbacks = {
+    persist: (pending: PendingBridgeSend) => Promise<void>;
+};
+
+export type OftSendOverrides = {
+    value?: bigint;
+    pendingSendCallbacks?: PendingBridgeSendCallbacks;
+};
 
 export type OftReceiveQuote = {
     amountIn: bigint;
@@ -79,9 +89,7 @@ export type OftTransportClient = {
         sendParam: SendParam,
         msgFee: MsgFee,
         refundAddress: string,
-        overrides?: {
-            value?: bigint;
-        },
+        overrides?: OftSendOverrides,
     ) => Promise<BridgeTransaction>;
     approvalRequired?: () => Promise<boolean>;
 };

--- a/packages/boltz-swaps/tests/oft/directSend.spec.ts
+++ b/packages/boltz-swaps/tests/oft/directSend.spec.ts
@@ -89,6 +89,8 @@ vi.mock("boltz-swaps/config", async (importActual) => ({
 vi.mock("../../src/oft/evm.ts", () => ({
     createEvmOftContract: (...args: unknown[]) =>
         mockCreateEvmOftContract(...args),
+    oftAbi: [],
+    tempoOftWrapperAbi: [],
     toViemSendParam: (sendParam: unknown[]) => sendParam,
 }));
 

--- a/packages/boltz-swaps/tests/oft/tron.spec.ts
+++ b/packages/boltz-swaps/tests/oft/tron.spec.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import type { TronConnector } from "@reown/appkit-utils/tron";
+import { PendingBridgeSendKind } from "boltz-swaps/bridge";
 import {
     createTronOftContract,
     getTronOftGuidFromTransactionInfo,
@@ -43,7 +44,11 @@ const createWalletProvider = (request = vi.fn()) =>
         provider: { request },
     }) as unknown as TronConnector;
 
-const createMockClient = () => {
+const createMockClient = (
+    sendRawTransaction = vi.fn().mockResolvedValue({
+        result: true,
+    }),
+) => {
     const triggerConstantContract = vi.fn();
     const triggerSmartContract = vi.fn().mockResolvedValue({
         result: {
@@ -52,9 +57,6 @@ const createMockClient = () => {
         transaction: {
             txID: "built-tron-tx",
         },
-    });
-    const sendRawTransaction = vi.fn().mockResolvedValue({
-        result: true,
     });
     const client = {
         transactionBuilder: {
@@ -112,13 +114,18 @@ describe("tron oft", () => {
         });
         const walletProvider = createWalletProvider(walletConnectRequest);
         const { client, sendRawTransaction } = createMockClient();
+        const persistPendingSend = vi.fn().mockResolvedValue(undefined);
         vi.mocked(tronChain.getTronWeb).mockResolvedValue(client);
 
         const transaction = await createTronOftContract({
             sourceAsset: "USDT0-TRON",
             contractAddress,
             walletProvider,
-        }).send([...sendParam], [...msgFee], refundAddress);
+        }).send([...sendParam], [...msgFee], refundAddress, {
+            pendingSendCallbacks: {
+                persist: persistPendingSend,
+            },
+        });
 
         expect(transaction.hash).toBe("wallet-connect-tx");
         expect(walletConnectRequest).toHaveBeenCalledWith(
@@ -139,6 +146,47 @@ describe("tron oft", () => {
             txID: "wallet-connect-tx",
             signature: ["0x01"],
         });
+        expect(persistPendingSend).toHaveBeenCalledWith({
+            kind: PendingBridgeSendKind.TronOft,
+            createdAt: expect.any(Number),
+            sourceAsset: "USDT0-TRON",
+            txHash: "wallet-connect-tx",
+        });
+        expect(sendRawTransaction.mock.invocationCallOrder[0]).toBeLessThan(
+            persistPendingSend.mock.invocationCallOrder[0],
+        );
+    });
+
+    test("should not persist pending Tron OFT sends before broadcast succeeds", async () => {
+        const walletConnectRequest = vi.fn().mockResolvedValue({
+            result: {
+                txID: "failed-broadcast-tron-tx",
+                signature: ["0x01"],
+            },
+        });
+        const walletProvider = createWalletProvider(walletConnectRequest);
+        const { client } = createMockClient(
+            vi.fn().mockResolvedValue({
+                result: false,
+                message: "broadcast failed",
+            }),
+        );
+        const persistPendingSend = vi.fn().mockResolvedValue(undefined);
+        vi.mocked(tronChain.getTronWeb).mockResolvedValue(client);
+
+        await expect(
+            createTronOftContract({
+                sourceAsset: "USDT0-TRON",
+                contractAddress,
+                walletProvider,
+            }).send([...sendParam], [...msgFee], refundAddress, {
+                pendingSendCallbacks: {
+                    persist: persistPendingSend,
+                },
+            }),
+        ).rejects.toThrow("broadcast failed");
+
+        expect(persistPendingSend).not.toHaveBeenCalled();
     });
 
     test("should decode hex Tron transaction failure messages", async () => {

--- a/src/components/BridgeSendRecovery.ts
+++ b/src/components/BridgeSendRecovery.ts
@@ -1,0 +1,171 @@
+import {
+    type BridgeTransaction,
+    type PendingBridgeSend,
+    PendingBridgeSendKind,
+    PendingBridgeSendRecoveryStatus,
+    bridgeRegistry,
+    recoverPendingBridgeSend,
+} from "boltz-swaps/bridge";
+import log from "loglevel";
+import { type Accessor, createEffect, createMemo, onCleanup } from "solid-js";
+
+import { useGlobalContext } from "../context/Global";
+import { usePayContext } from "../context/Pay";
+import type {
+    BridgeDetail,
+    PendingBridgeSendCallbacks,
+} from "../utils/swapCreator";
+
+const getPendingSendTransaction = (pending: PendingBridgeSend) => {
+    switch (pending.kind) {
+        case PendingBridgeSendKind.EvmOft:
+            return pending.fromNonce;
+        case PendingBridgeSendKind.SolanaOft:
+            return pending.signature;
+        case PendingBridgeSendKind.TronOft:
+            return pending.txHash;
+        default: {
+            const exhaustiveCheck: never = pending;
+            throw new Error(
+                `Unsupported pending bridge send: ${String(exhaustiveCheck)}`,
+            );
+        }
+    }
+};
+
+export const useBridgeSendRecovery = (params: {
+    swapId: Accessor<string>;
+    bridge: Accessor<BridgeDetail>;
+    txSent: Accessor<string | undefined>;
+}) => {
+    const { setSwap, swap } = usePayContext();
+    const { getSwap, setSwapStorage } = useGlobalContext();
+
+    const pendingSend = createMemo(() => swap()?.bridge?.pendingSend);
+
+    const updateBridge = async (
+        update: (bridge: BridgeDetail) => BridgeDetail,
+    ) => {
+        const currentSwap = await getSwap(params.swapId());
+        if (currentSwap === null || currentSwap.bridge === undefined) {
+            return;
+        }
+        currentSwap.bridge = update(currentSwap.bridge);
+        setSwap(currentSwap);
+        await setSwapStorage(currentSwap);
+    };
+
+    const persistBridgeSend = async (
+        txHash: string,
+        details?: BridgeTransaction["details"],
+    ) => {
+        await updateBridge((bridge) => {
+            const next: BridgeDetail = {
+                ...bridge,
+                txHash,
+                pendingSend: undefined,
+            };
+            if (details === undefined) {
+                delete next.details;
+            } else {
+                next.details = details;
+            }
+            return next;
+        });
+        log.info("Persisted bridge send tx hash for background worker", {
+            swapId: params.swapId(),
+            sourceAsset: params.bridge().sourceAsset,
+            destinationAsset: params.bridge().destinationAsset,
+            txHash,
+        });
+    };
+
+    const setPendingSend = async (pending: PendingBridgeSend | undefined) => {
+        await updateBridge((bridge) => ({ ...bridge, pendingSend: pending }));
+        if (pending !== undefined) {
+            log.info("Persisted pending bridge send for recovery", {
+                swapId: params.swapId(),
+                sourceAsset: params.bridge().sourceAsset,
+                destinationAsset: params.bridge().destinationAsset,
+                kind: pending.kind,
+                transaction: getPendingSendTransaction(pending),
+            });
+        }
+    };
+
+    const pendingSendCallbacks: PendingBridgeSendCallbacks = {
+        persist: (pending) => setPendingSend(pending),
+    };
+
+    let recovering = false;
+    const recover = async (pending: PendingBridgeSend) => {
+        if (recovering) {
+            return;
+        }
+        recovering = true;
+        const bridge = params.bridge();
+        try {
+            const result = await recoverPendingBridgeSend(
+                pending,
+                pending.kind === PendingBridgeSendKind.EvmOft
+                    ? bridgeRegistry
+                          .requireDriverForRoute(bridge)
+                          .getProvider(bridge.sourceAsset)
+                    : undefined,
+            );
+            switch (result.status) {
+                case PendingBridgeSendRecoveryStatus.Recovered:
+                    log.info("Recovered pending bridge send", {
+                        swapId: params.swapId(),
+                        kind: pending.kind,
+                        txHash: result.transactionHash,
+                    });
+                    await persistBridgeSend(result.transactionHash);
+                    return;
+
+                case PendingBridgeSendRecoveryStatus.Failed:
+                    log.warn("Pending bridge send recovery failed", {
+                        swapId: params.swapId(),
+                        kind: pending.kind,
+                    });
+                    await setPendingSend(undefined);
+                    return;
+
+                case PendingBridgeSendRecoveryStatus.Pending:
+                    return;
+
+                default: {
+                    const exhaustive: never = result;
+                    throw new Error(
+                        `Unsupported bridge recovery status: ${String(exhaustive)}`,
+                    );
+                }
+            }
+        } catch (error) {
+            log.warn("Failed to recover pending bridge send", {
+                swapId: params.swapId(),
+                error,
+            });
+        } finally {
+            recovering = false;
+        }
+    };
+
+    createEffect(() => {
+        const pending = pendingSend();
+        if (pending === undefined || params.txSent() !== undefined) {
+            return;
+        }
+
+        void recover(pending);
+        const interval = window.setInterval(() => void recover(pending), 5_000);
+        onCleanup(() => window.clearInterval(interval));
+    });
+
+    return {
+        pendingSend,
+        pendingSendCallbacks,
+        persistBridgeSend,
+        setPendingSend,
+    };
+};

--- a/src/components/BridgeSendRecovery.ts
+++ b/src/components/BridgeSendRecovery.ts
@@ -3,11 +3,18 @@ import {
     type PendingBridgeSend,
     PendingBridgeSendKind,
     PendingBridgeSendRecoveryStatus,
+    type PendingEvmOftBridgeSend,
     bridgeRegistry,
     recoverPendingBridgeSend,
 } from "boltz-swaps/bridge";
 import log from "loglevel";
-import { type Accessor, createEffect, createMemo, onCleanup } from "solid-js";
+import {
+    type Accessor,
+    createEffect,
+    createMemo,
+    createSignal,
+    onCleanup,
+} from "solid-js";
 
 import { useGlobalContext } from "../context/Global";
 import { usePayContext } from "../context/Pay";
@@ -37,11 +44,27 @@ export const useBridgeSendRecovery = (params: {
     swapId: Accessor<string>;
     bridge: Accessor<BridgeDetail>;
     txSent: Accessor<string | undefined>;
+    evmSendActive?: Accessor<boolean>;
 }) => {
     const { setSwap, swap } = usePayContext();
     const { getSwap, setSwapStorage } = useGlobalContext();
 
-    const pendingSend = createMemo(() => swap()?.bridge?.pendingSend);
+    const storedPendingSend = createMemo(() => swap()?.bridge?.pendingSend);
+    const pendingSend = createMemo(() => {
+        const pending = storedPendingSend();
+        return pending?.kind === PendingBridgeSendKind.EvmOft
+            ? undefined
+            : pending;
+    });
+    const evmSendCandidate = createMemo(
+        () =>
+            swap()?.bridge?.evmSendCandidate ??
+            (storedPendingSend()?.kind === PendingBridgeSendKind.EvmOft
+                ? (storedPendingSend() as PendingEvmOftBridgeSend)
+                : undefined),
+    );
+    const [evmSendCandidateRecoveryFailed, setEvmSendCandidateRecoveryFailed] =
+        createSignal(false);
 
     const updateBridge = async (
         update: (bridge: BridgeDetail) => BridgeDetail,
@@ -64,6 +87,7 @@ export const useBridgeSendRecovery = (params: {
                 ...bridge,
                 txHash,
                 pendingSend: undefined,
+                evmSendCandidate: undefined,
             };
             if (details === undefined) {
                 delete next.details;
@@ -89,6 +113,38 @@ export const useBridgeSendRecovery = (params: {
                 destinationAsset: params.bridge().destinationAsset,
                 kind: pending.kind,
                 transaction: getPendingSendTransaction(pending),
+            });
+        }
+    };
+
+    const setEvmSendCandidate = async (
+        candidate: PendingEvmOftBridgeSend | undefined,
+    ) => {
+        await updateBridge((bridge) => {
+            const next: BridgeDetail = {
+                ...bridge,
+                pendingSend:
+                    bridge.pendingSend?.kind === PendingBridgeSendKind.EvmOft
+                        ? undefined
+                        : bridge.pendingSend,
+                evmSendCandidate: candidate,
+            };
+            if (next.pendingSend === undefined) {
+                delete next.pendingSend;
+            }
+            if (candidate === undefined) {
+                delete next.evmSendCandidate;
+            }
+            return next;
+        });
+
+        setEvmSendCandidateRecoveryFailed(false);
+        if (candidate !== undefined) {
+            log.info("Persisted EVM bridge send candidate for recovery", {
+                swapId: params.swapId(),
+                sourceAsset: params.bridge().sourceAsset,
+                destinationAsset: params.bridge().destinationAsset,
+                fromNonce: candidate.fromNonce,
             });
         }
     };
@@ -151,6 +207,77 @@ export const useBridgeSendRecovery = (params: {
         }
     };
 
+    let recoveringEvmCandidate = false;
+    const recoverEvmSendCandidate = async (
+        candidate: PendingEvmOftBridgeSend | undefined,
+    ) => {
+        if (
+            candidate === undefined ||
+            recoveringEvmCandidate ||
+            params.txSent() !== undefined
+        ) {
+            return;
+        }
+
+        recoveringEvmCandidate = true;
+        const bridge = params.bridge();
+        try {
+            const result = await recoverPendingBridgeSend(
+                candidate,
+                bridgeRegistry
+                    .requireDriverForRoute(bridge)
+                    .getProvider(bridge.sourceAsset),
+            );
+            switch (result.status) {
+                case PendingBridgeSendRecoveryStatus.Recovered:
+                    log.info("Recovered EVM bridge send candidate", {
+                        swapId: params.swapId(),
+                        txHash: result.transactionHash,
+                    });
+                    await persistBridgeSend(result.transactionHash);
+                    return;
+
+                case PendingBridgeSendRecoveryStatus.Failed:
+                    log.warn("EVM bridge send candidate recovery failed", {
+                        swapId: params.swapId(),
+                    });
+                    setEvmSendCandidateRecoveryFailed(true);
+                    return;
+
+                case PendingBridgeSendRecoveryStatus.Pending:
+                    setEvmSendCandidateRecoveryFailed(false);
+                    return;
+
+                default: {
+                    const exhaustive: never = result;
+                    throw new Error(
+                        `Unsupported bridge recovery status: ${String(exhaustive)}`,
+                    );
+                }
+            }
+        } catch (error) {
+            setEvmSendCandidateRecoveryFailed(true);
+            log.warn("Failed to recover EVM bridge send candidate", {
+                swapId: params.swapId(),
+                error,
+            });
+        } finally {
+            recoveringEvmCandidate = false;
+        }
+    };
+
+    const retryEvmSendCandidateRecovery = async () => {
+        const candidate = evmSendCandidate();
+        if (candidate === undefined) {
+            return;
+        }
+
+        await setEvmSendCandidate({
+            ...candidate,
+            createdAt: Date.now(),
+        });
+    };
+
     createEffect(() => {
         const pending = pendingSend();
         if (pending === undefined || params.txSent() !== undefined) {
@@ -162,10 +289,36 @@ export const useBridgeSendRecovery = (params: {
         onCleanup(() => window.clearInterval(interval));
     });
 
+    createEffect(() => {
+        if (params.evmSendActive?.() === true) {
+            return;
+        }
+
+        const candidate = evmSendCandidate();
+        if (
+            candidate === undefined ||
+            params.txSent() !== undefined ||
+            evmSendCandidateRecoveryFailed()
+        ) {
+            return;
+        }
+
+        void recoverEvmSendCandidate(candidate);
+        const interval = window.setInterval(
+            () => void recoverEvmSendCandidate(candidate),
+            5_000,
+        );
+        onCleanup(() => window.clearInterval(interval));
+    });
+
     return {
         pendingSend,
         pendingSendCallbacks,
+        evmSendCandidate,
+        evmSendCandidateRecoveryFailed,
         persistBridgeSend,
+        recoverEvmSendCandidate: retryEvmSendCandidateRecovery,
+        setEvmSendCandidate,
         setPendingSend,
     };
 };

--- a/src/components/SendToBridge.tsx
+++ b/src/components/SendToBridge.tsx
@@ -7,7 +7,6 @@ import {
     type PendingEvmOftBridgeSend,
     bridgeRegistry,
 } from "boltz-swaps/bridge";
-import { isWalletRejectionError } from "boltz-swaps/errors";
 import { createTokenContract } from "boltz-swaps/evm/contracts";
 import type { PopulatedEvmTransaction } from "boltz-swaps/evm/transaction";
 import {
@@ -30,6 +29,7 @@ import {
     createMemo,
     createResource,
     createSignal,
+    onCleanup,
 } from "solid-js";
 import { sendPopulatedTransaction } from "src/utils/evmTransaction";
 import { type Address, getAddress } from "viem";
@@ -51,7 +51,72 @@ import InsufficientBalance from "./InsufficientBalance";
 import LoadingSpinner from "./LoadingSpinner";
 import WaitForBridge from "./WaitForBridge";
 
-const evmPendingSendBlockLookback = 5n;
+const evmSendCandidateBlockLookback = 5n;
+const evmSendCandidateRecoveryTimeoutMs = 120_000;
+
+const EvmSendCandidateRecovery = (props: {
+    failed: boolean;
+    createdAt: number;
+    onCheckAgain: () => Promise<void>;
+    onReset: () => Promise<void>;
+}) => {
+    const { t } = useGlobalContext();
+    const [now, setNow] = createSignal(Date.now());
+
+    const interval = window.setInterval(() => setNow(Date.now()), 1_000);
+    onCleanup(() => window.clearInterval(interval));
+
+    const remainingSeconds = createMemo(() =>
+        Math.max(
+            Math.ceil(
+                (props.createdAt + evmSendCandidateRecoveryTimeoutMs - now()) /
+                    1_000,
+            ),
+            0,
+        ),
+    );
+
+    const reset = () => {
+        if (window.confirm(t("did_not_send_transaction_confirm"))) {
+            void props.onReset();
+        }
+    };
+
+    return (
+        <>
+            <h2>
+                {t(
+                    props.failed
+                        ? "could_not_confirm_previous_transaction"
+                        : "checking_previous_transaction",
+                )}
+            </h2>
+            <h3>
+                {t(
+                    props.failed
+                        ? "could_not_confirm_previous_transaction_line"
+                        : "checking_previous_transaction_line",
+                )}
+            </h3>
+            <Show when={!props.failed}>
+                <p>
+                    {t("checking_previous_transaction_countdown", {
+                        seconds: remainingSeconds(),
+                    })}
+                </p>
+                <LoadingSpinner />
+            </Show>
+            <Show when={props.failed}>
+                <button class="btn" onClick={() => void props.onCheckAgain()}>
+                    {t("check_again")}
+                </button>
+            </Show>
+            <button class="btn btn-light" onClick={reset}>
+                {t("did_not_send_transaction")}
+            </button>
+        </>
+    );
+};
 
 const SendToBridge = (props: {
     bridge: BridgeDetail;
@@ -88,20 +153,25 @@ const SendToBridge = (props: {
     const [approvalTarget, setApprovalTarget] = createSignal<
         string | undefined
     >(undefined);
+    const [bridgeSendActive, setBridgeSendActive] = createSignal(false);
     const txSent = createMemo<string | undefined>(() => swap()?.bridge?.txHash);
     const {
+        evmSendCandidate,
+        evmSendCandidateRecoveryFailed,
         pendingSend,
         pendingSendCallbacks,
         persistBridgeSend,
-        setPendingSend,
+        recoverEvmSendCandidate,
+        setEvmSendCandidate,
     } = useBridgeSendRecovery({
         swapId: () => props.swapId,
         bridge: () => props.bridge,
         txSent,
+        evmSendActive: bridgeSendActive,
     });
 
-    // OFT transport sends (Solana/Tron) need callbacks to persist a pending
-    // send before broadcast. Other bridges (CCTP) go through the driver as-is.
+    // OFT transport sends (Solana/Tron) use callbacks to persist post-broadcast
+    // recovery state. Other bridges (CCTP) go through the driver as-is.
     const sendTransport = async (args: {
         contract: BridgeTransportClient;
         sendParam: BridgeSendParam;
@@ -631,9 +701,12 @@ const SendToBridge = (props: {
         });
 
         if (props.bridge.kind === BridgeKind.Oft) {
-            let txRequest: PopulatedEvmTransaction;
+            let prepared: {
+                candidate: PendingEvmOftBridgeSend;
+                txRequest: PopulatedEvmTransaction;
+            };
             try {
-                txRequest = await prepareOftFromEvm({
+                prepared = await prepareOftFromEvm({
                     signer: connectedSigner,
                     signerAddress,
                     directSendTarget: directSendTarget as OftDirectSendTarget,
@@ -655,17 +728,16 @@ const SendToBridge = (props: {
                 });
             }
 
+            await setEvmSendCandidate(prepared.candidate);
             try {
                 const hash = await sendPopulatedTransaction(
                     GasAbstractionType.None,
                     connectedSigner,
-                    txRequest,
+                    prepared.txRequest,
                 );
                 return { hash };
             } catch (error) {
-                if (isWalletRejectionError(error)) {
-                    await setPendingSend(undefined);
-                }
+                await setEvmSendCandidate(undefined);
                 throw error;
             }
         }
@@ -679,17 +751,16 @@ const SendToBridge = (props: {
         });
     };
 
-    // Capture the latest confirmed sender nonce as a lower bound and persist the
-    // populated call before broadcast. If the page is closed before the wallet
-    // returns we can find the resulting transaction by replaying OFTSent logs and
-    // matching on the sender and calldata.
     const prepareOftFromEvm = async (args: {
         signer: Signer;
         signerAddress: Address;
         directSendTarget: OftDirectSendTarget;
         sendParam: SendParam;
         msgFee: BridgeMsgFee;
-    }): Promise<PopulatedEvmTransaction> => {
+    }): Promise<{
+        candidate: PendingEvmOftBridgeSend;
+        txRequest: PopulatedEvmTransaction;
+    }> => {
         const txRequest: PopulatedEvmTransaction =
             populateOftDirectSendTransaction({
                 target: args.directSendTarget,
@@ -706,30 +777,26 @@ const SendToBridge = (props: {
                 address: args.signerAddress,
                 blockTag: "latest",
             }),
-            bridgeDriver()
-                .getProvider(props.bridge.sourceAsset)
-                .getBlockNumber(),
+            args.signer.provider.getBlockNumber(),
         ]);
 
-        const pending: PendingEvmOftBridgeSend = {
-            kind: PendingBridgeSendKind.EvmOft,
-            createdAt: Date.now(),
-            sender: args.signerAddress,
-            fromNonce,
-            // Reorgs can move the transaction back a few blocks; start a bit
-            // earlier so log replay still finds it.
-            fromBlock: Number(
-                latestBlock > evmPendingSendBlockLookback
-                    ? latestBlock - evmPendingSendBlockLookback
-                    : 0n,
-            ),
-            oftContractAddress: args.directSendTarget.oftContract.address,
-            transactionTo: txRequest.to,
-            calldata: txRequest.data,
+        return {
+            candidate: {
+                kind: PendingBridgeSendKind.EvmOft,
+                createdAt: Date.now(),
+                sender: args.signerAddress,
+                fromNonce,
+                fromBlock: Number(
+                    latestBlock > evmSendCandidateBlockLookback
+                        ? latestBlock - evmSendCandidateBlockLookback
+                        : 0n,
+                ),
+                oftContractAddress: args.directSendTarget.oftContract.address,
+                transactionTo: txRequest.to,
+                calldata: txRequest.data,
+            },
+            txRequest,
         };
-        await setPendingSend(pending);
-
-        return txRequest;
     };
 
     const sendBridge = async () => {
@@ -765,94 +832,116 @@ const SendToBridge = (props: {
                 />
             }>
             <Show
-                when={pendingSend() === undefined}
-                fallback={<WaitForBridge bridge={props.bridge} />}>
+                when={evmSendCandidate() === undefined || bridgeSendActive()}
+                fallback={
+                    <EvmSendCandidateRecovery
+                        createdAt={evmSendCandidate()!.createdAt}
+                        failed={evmSendCandidateRecoveryFailed()}
+                        onCheckAgain={recoverEvmSendCandidate}
+                        onReset={() => setEvmSendCandidate(undefined)}
+                    />
+                }>
                 <Show
-                    when={
-                        signerBalance() !== undefined &&
-                        hasEnoughMsgFee() !== undefined
-                    }
-                    fallback={
-                        <Show
-                            when={sourceWalletReady()}
-                            fallback={
-                                <ConnectWallet
-                                    asset={props.bridge.sourceAsset}
-                                />
-                            }>
-                            <LoadingSpinner />
-                        </Show>
-                    }>
+                    when={pendingSend() === undefined}
+                    fallback={<WaitForBridge bridge={props.bridge} />}>
                     <Show
                         when={
-                            signerBalance()! >=
-                            (requiredTokenBalance() ?? props.amount)
+                            signerBalance() !== undefined &&
+                            hasEnoughMsgFee() !== undefined
                         }
                         fallback={
-                            <InsufficientBalance
-                                asset={props.bridge.sourceAsset}
-                            />
+                            <Show
+                                when={sourceWalletReady()}
+                                fallback={
+                                    <ConnectWallet
+                                        asset={props.bridge.sourceAsset}
+                                    />
+                                }>
+                                <LoadingSpinner />
+                            </Show>
                         }>
                         <Show
-                            when={hasEnoughMsgFee()}
+                            when={
+                                signerBalance()! >=
+                                (requiredTokenBalance() ?? props.amount)
+                            }
                             fallback={
                                 <InsufficientBalance
                                     asset={props.bridge.sourceAsset}
-                                    line={t(
-                                        "insufficient_gas_balance_line" as DictKey,
-                                        {
-                                            gasToken: sourceGasToken(),
-                                        },
-                                    )}
                                 />
                             }>
                             <Show
-                                when={!needsApproval()}
+                                when={hasEnoughMsgFee()}
                                 fallback={
-                                    sourceTransport() ===
-                                    NetworkTransport.Tron ? (
-                                        <ApproveTrc20
-                                            asset={props.bridge.sourceAsset}
-                                            setNeedsApproval={setNeedsApproval}
-                                            approvalTarget={approvalTarget()!}
-                                        />
-                                    ) : (
-                                        <ApproveErc20
-                                            asset={props.bridge.sourceAsset}
-                                            value={() =>
-                                                requiredTokenBalance() ??
-                                                props.amount
-                                            }
-                                            setNeedsApproval={setNeedsApproval}
-                                            approvalTarget={
-                                                approvalTarget() as Address
-                                            }
-                                            resetAllowanceFirst={true}
-                                        />
-                                    )
+                                    <InsufficientBalance
+                                        asset={props.bridge.sourceAsset}
+                                        line={t(
+                                            "insufficient_gas_balance_line" as DictKey,
+                                            {
+                                                gasToken: sourceGasToken(),
+                                            },
+                                        )}
+                                    />
                                 }>
-                                <ContractTransaction
-                                    asset={props.bridge.sourceAsset}
-                                    /* eslint-disable-next-line solid/reactivity */
-                                    onClick={async () => {
-                                        const tx = await sendBridge();
-                                        await persistBridgeSend(
-                                            tx.hash,
-                                            tx.details,
-                                        );
-                                    }}
-                                    children={
-                                        <ConnectWallet
-                                            asset={props.bridge.sourceAsset}
-                                        />
-                                    }
-                                    buttonText={t("send")}
-                                    promptText={t("transaction_prompt", {
-                                        button: t("send"),
-                                    })}
-                                    waitingText={t("tx_in_mempool_subline")}
-                                    showHr={false}
-                                />
+                                <Show
+                                    when={!needsApproval()}
+                                    fallback={
+                                        sourceTransport() ===
+                                        NetworkTransport.Tron ? (
+                                            <ApproveTrc20
+                                                asset={props.bridge.sourceAsset}
+                                                setNeedsApproval={
+                                                    setNeedsApproval
+                                                }
+                                                approvalTarget={
+                                                    approvalTarget()!
+                                                }
+                                            />
+                                        ) : (
+                                            <ApproveErc20
+                                                asset={props.bridge.sourceAsset}
+                                                value={() =>
+                                                    requiredTokenBalance() ??
+                                                    props.amount
+                                                }
+                                                setNeedsApproval={
+                                                    setNeedsApproval
+                                                }
+                                                approvalTarget={
+                                                    approvalTarget() as Address
+                                                }
+                                                resetAllowanceFirst={true}
+                                            />
+                                        )
+                                    }>
+                                    <ContractTransaction
+                                        asset={props.bridge.sourceAsset}
+                                        /* eslint-disable-next-line solid/reactivity */
+                                        onClick={async () => {
+                                            setBridgeSendActive(true);
+                                            try {
+                                                const tx = await sendBridge();
+                                                await persistBridgeSend(
+                                                    tx.hash,
+                                                    tx.details,
+                                                );
+                                            } finally {
+                                                setBridgeSendActive(false);
+                                            }
+                                        }}
+                                        children={
+                                            <ConnectWallet
+                                                asset={props.bridge.sourceAsset}
+                                            />
+                                        }
+                                        buttonText={t("send")}
+                                        promptText={t("transaction_prompt", {
+                                            button: t("send"),
+                                        })}
+                                        waitingText={t("tx_in_mempool_subline")}
+                                        showHr={false}
+                                    />
+                                </Show>
                             </Show>
                         </Show>
                     </Show>

--- a/src/components/SendToBridge.tsx
+++ b/src/components/SendToBridge.tsx
@@ -1,8 +1,21 @@
-import { type BridgeTransaction, bridgeRegistry } from "boltz-swaps/bridge";
-import { createTokenContract } from "boltz-swaps/evm/contracts";
 import {
+    type BridgeMsgFee,
+    type BridgeSendParam,
+    type BridgeTransaction,
+    type BridgeTransportClient,
+    PendingBridgeSendKind,
+    type PendingEvmOftBridgeSend,
+    bridgeRegistry,
+} from "boltz-swaps/bridge";
+import { isWalletRejectionError } from "boltz-swaps/errors";
+import { createTokenContract } from "boltz-swaps/evm/contracts";
+import type { PopulatedEvmTransaction } from "boltz-swaps/evm/transaction";
+import {
+    type OftDirectSendTarget,
     type OftTransportClient,
+    type SendParam,
     getTronTokenAllowance,
+    populateOftDirectSendTransaction,
 } from "boltz-swaps/oft";
 import {
     BridgeKind,
@@ -18,6 +31,7 @@ import {
     createResource,
     createSignal,
 } from "solid-js";
+import { sendPopulatedTransaction } from "src/utils/evmTransaction";
 import { type Address, getAddress } from "viem";
 
 import { config } from "../config";
@@ -27,22 +41,25 @@ import { usePayContext } from "../context/Pay";
 import { type Signer, useWeb3Signer } from "../context/Web3";
 import type { DictKey } from "../i18n/i18n";
 import WalletConnectProvider from "../utils/WalletConnectProvider";
-import type { BridgeDetail } from "../utils/swapCreator";
+import { type BridgeDetail, GasAbstractionType } from "../utils/swapCreator";
 import ApproveErc20 from "./ApproveErc20";
 import ApproveTrc20 from "./ApproveTrc20";
+import { useBridgeSendRecovery } from "./BridgeSendRecovery";
 import ConnectWallet from "./ConnectWallet";
 import ContractTransaction from "./ContractTransaction";
 import InsufficientBalance from "./InsufficientBalance";
 import LoadingSpinner from "./LoadingSpinner";
 import WaitForBridge from "./WaitForBridge";
 
+const evmPendingSendBlockLookback = 5n;
+
 const SendToBridge = (props: {
     bridge: BridgeDetail;
     swapId: string;
     amount: bigint;
 }) => {
-    const { setSwap, swap } = usePayContext();
-    const { t, getSwap, setSwapStorage } = useGlobalContext();
+    const { swap } = usePayContext();
+    const { t } = useGlobalContext();
     const { signer, connectedWallet, getGasAbstractionSigner } =
         useWeb3Signer();
 
@@ -71,9 +88,36 @@ const SendToBridge = (props: {
     const [approvalTarget, setApprovalTarget] = createSignal<
         string | undefined
     >(undefined);
-    const txSent = createMemo(() => {
-        return swap()?.bridge?.txHash;
+    const txSent = createMemo<string | undefined>(() => swap()?.bridge?.txHash);
+    const {
+        pendingSend,
+        pendingSendCallbacks,
+        persistBridgeSend,
+        setPendingSend,
+    } = useBridgeSendRecovery({
+        swapId: () => props.swapId,
+        bridge: () => props.bridge,
+        txSent,
     });
+
+    // OFT transport sends (Solana/Tron) need callbacks to persist a pending
+    // send before broadcast. Other bridges (CCTP) go through the driver as-is.
+    const sendTransport = async (args: {
+        contract: BridgeTransportClient;
+        sendParam: BridgeSendParam;
+        msgFee: BridgeMsgFee;
+        refundAddress: string;
+    }): Promise<BridgeTransaction> => {
+        if (props.bridge.kind !== BridgeKind.Oft) {
+            return await bridgeDriver().sendTransport(args);
+        }
+        return await (args.contract as OftTransportClient).send(
+            args.sendParam as SendParam,
+            args.msgFee,
+            args.refundAddress,
+            { pendingSendCallbacks },
+        );
+    };
 
     const [signerChainId] = createResource(signer, async (currentSigner) => {
         return Number(await currentSigner.provider.getChainId());
@@ -469,7 +513,7 @@ const SendToBridge = (props: {
             lzTokenFee: msgFee[1].toString(),
         });
 
-        return await bridgeDriver().sendTransport({
+        return await sendTransport({
             contract: bridgeInstance,
             sendParam,
             msgFee,
@@ -531,7 +575,7 @@ const SendToBridge = (props: {
             lzTokenFee: msgFee[1].toString(),
         });
 
-        return await bridgeDriver().sendTransport({
+        return await sendTransport({
             contract: bridgeInstance,
             sendParam,
             msgFee,
@@ -586,6 +630,46 @@ const SendToBridge = (props: {
             lzTokenFee: msgFee[1].toString(),
         });
 
+        if (props.bridge.kind === BridgeKind.Oft) {
+            let txRequest: PopulatedEvmTransaction;
+            try {
+                txRequest = await prepareOftFromEvm({
+                    signer: connectedSigner,
+                    signerAddress,
+                    directSendTarget: directSendTarget as OftDirectSendTarget,
+                    sendParam: sendParam as SendParam,
+                    msgFee,
+                });
+            } catch (error) {
+                log.warn("Falling back to direct EVM OFT send", {
+                    sourceAsset: props.bridge.sourceAsset,
+                    destinationAsset: props.bridge.destinationAsset,
+                    error,
+                });
+                return await bridgeDriver().sendDirect({
+                    target: directSendTarget,
+                    runner: connectedSigner,
+                    sendParam,
+                    msgFee,
+                    refundAddress: signerAddress,
+                });
+            }
+
+            try {
+                const hash = await sendPopulatedTransaction(
+                    GasAbstractionType.None,
+                    connectedSigner,
+                    txRequest,
+                );
+                return { hash };
+            } catch (error) {
+                if (isWalletRejectionError(error)) {
+                    await setPendingSend(undefined);
+                }
+                throw error;
+            }
+        }
+
         return await bridgeDriver().sendDirect({
             target: directSendTarget,
             runner: connectedSigner,
@@ -593,6 +677,59 @@ const SendToBridge = (props: {
             msgFee,
             refundAddress: signerAddress,
         });
+    };
+
+    // Capture the latest confirmed sender nonce as a lower bound and persist the
+    // populated call before broadcast. If the page is closed before the wallet
+    // returns we can find the resulting transaction by replaying OFTSent logs and
+    // matching on the sender and calldata.
+    const prepareOftFromEvm = async (args: {
+        signer: Signer;
+        signerAddress: Address;
+        directSendTarget: OftDirectSendTarget;
+        sendParam: SendParam;
+        msgFee: BridgeMsgFee;
+    }): Promise<PopulatedEvmTransaction> => {
+        const txRequest: PopulatedEvmTransaction =
+            populateOftDirectSendTransaction({
+                target: args.directSendTarget,
+                sendParam: args.sendParam,
+                msgFee: args.msgFee,
+                refundAddress: args.signerAddress,
+            });
+        if (txRequest.to === undefined || txRequest.data === undefined) {
+            throw new Error("OFT direct send transaction is missing call data");
+        }
+
+        const [fromNonce, latestBlock] = await Promise.all([
+            args.signer.provider.getTransactionCount({
+                address: args.signerAddress,
+                blockTag: "latest",
+            }),
+            bridgeDriver()
+                .getProvider(props.bridge.sourceAsset)
+                .getBlockNumber(),
+        ]);
+
+        const pending: PendingEvmOftBridgeSend = {
+            kind: PendingBridgeSendKind.EvmOft,
+            createdAt: Date.now(),
+            sender: args.signerAddress,
+            fromNonce,
+            // Reorgs can move the transaction back a few blocks; start a bit
+            // earlier so log replay still finds it.
+            fromBlock: Number(
+                latestBlock > evmPendingSendBlockLookback
+                    ? latestBlock - evmPendingSendBlockLookback
+                    : 0n,
+            ),
+            oftContractAddress: args.directSendTarget.oftContract.address,
+            transactionTo: txRequest.to,
+            calldata: txRequest.data,
+        };
+        await setPendingSend(pending);
+
+        return txRequest;
     };
 
     const sendBridge = async () => {
@@ -614,35 +751,6 @@ const SendToBridge = (props: {
         }
     };
 
-    const persistBridgeSend = async (tx: BridgeTransaction) => {
-        const currentSwap = await getSwap(props.swapId);
-        if (currentSwap === null) {
-            return;
-        }
-        if (currentSwap.bridge !== undefined) {
-            const bridge = {
-                ...currentSwap.bridge,
-                txHash: tx.hash,
-            };
-            if (tx.details === undefined) {
-                delete bridge.details;
-            } else {
-                bridge.details = tx.details;
-            }
-
-            currentSwap.bridge = bridge;
-        }
-
-        setSwap(currentSwap);
-        await setSwapStorage(currentSwap);
-        log.info("Persisted bridge send tx hash for background worker", {
-            swapId: props.swapId,
-            sourceAsset: props.bridge.sourceAsset,
-            destinationAsset: props.bridge.destinationAsset,
-            txHash: tx.hash,
-        });
-    };
-
     createEffect(() => {
         void syncBridgeSendState();
     });
@@ -657,83 +765,95 @@ const SendToBridge = (props: {
                 />
             }>
             <Show
-                when={
-                    signerBalance() !== undefined &&
-                    hasEnoughMsgFee() !== undefined
-                }
-                fallback={
-                    <Show
-                        when={sourceWalletReady()}
-                        fallback={
-                            <ConnectWallet asset={props.bridge.sourceAsset} />
-                        }>
-                        <LoadingSpinner />
-                    </Show>
-                }>
+                when={pendingSend() === undefined}
+                fallback={<WaitForBridge bridge={props.bridge} />}>
                 <Show
                     when={
-                        signerBalance()! >=
-                        (requiredTokenBalance() ?? props.amount)
+                        signerBalance() !== undefined &&
+                        hasEnoughMsgFee() !== undefined
                     }
                     fallback={
-                        <InsufficientBalance asset={props.bridge.sourceAsset} />
+                        <Show
+                            when={sourceWalletReady()}
+                            fallback={
+                                <ConnectWallet
+                                    asset={props.bridge.sourceAsset}
+                                />
+                            }>
+                            <LoadingSpinner />
+                        </Show>
                     }>
                     <Show
-                        when={hasEnoughMsgFee()}
+                        when={
+                            signerBalance()! >=
+                            (requiredTokenBalance() ?? props.amount)
+                        }
                         fallback={
                             <InsufficientBalance
                                 asset={props.bridge.sourceAsset}
-                                line={t(
-                                    "insufficient_gas_balance_line" as DictKey,
-                                    {
-                                        gasToken: sourceGasToken(),
-                                    },
-                                )}
                             />
                         }>
                         <Show
-                            when={!needsApproval()}
+                            when={hasEnoughMsgFee()}
                             fallback={
-                                sourceTransport() === NetworkTransport.Tron ? (
-                                    <ApproveTrc20
-                                        asset={props.bridge.sourceAsset}
-                                        setNeedsApproval={setNeedsApproval}
-                                        approvalTarget={approvalTarget()!}
-                                    />
-                                ) : (
-                                    <ApproveErc20
-                                        asset={props.bridge.sourceAsset}
-                                        value={() =>
-                                            requiredTokenBalance() ??
-                                            props.amount
-                                        }
-                                        setNeedsApproval={setNeedsApproval}
-                                        approvalTarget={
-                                            approvalTarget() as Address
-                                        }
-                                        resetAllowanceFirst={true}
-                                    />
-                                )
+                                <InsufficientBalance
+                                    asset={props.bridge.sourceAsset}
+                                    line={t(
+                                        "insufficient_gas_balance_line" as DictKey,
+                                        {
+                                            gasToken: sourceGasToken(),
+                                        },
+                                    )}
+                                />
                             }>
-                            <ContractTransaction
-                                asset={props.bridge.sourceAsset}
-                                /* eslint-disable-next-line solid/reactivity */
-                                onClick={async () => {
-                                    const tx = await sendBridge();
-                                    await persistBridgeSend(tx);
-                                }}
-                                children={
-                                    <ConnectWallet
-                                        asset={props.bridge.sourceAsset}
-                                    />
-                                }
-                                buttonText={t("send")}
-                                promptText={t("transaction_prompt", {
-                                    button: t("send"),
-                                })}
-                                waitingText={t("tx_in_mempool_subline")}
-                                showHr={false}
-                            />
+                            <Show
+                                when={!needsApproval()}
+                                fallback={
+                                    sourceTransport() ===
+                                    NetworkTransport.Tron ? (
+                                        <ApproveTrc20
+                                            asset={props.bridge.sourceAsset}
+                                            setNeedsApproval={setNeedsApproval}
+                                            approvalTarget={approvalTarget()!}
+                                        />
+                                    ) : (
+                                        <ApproveErc20
+                                            asset={props.bridge.sourceAsset}
+                                            value={() =>
+                                                requiredTokenBalance() ??
+                                                props.amount
+                                            }
+                                            setNeedsApproval={setNeedsApproval}
+                                            approvalTarget={
+                                                approvalTarget() as Address
+                                            }
+                                            resetAllowanceFirst={true}
+                                        />
+                                    )
+                                }>
+                                <ContractTransaction
+                                    asset={props.bridge.sourceAsset}
+                                    /* eslint-disable-next-line solid/reactivity */
+                                    onClick={async () => {
+                                        const tx = await sendBridge();
+                                        await persistBridgeSend(
+                                            tx.hash,
+                                            tx.details,
+                                        );
+                                    }}
+                                    children={
+                                        <ConnectWallet
+                                            asset={props.bridge.sourceAsset}
+                                        />
+                                    }
+                                    buttonText={t("send")}
+                                    promptText={t("transaction_prompt", {
+                                        button: t("send"),
+                                    })}
+                                    waitingText={t("tx_in_mempool_subline")}
+                                    showHr={false}
+                                />
+                            </Show>
                         </Show>
                     </Show>
                 </Show>

--- a/src/components/WaitForBridge.tsx
+++ b/src/components/WaitForBridge.tsx
@@ -131,7 +131,7 @@ const OftCountdown = (props: {
 
 const WaitForBridge = (props: {
     bridge: BridgeDetail;
-    transactionHash: string;
+    transactionHash?: string;
 }) => {
     const { t } = useGlobalContext();
 
@@ -145,11 +145,17 @@ const WaitForBridge = (props: {
             <h3>{t("tx_in_mempool_warning")}</h3>
             <LoadingSpinner />
             <Show when={props.bridge.kind === BridgeKind.Oft}>
-                <OftCountdown
-                    sourceAsset={props.bridge.sourceAsset}
-                    destinationAsset={props.bridge.destinationAsset}
-                    txHash={props.transactionHash}
-                />
+                <Show
+                    when={props.transactionHash}
+                    fallback={<p>{t("oft_transfer_in_progress")}</p>}>
+                    {(transactionHash) => (
+                        <OftCountdown
+                            sourceAsset={props.bridge.sourceAsset}
+                            destinationAsset={props.bridge.destinationAsset}
+                            txHash={transactionHash()}
+                        />
+                    )}
+                </Show>
             </Show>
         </>
     );

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -36,6 +36,19 @@ const dict = {
         fee: "Boltz Fee",
         denomination: "Denomination",
         send: "Send",
+        checking_previous_transaction: "Checking previous transaction",
+        checking_previous_transaction_line:
+            "Please wait while we check whether your wallet submitted the bridge transaction.",
+        could_not_confirm_previous_transaction:
+            "Could not confirm previous transaction",
+        could_not_confirm_previous_transaction_line:
+            "We could not confirm whether your wallet submitted the bridge transaction.",
+        checking_previous_transaction_countdown:
+            "{{ seconds }} seconds remaining.",
+        check_again: "Check again",
+        did_not_send_transaction: "I didn't send a transaction",
+        did_not_send_transaction_confirm:
+            "Only continue if you are sure your wallet did not submit the transaction. Continuing can make you send funds twice.",
         continue: "Continue",
         receive: "Receive",
         min: "Min",
@@ -548,6 +561,18 @@ const dict = {
         fee: "Boltzgebühr",
         denomination: "Denominierung",
         send: "Sende",
+        checking_previous_transaction: "Vorherige Transaktion wird geprüft",
+        checking_previous_transaction_line:
+            "Bitte warte, während wir prüfen, ob dein Wallet die Bridge-Transaktion übermittelt hat.",
+        could_not_confirm_previous_transaction:
+            "Vorherige Transaktion konnte nicht bestätigt werden",
+        could_not_confirm_previous_transaction_line:
+            "Wir konnten nicht bestätigen, ob dein Wallet die Bridge-Transaktion übermittelt hat.",
+        checking_previous_transaction_countdown: "Noch {{ seconds }} Sekunden.",
+        check_again: "Erneut prüfen",
+        did_not_send_transaction: "Ich habe keine Transaktion gesendet",
+        did_not_send_transaction_confirm:
+            "Fahre nur fort, wenn du sicher bist, dass dein Wallet die Transaktion nicht übermittelt hat. Wenn du fortfährst, könntest du Geld zweimal senden.",
         continue: "Weiter",
         receive: "Empfange",
         min: "Min",
@@ -1076,6 +1101,19 @@ const dict = {
         fee: "Comisión de Boltz",
         denomination: "Denominación",
         send: "Enviar",
+        checking_previous_transaction: "Comprobando transacción anterior",
+        checking_previous_transaction_line:
+            "Espera mientras comprobamos si tu billetera envió la transacción de puente.",
+        could_not_confirm_previous_transaction:
+            "No se pudo confirmar la transacción anterior",
+        could_not_confirm_previous_transaction_line:
+            "No pudimos confirmar si tu billetera envió la transacción de puente.",
+        checking_previous_transaction_countdown:
+            "Quedan {{ seconds }} segundos.",
+        check_again: "Comprobar de nuevo",
+        did_not_send_transaction: "No envié una transacción",
+        did_not_send_transaction_confirm:
+            "Continúa solo si tienes la certeza de que tu billetera no envió la transacción. Continuar puede hacer que envíes fondos dos veces.",
         continue: "Continuar",
         receive: "Recibir",
         min: "Mín",
@@ -1601,6 +1639,19 @@ const dict = {
         fee: "Taxa da Boltz",
         denomination: "Denominação",
         send: "Enviar",
+        checking_previous_transaction: "Verificando transação anterior",
+        checking_previous_transaction_line:
+            "Por favor, aguarde enquanto verificamos se sua carteira enviou a transação da ponte.",
+        could_not_confirm_previous_transaction:
+            "Não foi possível confirmar a transação anterior",
+        could_not_confirm_previous_transaction_line:
+            "Não foi possível confirmar se sua carteira enviou a transação da ponte.",
+        checking_previous_transaction_countdown:
+            "{{ seconds }} segundos restantes.",
+        check_again: "Verificar novamente",
+        did_not_send_transaction: "Eu não enviei uma transação",
+        did_not_send_transaction_confirm:
+            "Continue apenas se tiver certeza de que sua carteira não enviou a transação. Continuar pode fazer com que você envie fundos duas vezes.",
         continue: "Continuar",
         receive: "Receber",
         min: "Mín",
@@ -2121,6 +2172,17 @@ const dict = {
         fee: "Boltz费",
         denomination: "面额",
         send: "发送",
+        checking_previous_transaction: "正在检查上一笔交易",
+        checking_previous_transaction_line:
+            "请稍候，我们正在检查您的钱包是否已提交桥接交易。",
+        could_not_confirm_previous_transaction: "无法确认上一笔交易",
+        could_not_confirm_previous_transaction_line:
+            "我们无法确认您的钱包是否已提交桥接交易。",
+        checking_previous_transaction_countdown: "剩余 {{ seconds }} 秒。",
+        check_again: "再次检查",
+        did_not_send_transaction: "我没有发送交易",
+        did_not_send_transaction_confirm:
+            "仅当您确定钱包没有提交该交易时才继续。继续可能会导致您重复发送资金。",
         continue: "继续",
         receive: "接收",
         min: "最小",
@@ -2590,6 +2652,18 @@ const dict = {
         fee: "Boltz手数料",
         denomination: "単位",
         send: "送信",
+        checking_previous_transaction: "前回のトランザクションを確認中",
+        checking_previous_transaction_line:
+            "ウォレットがブリッジトランザクションを送信したか確認しています。しばらくお待ちください。",
+        could_not_confirm_previous_transaction:
+            "前回のトランザクションを確認できませんでした",
+        could_not_confirm_previous_transaction_line:
+            "ウォレットがブリッジトランザクションを送信したか確認できませんでした。",
+        checking_previous_transaction_countdown: "残り {{ seconds }} 秒。",
+        check_again: "再確認",
+        did_not_send_transaction: "トランザクションを送信していません",
+        did_not_send_transaction_confirm:
+            "ウォレットがトランザクションを送信していないことが確実な場合のみ続行してください。続行すると、資金を二重に送信する可能性があります。",
         continue: "続ける",
         receive: "受取",
         min: "最小",

--- a/src/utils/swapCreator.ts
+++ b/src/utils/swapCreator.ts
@@ -2,7 +2,11 @@ import { sha256 } from "@noble/hashes/sha2.js";
 import { hex } from "@scure/base";
 import type BigNumber from "bignumber.js";
 import { OutputType } from "boltz-core";
-import type { BridgeDetails, BridgeRoute } from "boltz-swaps/bridge";
+import type {
+    BridgeDetails,
+    BridgeRoute,
+    PendingBridgeSend,
+} from "boltz-swaps/bridge";
 import {
     type ChainSwapCreatedResponse,
     type ReverseCreatedResponse,
@@ -42,6 +46,11 @@ export type BridgeDetail = BridgeRoute & {
     position: SwapPosition;
     txHash?: string;
     details?: BridgeDetails;
+    pendingSend?: PendingBridgeSend;
+};
+
+export type PendingBridgeSendCallbacks = {
+    persist: (pending: PendingBridgeSend) => Promise<void>;
 };
 
 export type GasAbstraction = {

--- a/src/utils/swapCreator.ts
+++ b/src/utils/swapCreator.ts
@@ -6,6 +6,7 @@ import type {
     BridgeDetails,
     BridgeRoute,
     PendingBridgeSend,
+    PendingEvmOftBridgeSend,
 } from "boltz-swaps/bridge";
 import {
     type ChainSwapCreatedResponse,
@@ -47,6 +48,7 @@ export type BridgeDetail = BridgeRoute & {
     txHash?: string;
     details?: BridgeDetails;
     pendingSend?: PendingBridgeSend;
+    evmSendCandidate?: PendingEvmOftBridgeSend;
 };
 
 export type PendingBridgeSendCallbacks = {

--- a/tests/components/WaitForBridge.spec.tsx
+++ b/tests/components/WaitForBridge.spec.tsx
@@ -105,4 +105,24 @@ describe("WaitForBridge", () => {
             vi.mocked(waitForOftTransactionConfirmationTimestamp),
         ).toHaveBeenCalledTimes(1);
     });
+
+    test("shows the in-progress copy without a transaction hash", () => {
+        render(() => (
+            <WaitForBridge
+                bridge={{
+                    kind: BridgeKind.Oft,
+                    position: SwapPosition.Pre,
+                    sourceAsset: "USDT0-ETH",
+                    destinationAsset: "USDT0",
+                }}
+            />
+        ));
+
+        expect(
+            screen.getByText(mockTranslations.oft_transfer_in_progress),
+        ).toBeInTheDocument();
+        expect(
+            waitForOftTransactionConfirmationTimestamp,
+        ).not.toHaveBeenCalled();
+    });
 });

--- a/tests/pages/RescueExternalEvmScan.spec.tsx
+++ b/tests/pages/RescueExternalEvmScan.spec.tsx
@@ -91,6 +91,7 @@ describe("RescueExternal EVM scan", () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.stubEnv("VITE_RSK_LOG_SCAN_ENDPOINT", "http://localhost:8545");
+        vi.stubEnv("VITE_ARBITRUM_LOG_SCAN_ENDPOINT", "");
         mockGetRestorableSwaps.mockResolvedValue([]);
         mockGetSweepableGasAbstractionBalances.mockResolvedValue([]);
     });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -7,7 +7,7 @@ import { config as runtimeConfig } from "../src/config";
 import { chooseUrl } from "../src/configs/base";
 import { config as mainnetConfig } from "../src/configs/mainnet";
 
-log.setLevel("error");
+log.setLevel("silent");
 setLogger(log);
 
 setBoltzSwapsConfig({

--- a/tests/utils/bridgePendingSend.spec.ts
+++ b/tests/utils/bridgePendingSend.spec.ts
@@ -205,7 +205,7 @@ describe("recoverPendingEvmOftSend", () => {
 
     test("keeps pending while the nonce is still in the mempool", async () => {
         const result = await recoverPendingEvmOftSend(
-            pendingSend,
+            { ...pendingSend, createdAt: Date.now() },
             createProvider({
                 logs: [],
                 latestNonce: 7,
@@ -215,6 +215,21 @@ describe("recoverPendingEvmOftSend", () => {
 
         expect(result).toEqual({
             status: PendingBridgeSendRecoveryStatus.Pending,
+        });
+    });
+
+    test("fails when a mempool tx is not found before expiry", async () => {
+        const result = await recoverPendingEvmOftSend(
+            pendingSend,
+            createProvider({
+                logs: [],
+                latestNonce: 7,
+                pendingNonce: 8,
+            }),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Failed,
         });
     });
 

--- a/tests/utils/bridgePendingSend.spec.ts
+++ b/tests/utils/bridgePendingSend.spec.ts
@@ -1,0 +1,371 @@
+import {
+    PendingBridgeSendKind,
+    PendingBridgeSendRecoveryStatus,
+    type PendingEvmOftBridgeSend,
+    type PendingSolanaOftBridgeSend,
+    type PendingTronOftBridgeSend,
+    recoverPendingEvmOftSend,
+    recoverPendingSolanaOftSend,
+    recoverPendingTronOftSend,
+} from "boltz-swaps/bridge";
+import { oftAbi } from "boltz-swaps/oft";
+import { getSolanaConnection } from "boltz-swaps/solana";
+import type * as TronChain from "boltz-swaps/tron";
+import { getTronTransaction, getTronTransactionInfo } from "boltz-swaps/tron";
+import {
+    type Hex,
+    type PublicClient,
+    encodeAbiParameters,
+    encodeEventTopics,
+} from "viem";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("boltz-swaps/solana", () => ({
+    getSolanaConnection: vi.fn(),
+}));
+
+vi.mock("boltz-swaps/tron", async (importOriginal) => ({
+    ...(await importOriginal<typeof TronChain>()),
+    getTronTransaction: vi.fn(),
+    getTronTransactionInfo: vi.fn(),
+}));
+
+const sender = "0x1000000000000000000000000000000000000000";
+const target = "0x2000000000000000000000000000000000000000";
+const oftContractAddress = "0x3000000000000000000000000000000000000000";
+const calldata = "0xabcdef";
+const transactionHash =
+    "0x1111111111111111111111111111111111111111111111111111111111111111";
+const solanaSignature =
+    "4Z5XjC7hYw5Z5TFySTbRHzM2cTRkuzMCVYDn6H3CUf1W9EN2TRdLhXjFiKDLxx8FEh3zKfJQyTjU3KFiKxVYjR7m";
+const tronTransactionHash =
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+const pendingSend: PendingEvmOftBridgeSend = {
+    kind: PendingBridgeSendKind.EvmOft,
+    createdAt: 1,
+    sender,
+    fromNonce: 7,
+    fromBlock: 100,
+    oftContractAddress,
+    transactionTo: target,
+    calldata,
+};
+
+const createOftSentLog = (
+    overrides: Partial<{
+        transactionHash: string;
+        address: string;
+        fromAddress: string;
+    }> = {},
+) => ({
+    address: overrides.address ?? oftContractAddress,
+    transactionHash: overrides.transactionHash ?? transactionHash,
+    data: encodeAbiParameters(
+        [{ type: "uint32" }, { type: "uint256" }, { type: "uint256" }],
+        [30184, 1000n, 990n],
+    ),
+    topics: encodeEventTopics({
+        abi: oftAbi,
+        eventName: "OFTSent",
+        args: {
+            guid: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            fromAddress: (overrides.fromAddress ?? sender) as Hex,
+        },
+    }),
+    blockNumber: 101,
+    index: 0,
+});
+
+const createProvider = ({
+    logs = [createOftSentLog()],
+    transaction = {
+        nonce: 7,
+        from: sender,
+        to: target,
+        value: 123n,
+        input: calldata,
+    },
+    receipt = {
+        status: "success",
+        logs: [createOftSentLog()],
+    },
+    latestNonce = 7,
+    pendingNonce = latestNonce,
+}: {
+    logs?: unknown[];
+    transaction?: unknown;
+    receipt?: unknown;
+    latestNonce?: number;
+    pendingNonce?: number;
+} = {}) =>
+    ({
+        getLogs: vi.fn().mockResolvedValue(logs),
+        getTransaction: vi.fn().mockResolvedValue(transaction),
+        getTransactionReceipt: vi.fn().mockResolvedValue(receipt),
+        getTransactionCount: vi
+            .fn()
+            .mockImplementation(({ blockTag }: { blockTag: string }) =>
+                Promise.resolve(
+                    blockTag === "pending" ? pendingNonce : latestNonce,
+                ),
+            ),
+    }) as unknown as PublicClient;
+
+describe("recoverPendingEvmOftSend", () => {
+    test("recovers a tx matching sender calldata and OFTSent", async () => {
+        const result = await recoverPendingEvmOftSend(
+            pendingSend,
+            createProvider(),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Recovered,
+            transactionHash,
+        });
+    });
+
+    test("filters OFTSent logs by indexed sender", async () => {
+        const provider = createProvider();
+
+        await recoverPendingEvmOftSend(pendingSend, provider);
+
+        expect(provider.getLogs).toHaveBeenCalledWith(
+            expect.objectContaining({
+                args: { fromAddress: sender },
+            }),
+        );
+    });
+
+    test("recovers when duplicate OFTSent logs point to the same tx", async () => {
+        const result = await recoverPendingEvmOftSend(
+            pendingSend,
+            createProvider({
+                logs: [createOftSentLog(), createOftSentLog()],
+            }),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Recovered,
+            transactionHash,
+        });
+    });
+
+    test("recovers when the wallet broadcasts with a higher nonce", async () => {
+        const result = await recoverPendingEvmOftSend(
+            pendingSend,
+            createProvider({
+                transaction: {
+                    nonce: 8,
+                    from: sender,
+                    to: target,
+                    value: 123n,
+                    input: calldata,
+                },
+                latestNonce: 8,
+            }),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Recovered,
+            transactionHash,
+        });
+    });
+
+    test("fails when calldata differs and the nonce is mined", async () => {
+        const result = await recoverPendingEvmOftSend(
+            pendingSend,
+            createProvider({
+                transaction: {
+                    nonce: 7,
+                    from: sender,
+                    to: target,
+                    value: 123n,
+                    input: "0x123456",
+                },
+                latestNonce: 8,
+            }),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Failed,
+        });
+    });
+
+    test("keeps pending while the nonce has not been mined", async () => {
+        const result = await recoverPendingEvmOftSend(
+            { ...pendingSend, createdAt: Date.now() },
+            createProvider({ logs: [], latestNonce: 7 }),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Pending,
+        });
+    });
+
+    test("keeps pending while the nonce is still in the mempool", async () => {
+        const result = await recoverPendingEvmOftSend(
+            pendingSend,
+            createProvider({
+                logs: [],
+                latestNonce: 7,
+                pendingNonce: 8,
+            }),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Pending,
+        });
+    });
+
+    test("fails when the nonce never advances before expiry", async () => {
+        const result = await recoverPendingEvmOftSend(
+            pendingSend,
+            createProvider({
+                logs: [],
+                latestNonce: 7,
+                pendingNonce: 7,
+            }),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Failed,
+        });
+    });
+
+    test("fails when the nonce is mined without a matching OFTSent", async () => {
+        const result = await recoverPendingEvmOftSend(
+            pendingSend,
+            createProvider({ logs: [], latestNonce: 8 }),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Failed,
+        });
+    });
+
+    test("keeps checking briefly after nonce advances to allow log indexing", async () => {
+        const result = await recoverPendingEvmOftSend(
+            { ...pendingSend, createdAt: Date.now() },
+            createProvider({ logs: [], latestNonce: 8 }),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Pending,
+        });
+    });
+});
+
+const mockedGetSolanaConnection = vi.mocked(getSolanaConnection);
+const mockedGetTronTransaction = vi.mocked(getTronTransaction);
+const mockedGetTronTransactionInfo = vi.mocked(getTronTransactionInfo);
+
+const solanaPendingSend: PendingSolanaOftBridgeSend = {
+    kind: PendingBridgeSendKind.SolanaOft,
+    sourceAsset: "USDT0-SOL",
+    lastValidBlockHeight: 100,
+    signature: solanaSignature,
+};
+
+const createSolanaConnection = ({
+    status = null,
+    blockHeight = 50,
+}: {
+    status?: unknown;
+    blockHeight?: number;
+} = {}) => ({
+    getSignatureStatuses: vi.fn().mockResolvedValue({ value: [status] }),
+    getBlockHeight: vi.fn().mockResolvedValue(blockHeight),
+    sendRawTransaction: vi.fn(),
+});
+
+describe("recoverPendingSolanaOftSend", () => {
+    test("recovers a signed tx already found on-chain", async () => {
+        const connection = createSolanaConnection({
+            status: { err: null },
+        });
+        mockedGetSolanaConnection.mockResolvedValue(connection as never);
+
+        const result = await recoverPendingSolanaOftSend(solanaPendingSend);
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Recovered,
+            transactionHash: solanaSignature,
+        });
+        expect(connection.sendRawTransaction).not.toHaveBeenCalled();
+    });
+
+    test("keeps a signed tx pending while it is not found and the blockhash is valid", async () => {
+        const connection = createSolanaConnection();
+        mockedGetSolanaConnection.mockResolvedValue(connection as never);
+
+        const result = await recoverPendingSolanaOftSend(solanaPendingSend);
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Pending,
+        });
+        expect(connection.sendRawTransaction).not.toHaveBeenCalled();
+    });
+
+    test("fails when the signed tx blockhash has expired", async () => {
+        const connection = createSolanaConnection({
+            blockHeight: 101,
+        });
+        mockedGetSolanaConnection.mockResolvedValue(connection as never);
+
+        const result = await recoverPendingSolanaOftSend(solanaPendingSend);
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Failed,
+        });
+        expect(connection.sendRawTransaction).not.toHaveBeenCalled();
+    });
+});
+
+const tronPendingSend: PendingTronOftBridgeSend = {
+    kind: PendingBridgeSendKind.TronOft,
+    createdAt: Date.now(),
+    sourceAsset: "USDT0-TRON",
+    txHash: tronTransactionHash,
+};
+
+describe("recoverPendingTronOftSend", () => {
+    test("recovers a tx already found on-chain", async () => {
+        mockedGetTronTransaction.mockResolvedValue(undefined);
+        mockedGetTronTransactionInfo.mockResolvedValue({
+            receipt: { result: "SUCCESS" },
+        } as never);
+
+        const result = await recoverPendingTronOftSend(tronPendingSend);
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Recovered,
+            transactionHash: tronTransactionHash,
+        });
+    });
+
+    test("keeps a signed tx pending when it is not found on-chain", async () => {
+        mockedGetTronTransaction.mockResolvedValue(undefined);
+        mockedGetTronTransactionInfo.mockResolvedValue(undefined);
+
+        const result = await recoverPendingTronOftSend(tronPendingSend);
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Pending,
+        });
+    });
+
+    test("fails when the transaction is found failed on-chain", async () => {
+        mockedGetTronTransaction.mockResolvedValue(undefined);
+        mockedGetTronTransactionInfo.mockResolvedValue({
+            result: "FAILED",
+            receipt: { result: "REVERT" },
+        } as never);
+
+        const result = await recoverPendingTronOftSend(tronPendingSend);
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Failed,
+        });
+    });
+});


### PR DESCRIPTION
Closes #1425
Related to #1402

Allows user to resume a swap when the browser was closed before the OFT transfer completed (by retrieving the missing txHash);

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery system for pending bridge transactions across EVM, Solana, and Tron chains.
  * Enhanced UI to display localized "waiting for bridge" status during transaction confirmation.

* **Bug Fixes**
  * Improved transaction persistence and tracking for cross-chain bridge operations.
  * Better handling of wallet rejection and transaction state management.

* **Tests**
  * Added comprehensive test suite for transaction recovery logic across all supported chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->