### PR TITLE
feat: block known token addresses in swap creation

### DIFF
--- a/src/components/AddressInput.tsx
+++ b/src/components/AddressInput.tsx
@@ -25,6 +25,7 @@ import {
     extractInvoice,
     isInvoice,
 } from "../utils/invoice";
+import { isKnownStablecoinTokenAddress } from "../utils/knownTokenAddresses";
 
 const AddressInput = () => {
     let inputRef!: HTMLInputElement;
@@ -68,35 +69,38 @@ const AddressInput = () => {
         try {
             const currentPair = pair();
             const assetName = currentPair.toAsset;
+
+            if (isKnownStablecoinTokenAddress(assetName, address)) {
+                throw new Error("token address");
+            }
+
+            const acceptAddress = (nextAddress: string) => {
+                input.setCustomValidity("");
+                input.classList.remove("invalid");
+                setAddressValid(true);
+                setOnchainAddress(nextAddress);
+            };
+
             if (isEvmAsset(assetName)) {
                 if (!isAddress(address)) {
                     throw new Error();
                 }
 
-                input.setCustomValidity("");
-                input.classList.remove("invalid");
-                setAddressValid(true);
-                setOnchainAddress(getAddress(address));
+                acceptAddress(getAddress(address));
                 return;
             }
 
             const transport = getNetworkTransport(assetName);
             if (transport === NetworkTransport.Solana) {
                 if (isValidSolanaAddress(address)) {
-                    input.setCustomValidity("");
-                    input.classList.remove("invalid");
-                    setAddressValid(true);
-                    setOnchainAddress(address);
+                    acceptAddress(address);
                     return;
                 }
             }
 
             if (transport === NetworkTransport.Tron) {
                 if (isValidTronAddress(address)) {
-                    input.setCustomValidity("");
-                    input.classList.remove("invalid");
-                    setAddressValid(true);
-                    setOnchainAddress(address);
+                    acceptAddress(address);
                     return;
                 }
             }

--- a/src/components/AddressInput.tsx
+++ b/src/components/AddressInput.tsx
@@ -25,7 +25,7 @@ import {
     extractInvoice,
     isInvoice,
 } from "../utils/invoice";
-import { isKnownStablecoinTokenAddress } from "../utils/knownTokenAddresses";
+import { isKnownTokenAddress } from "../utils/knownTokenAddresses";
 
 const AddressInput = () => {
     let inputRef!: HTMLInputElement;
@@ -70,7 +70,7 @@ const AddressInput = () => {
             const currentPair = pair();
             const assetName = currentPair.toAsset;
 
-            if (isKnownStablecoinTokenAddress(assetName, address)) {
+            if (isKnownTokenAddress(assetName, address)) {
                 throw new Error("token address");
             }
 

--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -45,7 +45,7 @@ import {
     fetchLnurl,
     getAssetByBip21Prefix,
 } from "../utils/invoice";
-import { isKnownStablecoinTokenAddress } from "../utils/knownTokenAddresses";
+import { isKnownTokenAddress } from "../utils/knownTokenAddresses";
 import { findMagicRoutingHint } from "../utils/magicRoutingHint";
 import { firstResolved, promiseWithTimeout } from "../utils/promise";
 import { gasTopUpSupported } from "../utils/quoter";
@@ -888,9 +888,7 @@ const CreateButton = () => {
                 getGasToken(),
             );
 
-            if (
-                isKnownStablecoinTokenAddress(assetReceive(), onchainAddress())
-            ) {
+            if (isKnownTokenAddress(assetReceive(), onchainAddress())) {
                 showInvalidAddress(assetReceive());
                 return;
             }

--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -45,6 +45,7 @@ import {
     fetchLnurl,
     getAssetByBip21Prefix,
 } from "../utils/invoice";
+import { isKnownStablecoinTokenAddress } from "../utils/knownTokenAddresses";
 import { findMagicRoutingHint } from "../utils/magicRoutingHint";
 import { firstResolved, promiseWithTimeout } from "../utils/promise";
 import { gasTopUpSupported } from "../utils/quoter";
@@ -413,6 +414,16 @@ const CreateButton = () => {
         (assetReceive() !== LN && onchainAddress() !== ""
             ? onchainAddress()
             : undefined);
+
+    const showInvalidAddress = (asset: string) => {
+        setAddressValid(false);
+        notify(
+            "error",
+            t("invalid_address", {
+                asset,
+            }),
+        );
+    };
 
     const fetchInvoice = async () => {
         if (lnurl() !== undefined && lnurl() !== "") {
@@ -878,16 +889,17 @@ const CreateButton = () => {
             );
 
             if (
+                isKnownStablecoinTokenAddress(assetReceive(), onchainAddress())
+            ) {
+                showInvalidAddress(assetReceive());
+                return;
+            }
+
+            if (
                 (assetReceive() === BTC || assetReceive() === LBTC) &&
                 !validateOnchainAddress(assetReceive(), claimAddress)
             ) {
-                setAddressValid(false);
-                notify(
-                    "error",
-                    t("invalid_address", {
-                        asset: assetReceive(),
-                    }),
-                );
+                showInvalidAddress(assetReceive());
                 return;
             }
 

--- a/src/context/Create.tsx
+++ b/src/context/Create.tsx
@@ -28,6 +28,7 @@ import type { DictKey } from "../i18n/i18n";
 import Pair, { RequiredInput } from "../utils/Pair";
 import { validateAddress } from "../utils/compat";
 import { isInvoice, isLnurl } from "../utils/invoice";
+import { isKnownStablecoinTokenAddress } from "../utils/knownTokenAddresses";
 import { getUrlParam, resetUrlParam, urlParamIsSet } from "../utils/urlParams";
 import { useGlobalContext } from "./Global";
 
@@ -369,13 +370,18 @@ const CreateProvider = (props: { children: JSX.Element }) => {
         return new Pair(pairs(), LN, BTC, regularPairs());
     };
 
+    const hasBlockedOnchainAddress = () =>
+        isKnownStablecoinTokenAddress(pair().toAsset, onchainAddress());
+
     createEffect(() => {
         if (amountValid() && pair().isRoutable) {
             const requiredInput = pair().requiredInput;
+            const validDestinationAddress =
+                addressValid() && !hasBlockedOnchainAddress();
             if (
                 ((requiredInput === RequiredInput.Address ||
                     requiredInput === RequiredInput.Web3) &&
-                    addressValid()) ||
+                    validDestinationAddress) ||
                 (requiredInput === RequiredInput.Invoice && invoiceValid())
             ) {
                 setValid(true);
@@ -383,6 +389,12 @@ const CreateProvider = (props: { children: JSX.Element }) => {
             }
         }
         setValid(false);
+    });
+
+    createEffect(() => {
+        if (addressValid() && hasBlockedOnchainAddress()) {
+            setAddressValid(false);
+        }
     });
 
     createEffect(

--- a/src/context/Create.tsx
+++ b/src/context/Create.tsx
@@ -28,7 +28,7 @@ import type { DictKey } from "../i18n/i18n";
 import Pair, { RequiredInput } from "../utils/Pair";
 import { validateAddress } from "../utils/compat";
 import { isInvoice, isLnurl } from "../utils/invoice";
-import { isKnownStablecoinTokenAddress } from "../utils/knownTokenAddresses";
+import { isKnownTokenAddress } from "../utils/knownTokenAddresses";
 import { getUrlParam, resetUrlParam, urlParamIsSet } from "../utils/urlParams";
 import { useGlobalContext } from "./Global";
 
@@ -371,7 +371,7 @@ const CreateProvider = (props: { children: JSX.Element }) => {
     };
 
     const hasBlockedOnchainAddress = () =>
-        isKnownStablecoinTokenAddress(pair().toAsset, onchainAddress());
+        isKnownTokenAddress(pair().toAsset, onchainAddress());
 
     createEffect(() => {
         if (amountValid() && pair().isRoutable) {

--- a/src/utils/knownTokenAddresses.ts
+++ b/src/utils/knownTokenAddresses.ts
@@ -1,0 +1,31 @@
+import { isAddress } from "ethers/address";
+
+import { config } from "../config";
+import { isStablecoinAsset } from "../consts/Assets";
+
+const normalizeAddress = (address: string) => {
+    const trimmed = address.trim();
+    return isAddress(trimmed) ? trimmed.toLowerCase() : trimmed;
+};
+
+export const isKnownStablecoinTokenAddress = (
+    asset: string,
+    address: string,
+): boolean => {
+    if (!isStablecoinAsset(asset)) {
+        return false;
+    }
+
+    const normalizedAddress = normalizeAddress(address);
+    if (normalizedAddress === "") {
+        return false;
+    }
+
+    return Object.entries(config.assets ?? {}).some(
+        ([candidateAsset, candidateConfig]) =>
+            isStablecoinAsset(candidateAsset) &&
+            candidateConfig.token?.address !== undefined &&
+            normalizeAddress(candidateConfig.token.address) ===
+                normalizedAddress,
+    );
+};

--- a/src/utils/knownTokenAddresses.ts
+++ b/src/utils/knownTokenAddresses.ts
@@ -1,18 +1,18 @@
-import { isAddress } from "ethers/address";
+import { isAddress } from "ethers";
 
 import { config } from "../config";
-import { isStablecoinAsset } from "../consts/Assets";
+import { AssetKind } from "../consts/AssetKind";
 
 const normalizeAddress = (address: string) => {
     const trimmed = address.trim();
     return isAddress(trimmed) ? trimmed.toLowerCase() : trimmed;
 };
 
-export const isKnownStablecoinTokenAddress = (
+export const isKnownTokenAddress = (
     asset: string,
     address: string,
 ): boolean => {
-    if (!isStablecoinAsset(asset)) {
+    if (config.assets?.[asset]?.type !== AssetKind.ERC20) {
         return false;
     }
 
@@ -21,9 +21,9 @@ export const isKnownStablecoinTokenAddress = (
         return false;
     }
 
-    return Object.entries(config.assets ?? {}).some(
-        ([candidateAsset, candidateConfig]) =>
-            isStablecoinAsset(candidateAsset) &&
+    return Object.values(config.assets ?? {}).some(
+        (candidateConfig) =>
+            candidateConfig.type === AssetKind.ERC20 &&
             candidateConfig.token?.address !== undefined &&
             normalizeAddress(candidateConfig.token.address) ===
                 normalizedAddress,

--- a/tests/components/AddressInput.spec.tsx
+++ b/tests/components/AddressInput.spec.tsx
@@ -4,6 +4,8 @@ import { vi } from "vitest";
 
 import AddressInput from "../../src/components/AddressInput";
 import InvoiceInput from "../../src/components/InvoiceInput";
+import { config as runtimeConfig } from "../../src/config";
+import { config as mainnetConfig } from "../../src/configs/mainnet";
 import { BTC, LBTC, LN } from "../../src/consts/Assets";
 import Pair from "../../src/utils/Pair";
 import {
@@ -12,6 +14,8 @@ import {
     globalSignals,
     signals,
 } from "../helper";
+
+const originalAssets = structuredClone(runtimeConfig.assets ?? {});
 
 vi.mock("../../src/utils/invoice", async () => {
     const actual = await vi.importActual("../../src/utils/invoice");
@@ -56,6 +60,19 @@ vi.mock("../../src/utils/validation", async () => {
 
 afterEach(() => {
     localStorage.clear();
+});
+
+beforeAll(() => {
+    runtimeConfig.assets = {
+        ...runtimeConfig.assets,
+        "USDC-SOL": structuredClone(mainnetConfig.assets!["USDC-SOL"]),
+        "USDT0-SOL": structuredClone(mainnetConfig.assets!["USDT0-SOL"]),
+        "USDT0-TRON": structuredClone(mainnetConfig.assets!["USDT0-TRON"]),
+    };
+});
+
+afterAll(() => {
+    runtimeConfig.assets = originalAssets;
 });
 
 const setPairAssets = (fromAsset: string, toAsset: string) => {
@@ -110,6 +127,42 @@ describe("AddressInput", () => {
                     expect(input.className).toContain("invalid");
                 });
             }
+        },
+    );
+
+    test.each`
+        asset           | address
+        ${"USDC-SOL"}   | ${"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"}
+        ${"USDT0-SOL"}  | ${"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"}
+        ${"USDT0-SOL"}  | ${"Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"}
+        ${"USDT0-TRON"} | ${"TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"}
+    `(
+        "should reject known token address $address",
+        async ({ asset, address }) => {
+            render(
+                () => (
+                    <>
+                        <TestComponent />
+                        <AddressInput />
+                    </>
+                ),
+                { wrapper: contextWrapper },
+            );
+
+            setPairAssets(signals.pair().fromAsset, asset);
+
+            const input = (await screen.findByTestId(
+                "onchainAddress",
+            )) as HTMLInputElement;
+
+            fireEvent.input(input, {
+                target: { value: address },
+            });
+
+            await waitFor(() => {
+                expect(signals.addressValid()).toEqual(false);
+                expect(input.className).toContain("invalid");
+            });
         },
     );
 

--- a/tests/components/AddressInput.spec.tsx
+++ b/tests/components/AddressInput.spec.tsx
@@ -6,7 +6,7 @@ import AddressInput from "../../src/components/AddressInput";
 import InvoiceInput from "../../src/components/InvoiceInput";
 import { config as runtimeConfig } from "../../src/config";
 import { config as mainnetConfig } from "../../src/configs/mainnet";
-import { BTC, LBTC, LN } from "../../src/consts/Assets";
+import { BTC, LBTC, LN, TBTC } from "../../src/consts/Assets";
 import Pair from "../../src/utils/Pair";
 import {
     TestComponent,
@@ -132,6 +132,7 @@ describe("AddressInput", () => {
 
     test.each`
         asset           | address
+        ${TBTC}         | ${runtimeConfig.assets!.TBTC.token!.address}
         ${"USDC-SOL"}   | ${"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"}
         ${"USDT0-SOL"}  | ${"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"}
         ${"USDT0-SOL"}  | ${"Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"}

--- a/tests/context/Create.spec.tsx
+++ b/tests/context/Create.spec.tsx
@@ -1,7 +1,8 @@
-import { render } from "@solidjs/testing-library";
+import { render, waitFor } from "@solidjs/testing-library";
 
+import { config as runtimeConfig } from "../../src/config";
 import type * as ConfigModule from "../../src/config";
-import { BTC, LBTC, LN, RBTC } from "../../src/consts/Assets";
+import { BTC, LBTC, LN, RBTC, USDC, USDT0 } from "../../src/consts/Assets";
 import { SwapType } from "../../src/consts/Enums";
 import Pair from "../../src/utils/Pair";
 import {
@@ -183,4 +184,23 @@ describe("signals", () => {
         expect(signals.addressValid()).toEqual(false);
         expect(signals.valid()).toEqual(false);
     });
+
+    test.each`
+        receiveAsset | address
+        ${USDC}      | ${runtimeConfig.assets!.USDC.token!.address}
+        ${USDT0}     | ${runtimeConfig.assets!.USDC.token!.address}
+    `(
+        "should mark known stablecoin token addresses invalid",
+        async ({ receiveAsset, address }) => {
+            render(() => <TestComponent />, { wrapper: contextWrapper });
+
+            setPairAssets(LN, receiveAsset);
+            signals.setOnchainAddress(address);
+            signals.setAddressValid(true);
+
+            await waitFor(() => {
+                expect(signals.addressValid()).toEqual(false);
+            });
+        },
+    );
 });

--- a/tests/context/Create.spec.tsx
+++ b/tests/context/Create.spec.tsx
@@ -2,7 +2,15 @@ import { render, waitFor } from "@solidjs/testing-library";
 
 import { config as runtimeConfig } from "../../src/config";
 import type * as ConfigModule from "../../src/config";
-import { BTC, LBTC, LN, RBTC, USDC, USDT0 } from "../../src/consts/Assets";
+import {
+    BTC,
+    LBTC,
+    LN,
+    RBTC,
+    TBTC,
+    USDC,
+    USDT0,
+} from "../../src/consts/Assets";
 import { SwapType } from "../../src/consts/Enums";
 import Pair from "../../src/utils/Pair";
 import {
@@ -187,10 +195,11 @@ describe("signals", () => {
 
     test.each`
         receiveAsset | address
+        ${TBTC}      | ${runtimeConfig.assets!.TBTC.token!.address}
         ${USDC}      | ${runtimeConfig.assets!.USDC.token!.address}
         ${USDT0}     | ${runtimeConfig.assets!.USDC.token!.address}
     `(
-        "should mark known stablecoin token addresses invalid",
+        "should mark known token addresses invalid",
         async ({ receiveAsset, address }) => {
             render(() => <TestComponent />, { wrapper: contextWrapper });
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -145,6 +145,7 @@ vi.mock("ethers", () => {
         getAddress: (value: string) => value,
         getBytes,
         id: (value: string) => keccak256(toBytes(value)),
+        isAddress: (value: string) => /^0x[0-9a-fA-F]{40}$/.test(value),
         keccak256: vi.fn((value: string) => value),
         solidityPacked,
         zeroPadValue,

--- a/tests/utils/knownTokenAddresses.spec.ts
+++ b/tests/utils/knownTokenAddresses.spec.ts
@@ -1,7 +1,7 @@
 import { config as runtimeConfig } from "../../src/config";
 import { config as mainnetConfig } from "../../src/configs/mainnet";
-import { BTC, USDC, USDT0 } from "../../src/consts/Assets";
-import { isKnownStablecoinTokenAddress } from "../../src/utils/knownTokenAddresses";
+import { BTC, RBTC, TBTC, USDC, USDT0 } from "../../src/consts/Assets";
+import { isKnownTokenAddress } from "../../src/utils/knownTokenAddresses";
 
 const originalAssets = structuredClone(runtimeConfig.assets ?? {});
 
@@ -18,9 +18,10 @@ afterAll(() => {
     runtimeConfig.assets = originalAssets;
 });
 
-describe("known stablecoin token addresses", () => {
+describe("known token addresses", () => {
     test.each`
         asset           | tokenAddress
+        ${TBTC}         | ${"0x6c84a8f1c29108F47a79964b5Fe888D4f4D0dE40"}
         ${USDC}         | ${"0xAF88D065E77C8CC2239327C5EDB3A432268E5831"}
         ${USDT0}        | ${"0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9"}
         ${"USDC-SOL"}   | ${"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"}
@@ -29,43 +30,56 @@ describe("known stablecoin token addresses", () => {
     `(
         "matches $asset token address $tokenAddress",
         ({ asset, tokenAddress }) => {
-            expect(isKnownStablecoinTokenAddress(asset, tokenAddress)).toBe(
-                true,
-            );
+            expect(isKnownTokenAddress(asset, tokenAddress)).toBe(true);
         },
     );
 
-    test("matches a different stablecoin's token address", () => {
+    test("matches a different token address", () => {
         expect(
-            isKnownStablecoinTokenAddress(
+            isKnownTokenAddress(
                 "USDT0-SOL",
                 runtimeConfig.assets!["USDC-SOL"].token!.address,
             ),
         ).toBe(true);
     });
 
-    test("matches another configured token address for the same stablecoin", () => {
+    test("matches another configured token address for the same asset", () => {
         expect(
-            isKnownStablecoinTokenAddress(
+            isKnownTokenAddress(
                 "USDC-SOL",
                 runtimeConfig.assets!.USDC.token!.address,
             ),
         ).toBe(true);
     });
 
+    test("does not lowercase case-sensitive token addresses", () => {
+        expect(
+            isKnownTokenAddress(
+                "USDT0-TRON",
+                runtimeConfig.assets![
+                    "USDT0-TRON"
+                ].token!.address.toLowerCase(),
+            ),
+        ).toBe(false);
+    });
+
     test("does not match regular addresses", () => {
         expect(
-            isKnownStablecoinTokenAddress(
+            isKnownTokenAddress(
                 USDC,
                 "0x1000000000000000000000000000000000000000",
             ),
         ).toBe(false);
     });
 
-    test("ignores assets without token config", () => {
+    test.each`
+        asset
+        ${BTC}
+        ${RBTC}
+    `("ignores non-ERC20 asset $asset", ({ asset }) => {
         expect(
-            isKnownStablecoinTokenAddress(
-                BTC,
+            isKnownTokenAddress(
+                asset,
                 runtimeConfig.assets!.USDC.token!.address,
             ),
         ).toBe(false);

--- a/tests/utils/knownTokenAddresses.spec.ts
+++ b/tests/utils/knownTokenAddresses.spec.ts
@@ -1,0 +1,73 @@
+import { config as runtimeConfig } from "../../src/config";
+import { config as mainnetConfig } from "../../src/configs/mainnet";
+import { BTC, USDC, USDT0 } from "../../src/consts/Assets";
+import { isKnownStablecoinTokenAddress } from "../../src/utils/knownTokenAddresses";
+
+const originalAssets = structuredClone(runtimeConfig.assets ?? {});
+
+beforeAll(() => {
+    runtimeConfig.assets = {
+        ...runtimeConfig.assets,
+        "USDC-SOL": structuredClone(mainnetConfig.assets!["USDC-SOL"]),
+        "USDT0-SOL": structuredClone(mainnetConfig.assets!["USDT0-SOL"]),
+        "USDT0-TRON": structuredClone(mainnetConfig.assets!["USDT0-TRON"]),
+    };
+});
+
+afterAll(() => {
+    runtimeConfig.assets = originalAssets;
+});
+
+describe("known stablecoin token addresses", () => {
+    test.each`
+        asset           | tokenAddress
+        ${USDC}         | ${"0xAF88D065E77C8CC2239327C5EDB3A432268E5831"}
+        ${USDT0}        | ${"0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9"}
+        ${"USDC-SOL"}   | ${"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"}
+        ${"USDT0-SOL"}  | ${"Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"}
+        ${"USDT0-TRON"} | ${"TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"}
+    `(
+        "matches $asset token address $tokenAddress",
+        ({ asset, tokenAddress }) => {
+            expect(isKnownStablecoinTokenAddress(asset, tokenAddress)).toBe(
+                true,
+            );
+        },
+    );
+
+    test("matches a different stablecoin's token address", () => {
+        expect(
+            isKnownStablecoinTokenAddress(
+                "USDT0-SOL",
+                runtimeConfig.assets!["USDC-SOL"].token!.address,
+            ),
+        ).toBe(true);
+    });
+
+    test("matches another configured token address for the same stablecoin", () => {
+        expect(
+            isKnownStablecoinTokenAddress(
+                "USDC-SOL",
+                runtimeConfig.assets!.USDC.token!.address,
+            ),
+        ).toBe(true);
+    });
+
+    test("does not match regular addresses", () => {
+        expect(
+            isKnownStablecoinTokenAddress(
+                USDC,
+                "0x1000000000000000000000000000000000000000",
+            ),
+        ).toBe(false);
+    });
+
+    test("ignores assets without token config", () => {
+        expect(
+            isKnownStablecoinTokenAddress(
+                BTC,
+                runtimeConfig.assets!.USDC.token!.address,
+            ),
+        ).toBe(false);
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Known token addresses are now detected and rejected when used as destination addresses, preventing invalid operations.
  * Improved address validation consistency across address input components and swap creation flows.

* **Refactor**
  * Address validation logic has been centralized through helper functions for more consistent error handling across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->