### PR TITLE
fix: skip getAddress on CCTP source TokenMessenger

### DIFF
--- a/src/components/SendToBridge.tsx
+++ b/src/components/SendToBridge.tsx
@@ -6,7 +6,7 @@ import {
     createResource,
     createSignal,
 } from "solid-js";
-import type { Address } from "viem";
+import { type Address, getAddress } from "viem";
 
 import { config } from "../config";
 import { BridgeKind, CctpReceiveMode, NetworkTransport } from "../configs/base";
@@ -63,7 +63,7 @@ const SendToBridge = (props: {
     >(undefined);
     const [needsApproval, setNeedsApproval] = createSignal<boolean>(false);
     const [approvalTarget, setApprovalTarget] = createSignal<
-        Address | undefined
+        string | undefined
     >(undefined);
     const txSent = createMemo(() => {
         return swap()?.bridge?.txHash;
@@ -155,7 +155,7 @@ const SendToBridge = (props: {
         }: {
             trackRequiredTokenBalance?: boolean;
             needsApproval?: boolean;
-            approvalTarget?: Address;
+            approvalTarget?: string;
         } = {},
     ) => {
         const hasEnoughTokenBalance = balance >= requiredTokenAmount;
@@ -220,11 +220,14 @@ const SendToBridge = (props: {
                 msgFee,
             );
 
+        const executionContractAddress = getAddress(
+            directSendTarget.executionContract.address,
+        );
         let needsUpdatedApproval = false;
         if (needsUserApproval) {
             const allowance = await tokenContract.read.allowance([
                 connectedSigner.address,
-                directSendTarget.executionContract.address,
+                executionContractAddress,
             ]);
 
             needsUpdatedApproval = allowance < requiredTokenAmount;
@@ -243,7 +246,7 @@ const SendToBridge = (props: {
             {
                 needsApproval: needsUpdatedApproval,
                 approvalTarget: needsUserApproval
-                    ? directSendTarget.executionContract.address
+                    ? executionContractAddress
                     : undefined,
             },
         );
@@ -313,7 +316,7 @@ const SendToBridge = (props: {
         const approvalRequired =
             (await oftBridgeInstance.approvalRequired?.()) ?? false;
         let needsUpdatedApproval = false;
-        let spenderAddress: Address | undefined;
+        let spenderAddress: string | undefined;
 
         if (approvalRequired) {
             spenderAddress = (await bridgeDriver().getContract(bridgeRoute))
@@ -699,7 +702,9 @@ const SendToBridge = (props: {
                                             props.amount
                                         }
                                         setNeedsApproval={setNeedsApproval}
-                                        approvalTarget={approvalTarget()}
+                                        approvalTarget={
+                                            approvalTarget() as Address
+                                        }
                                         resetAllowanceFirst={true}
                                     />
                                 )

--- a/src/utils/bridge/CctpBridgeDriver.ts
+++ b/src/utils/bridge/CctpBridgeDriver.ts
@@ -306,7 +306,7 @@ export class CctpBridgeDriver extends BridgeDriver {
         const sourceConfig = this.requireCctpConfig(route.sourceAsset);
         return Promise.resolve({
             name: "CCTP",
-            address: getAddress(sourceConfig.tokenMessenger),
+            address: sourceConfig.tokenMessenger,
             explorer: "",
         });
     };

--- a/src/utils/oft/registry.ts
+++ b/src/utils/oft/registry.ts
@@ -1,5 +1,4 @@
 import log from "loglevel";
-import type { Address } from "viem";
 
 import { config } from "../../config";
 import { Usdt0Kind } from "../../configs/base";
@@ -10,7 +9,7 @@ import type { OftRoute } from "./types";
 
 export type OftContract = {
     name: string;
-    address: Address;
+    address: string;
     explorer: string;
 };
 

--- a/tests/utils/cctpBridgeDriver.spec.ts
+++ b/tests/utils/cctpBridgeDriver.spec.ts
@@ -437,6 +437,27 @@ describe("CctpBridgeDriver", () => {
         });
     });
 
+    test("getContract passes Solana source TokenMessenger through unchanged", async () => {
+        const requireSolanaCctpBridge = () => {
+            const bridge = mainnetConfig.assets!["USDC-SOL"].bridge;
+            if (bridge?.kind !== BridgeKind.Cctp) {
+                throw new Error("USDC-SOL is not configured as CCTP");
+            }
+            return bridge;
+        };
+        const solanaTokenMessenger =
+            requireSolanaCctpBridge().cctp.tokenMessenger;
+
+        expect(solanaTokenMessenger).not.toMatch(/^0x/);
+
+        await expect(
+            driver.getContract(solanaSourceRoute),
+        ).resolves.toMatchObject({
+            name: "CCTP",
+            address: solanaTokenMessenger,
+        });
+    });
+
     test("encodeRouterExecuteData encodes executeCctp with the CctpData", async () => {
         const recipient = "0x1234567890123456789012345678901234567890";
         const contract = await driver.getQuotedContract(route);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal address type handling for bridge operations and OFT contracts to ensure consistent normalization and validation across different blockchain networks.

* **Tests**
  * Added test coverage for bridge contract address handling on Solana routes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoltzExchange/boltz-web-app/pull/1450)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->