### PR TITLE
feat: recover pending CCTP bridge sends

### DIFF
--- a/packages/boltz-swaps/src/bridge/CctpBridgeDriver.ts
+++ b/packages/boltz-swaps/src/bridge/CctpBridgeDriver.ts
@@ -544,10 +544,10 @@ export class CctpBridgeDriver extends BridgeDriver {
             );
         }
 
-        void args.msgFee;
-        void args.refundAddress;
         return await (args.contract as SolanaCctpTransportClient).send(
             args.sendParam as CctpSendParam,
+            args.msgFee,
+            args.refundAddress,
         );
     };
 

--- a/packages/boltz-swaps/src/bridge/index.ts
+++ b/packages/boltz-swaps/src/bridge/index.ts
@@ -10,7 +10,9 @@ export { BridgeRegistry, bridgeRegistry } from "./registry.ts";
 export {
     PendingBridgeSendRecoveryStatus,
     recoverPendingBridgeSend,
+    recoverPendingEvmCctpSend,
     recoverPendingEvmOftSend,
+    recoverPendingSolanaCctpSend,
     recoverPendingSolanaOftSend,
     recoverPendingTronOftSend,
 } from "./pendingSend.ts";
@@ -24,8 +26,12 @@ export { vFromSignature } from "./signature.ts";
 export type { BridgeDetails, SolanaDetails } from "../types.ts";
 export type {
     PendingBridgeSend,
+    PendingBridgeSendCallbacks,
     PendingBridgeSendRecoveryResult,
+    PendingEvmBridgeSend,
+    PendingEvmCctpBridgeSend,
     PendingEvmOftBridgeSend,
+    PendingSolanaCctpBridgeSend,
     PendingSolanaOftBridgeSend,
     PendingTronOftBridgeSend,
 } from "./pendingSend.ts";

--- a/packages/boltz-swaps/src/bridge/pendingSend.ts
+++ b/packages/boltz-swaps/src/bridge/pendingSend.ts
@@ -3,10 +3,14 @@ import {
     type Log,
     type PublicClient,
     decodeEventLog,
+    decodeFunctionData,
     getAbiItem,
     getAddress,
 } from "viem";
 
+import { tokenMessengerV2Abi } from "../cctp/directSend.ts";
+import { cctpMessageSentTopic } from "../cctp/events.ts";
+import { cctpEmptyHookData } from "../cctp/evm.ts";
 import { getLogger } from "../logger.ts";
 import { oftAbi } from "../oft/evm.ts";
 import { getSolanaConnection } from "../solana/index.ts";
@@ -28,8 +32,30 @@ export type PendingEvmOftBridgeSend = {
     calldata: string;
 };
 
+export type PendingEvmCctpBridgeSend = {
+    kind: PendingBridgeSendKind.EvmCctp;
+    createdAt: number;
+    sender: string;
+    fromNonce: number;
+    fromBlock: number;
+    tokenMessenger: string;
+    messageTransmitter: string;
+    calldata: string;
+};
+
+export type PendingEvmBridgeSend =
+    | PendingEvmOftBridgeSend
+    | PendingEvmCctpBridgeSend;
+
 export type PendingSolanaOftBridgeSend = {
     kind: PendingBridgeSendKind.SolanaOft;
+    sourceAsset: string;
+    lastValidBlockHeight: number;
+    signature: string;
+};
+
+export type PendingSolanaCctpBridgeSend = {
+    kind: PendingBridgeSendKind.SolanaCctp;
     sourceAsset: string;
     lastValidBlockHeight: number;
     signature: string;
@@ -44,8 +70,14 @@ export type PendingTronOftBridgeSend = {
 
 export type PendingBridgeSend =
     | PendingEvmOftBridgeSend
+    | PendingEvmCctpBridgeSend
     | PendingSolanaOftBridgeSend
+    | PendingSolanaCctpBridgeSend
     | PendingTronOftBridgeSend;
+
+export type PendingBridgeSendCallbacks = {
+    persist: (pending: PendingBridgeSend) => Promise<void>;
+};
 
 export enum PendingBridgeSendRecoveryStatus {
     Recovered = "recovered",
@@ -62,6 +94,10 @@ export type PendingBridgeSendRecoveryResult =
     | { status: PendingBridgeSendRecoveryStatus.Pending };
 
 const oftSentEvent = getAbiItem({ abi: oftAbi, name: "OFTSent" });
+const cctpDepositForBurnEvent = getAbiItem({
+    abi: tokenMessengerV2Abi,
+    name: "DepositForBurn",
+});
 
 const evmSendRecoveryTimeoutMs = 120_000;
 
@@ -69,6 +105,34 @@ const sameEvmString = (left: string | null | undefined, right: string) =>
     left !== null &&
     left !== undefined &&
     left.toLowerCase() === right.toLowerCase();
+
+const decodeCctpPendingSendCalldata = (calldata: string) => {
+    const decoded = decodeFunctionData({
+        abi: tokenMessengerV2Abi,
+        data: calldata as Hex,
+    });
+    const [
+        amount,
+        destinationDomain,
+        mintRecipient,
+        burnToken,
+        destinationCaller,
+        maxFee,
+        minFinalityThreshold,
+        hookData = cctpEmptyHookData,
+    ] = decoded.args;
+
+    return {
+        amount,
+        destinationDomain,
+        mintRecipient,
+        burnToken,
+        destinationCaller,
+        maxFee,
+        minFinalityThreshold,
+        hookData,
+    };
+};
 
 const isOftSentLog = (event: Log, oftContractAddress: string) => {
     if (!sameEvmString(event.address, oftContractAddress)) {
@@ -85,6 +149,83 @@ const isOftSentLog = (event: Log, oftContractAddress: string) => {
     } catch {
         return false;
     }
+};
+
+const hasCctpMessageSentLog = (
+    receipt: { logs: ReadonlyArray<Log> },
+    messageTransmitter: string,
+) =>
+    receipt.logs.some(
+        (entry) =>
+            sameAddress(entry.address, messageTransmitter) &&
+            entry.topics[0]?.toLowerCase() === cctpMessageSentTopic,
+    );
+
+const isMatchingCctpDepositForBurn = (
+    event: Log,
+    pendingSend: PendingEvmCctpBridgeSend,
+    expected: ReturnType<typeof decodeCctpPendingSendCalldata>,
+) => {
+    if (!sameAddress(event.address, pendingSend.tokenMessenger)) {
+        return false;
+    }
+
+    try {
+        const decoded = decodeEventLog({
+            abi: tokenMessengerV2Abi,
+            eventName: "DepositForBurn",
+            data: event.data as Hex,
+            topics: event.topics as [Hex, ...Hex[]],
+        });
+        if (decoded.eventName !== "DepositForBurn") {
+            return false;
+        }
+
+        const args = decoded.args;
+        return (
+            sameAddress(args.burnToken, expected.burnToken) &&
+            sameAddress(args.depositor, pendingSend.sender) &&
+            args.amount === expected.amount &&
+            args.destinationDomain === expected.destinationDomain &&
+            sameHex(args.mintRecipient, expected.mintRecipient) &&
+            sameHex(args.destinationCaller, expected.destinationCaller) &&
+            args.maxFee === expected.maxFee &&
+            args.minFinalityThreshold === expected.minFinalityThreshold &&
+            sameHex(args.hookData, expected.hookData)
+        );
+    } catch {
+        return false;
+    }
+};
+
+const getPendingEvmSendTimeoutResult = async (
+    pendingSend: PendingEvmBridgeSend,
+    provider: PublicClient,
+    label: string,
+): Promise<PendingBridgeSendRecoveryResult> => {
+    const [latestNonce, pendingNonce] = await Promise.all([
+        provider.getTransactionCount({
+            address: getAddress(pendingSend.sender),
+            blockTag: "latest",
+        }),
+        provider.getTransactionCount({
+            address: getAddress(pendingSend.sender),
+            blockTag: "pending",
+        }),
+    ]);
+    const age = Date.now() - pendingSend.createdAt;
+    if (age > evmSendRecoveryTimeoutMs) {
+        getLogger().warn(`Pending EVM ${label} send recovery timed out`, {
+            sender: pendingSend.sender,
+            fromNonce: pendingSend.fromNonce,
+            fromBlock: pendingSend.fromBlock,
+            latestNonce,
+            pendingNonce,
+        });
+        return { status: PendingBridgeSendRecoveryStatus.Failed };
+    }
+
+    return { status: PendingBridgeSendRecoveryStatus.Pending };
 };
 
 export const recoverPendingEvmOftSend = async (
@@ -158,32 +299,94 @@ export const recoverPendingEvmOftSend = async (
         return { status: PendingBridgeSendRecoveryStatus.Pending };
     }
 
-    const [latestNonce, pendingNonce] = await Promise.all([
-        provider.getTransactionCount({
-            address: getAddress(pendingSend.sender),
-            blockTag: "latest",
-        }),
-        provider.getTransactionCount({
-            address: getAddress(pendingSend.sender),
-            blockTag: "pending",
-        }),
-    ]);
-    const age = Date.now() - pendingSend.createdAt;
-    if (age > evmSendRecoveryTimeoutMs) {
-        log.warn("Pending EVM OFT send recovery timed out", {
-            sender: pendingSend.sender,
-            fromNonce: pendingSend.fromNonce,
-            latestNonce,
-            pendingNonce,
-        });
-        return { status: PendingBridgeSendRecoveryStatus.Failed };
-    }
-
-    return { status: PendingBridgeSendRecoveryStatus.Pending };
+    return await getPendingEvmSendTimeoutResult(pendingSend, provider, "OFT");
 };
 
-export const recoverPendingSolanaOftSend = async (
-    pendingSend: PendingSolanaOftBridgeSend,
+export const recoverPendingEvmCctpSend = async (
+    pendingSend: PendingEvmCctpBridgeSend,
+    provider: PublicClient,
+): Promise<PendingBridgeSendRecoveryResult> => {
+    const log = getLogger();
+    const expected = decodeCctpPendingSendCalldata(pendingSend.calldata);
+    const logs = await provider.getLogs({
+        address: getAddress(pendingSend.tokenMessenger),
+        fromBlock: BigInt(pendingSend.fromBlock),
+        toBlock: "latest",
+        event: cctpDepositForBurnEvent,
+        args: {
+            burnToken: getAddress(expected.burnToken),
+            depositor: getAddress(pendingSend.sender),
+            minFinalityThreshold: expected.minFinalityThreshold,
+        },
+    });
+    log.info("Checking pending EVM CCTP send", {
+        sender: pendingSend.sender,
+        fromNonce: pendingSend.fromNonce,
+        fromBlock: pendingSend.fromBlock,
+        logs: logs.length,
+    });
+
+    const matches = new Set<string>();
+    for (const event of logs) {
+        if (
+            event.transactionHash === null ||
+            !isMatchingCctpDepositForBurn(event, pendingSend, expected)
+        ) {
+            continue;
+        }
+
+        const transactionHash = event.transactionHash;
+        const [transaction, receipt] = await Promise.all([
+            provider.getTransaction({ hash: transactionHash }),
+            provider.getTransactionReceipt({ hash: transactionHash }),
+        ]);
+        if (
+            transaction === null ||
+            receipt === null ||
+            receipt.status !== "success"
+        ) {
+            continue;
+        }
+
+        if (
+            transaction.nonce >= pendingSend.fromNonce &&
+            sameAddress(transaction.from, pendingSend.sender) &&
+            sameAddress(transaction.to, pendingSend.tokenMessenger) &&
+            sameHex(transaction.input, pendingSend.calldata) &&
+            hasCctpMessageSentLog(receipt, pendingSend.messageTransmitter)
+        ) {
+            matches.add(transactionHash);
+        }
+    }
+    const matchedTransactionHashes = [...matches];
+
+    if (matchedTransactionHashes.length === 1) {
+        log.info("Recovered pending EVM CCTP send", {
+            sender: pendingSend.sender,
+            fromNonce: pendingSend.fromNonce,
+            transactionHash: matchedTransactionHashes[0],
+        });
+        return {
+            status: PendingBridgeSendRecoveryStatus.Recovered,
+            transactionHash: matchedTransactionHashes[0],
+        };
+    }
+
+    if (matchedTransactionHashes.length > 1) {
+        log.warn("Found multiple matching pending CCTP bridge sends", {
+            sender: pendingSend.sender,
+            fromNonce: pendingSend.fromNonce,
+            matches: matchedTransactionHashes,
+        });
+        return { status: PendingBridgeSendRecoveryStatus.Pending };
+    }
+
+    return await getPendingEvmSendTimeoutResult(pendingSend, provider, "CCTP");
+};
+
+const recoverPendingSolanaSend = async (
+    pendingSend: PendingSolanaOftBridgeSend | PendingSolanaCctpBridgeSend,
+    label: string,
 ): Promise<PendingBridgeSendRecoveryResult> => {
     const log = getLogger();
     const connection = await getSolanaConnection(pendingSend.sourceAsset);
@@ -194,7 +397,7 @@ export const recoverPendingSolanaOftSend = async (
     ).value[0];
     if (status !== null) {
         if (status.err !== null) {
-            log.warn("Pending Solana OFT send failed on-chain", {
+            log.warn(`Pending Solana ${label} send failed on-chain`, {
                 sourceAsset: pendingSend.sourceAsset,
                 signature: pendingSend.signature,
                 error: status.err,
@@ -202,7 +405,7 @@ export const recoverPendingSolanaOftSend = async (
             return { status: PendingBridgeSendRecoveryStatus.Failed };
         }
 
-        log.info("Recovered pending Solana OFT send", {
+        log.info(`Recovered pending Solana ${label} send`, {
             sourceAsset: pendingSend.sourceAsset,
             signature: pendingSend.signature,
         });
@@ -214,7 +417,7 @@ export const recoverPendingSolanaOftSend = async (
 
     const currentBlockHeight = await connection.getBlockHeight("confirmed");
     if (currentBlockHeight > pendingSend.lastValidBlockHeight) {
-        log.warn("Pending Solana OFT send blockhash expired", {
+        log.warn(`Pending Solana ${label} send blockhash expired`, {
             sourceAsset: pendingSend.sourceAsset,
             signature: pendingSend.signature,
             currentBlockHeight,
@@ -225,6 +428,16 @@ export const recoverPendingSolanaOftSend = async (
 
     return { status: PendingBridgeSendRecoveryStatus.Pending };
 };
+
+export const recoverPendingSolanaOftSend = async (
+    pendingSend: PendingSolanaOftBridgeSend,
+): Promise<PendingBridgeSendRecoveryResult> =>
+    await recoverPendingSolanaSend(pendingSend, "OFT");
+
+export const recoverPendingSolanaCctpSend = async (
+    pendingSend: PendingSolanaCctpBridgeSend,
+): Promise<PendingBridgeSendRecoveryResult> =>
+    await recoverPendingSolanaSend(pendingSend, "CCTP");
 
 export const recoverPendingTronOftSend = async (
     pendingSend: PendingTronOftBridgeSend,
@@ -285,8 +498,19 @@ export const recoverPendingBridgeSend = async (
             }
             return await recoverPendingEvmOftSend(pendingSend, provider);
 
+        case PendingBridgeSendKind.EvmCctp:
+            if (provider === undefined) {
+                throw new Error(
+                    "EVM pending bridge send recovery needs an RPC provider",
+                );
+            }
+            return await recoverPendingEvmCctpSend(pendingSend, provider);
+
         case PendingBridgeSendKind.SolanaOft:
             return await recoverPendingSolanaOftSend(pendingSend);
+
+        case PendingBridgeSendKind.SolanaCctp:
+            return await recoverPendingSolanaCctpSend(pendingSend);
 
         case PendingBridgeSendKind.TronOft:
             return await recoverPendingTronOftSend(pendingSend);

--- a/packages/boltz-swaps/src/bridge/pendingSend.ts
+++ b/packages/boltz-swaps/src/bridge/pendingSend.ts
@@ -152,12 +152,12 @@ const isOftSentLog = (event: Log, oftContractAddress: string) => {
 };
 
 const hasCctpMessageSentLog = (
-    receipt: { logs: ReadonlyArray<Log> },
+    logs: ReadonlyArray<Log>,
     messageTransmitter: string,
 ) =>
-    receipt.logs.some(
+    logs.some(
         (entry) =>
-            sameAddress(entry.address, messageTransmitter) &&
+            sameEvmString(entry.address, messageTransmitter) &&
             entry.topics[0]?.toLowerCase() === cctpMessageSentTopic,
     );
 
@@ -166,7 +166,7 @@ const isMatchingCctpDepositForBurn = (
     pendingSend: PendingEvmCctpBridgeSend,
     expected: ReturnType<typeof decodeCctpPendingSendCalldata>,
 ) => {
-    if (!sameAddress(event.address, pendingSend.tokenMessenger)) {
+    if (!sameEvmString(event.address, pendingSend.tokenMessenger)) {
         return false;
     }
 
@@ -183,15 +183,15 @@ const isMatchingCctpDepositForBurn = (
 
         const args = decoded.args;
         return (
-            sameAddress(args.burnToken, expected.burnToken) &&
-            sameAddress(args.depositor, pendingSend.sender) &&
+            sameEvmString(args.burnToken, expected.burnToken) &&
+            sameEvmString(args.depositor, pendingSend.sender) &&
             args.amount === expected.amount &&
             args.destinationDomain === expected.destinationDomain &&
-            sameHex(args.mintRecipient, expected.mintRecipient) &&
-            sameHex(args.destinationCaller, expected.destinationCaller) &&
+            sameEvmString(args.mintRecipient, expected.mintRecipient) &&
+            sameEvmString(args.destinationCaller, expected.destinationCaller) &&
             args.maxFee === expected.maxFee &&
             args.minFinalityThreshold === expected.minFinalityThreshold &&
-            sameHex(args.hookData, expected.hookData)
+            sameEvmString(args.hookData, expected.hookData)
         );
     } catch {
         return false;
@@ -350,10 +350,10 @@ export const recoverPendingEvmCctpSend = async (
 
         if (
             transaction.nonce >= pendingSend.fromNonce &&
-            sameAddress(transaction.from, pendingSend.sender) &&
-            sameAddress(transaction.to, pendingSend.tokenMessenger) &&
-            sameHex(transaction.input, pendingSend.calldata) &&
-            hasCctpMessageSentLog(receipt, pendingSend.messageTransmitter)
+            sameEvmString(transaction.from, pendingSend.sender) &&
+            sameEvmString(transaction.to, pendingSend.tokenMessenger) &&
+            sameEvmString(transaction.input, pendingSend.calldata) &&
+            hasCctpMessageSentLog(receipt.logs, pendingSend.messageTransmitter)
         ) {
             matches.add(transactionHash);
         }

--- a/packages/boltz-swaps/src/bridge/types.ts
+++ b/packages/boltz-swaps/src/bridge/types.ts
@@ -31,7 +31,9 @@ export type { BridgeTransaction };
 export type { BridgeRoute };
 
 export enum PendingBridgeSendKind {
+    EvmCctp = "evm-cctp",
     EvmOft = "evm-oft",
+    SolanaCctp = "solana-cctp",
     SolanaOft = "solana-oft",
     TronOft = "tron-oft",
 }

--- a/packages/boltz-swaps/src/cctp/directSend.ts
+++ b/packages/boltz-swaps/src/cctp/directSend.ts
@@ -1,13 +1,20 @@
 import { hex } from "@scure/base";
-import { type Address, getAddress, getContract, parseAbi } from "viem";
+import {
+    type Address,
+    encodeFunctionData,
+    getAddress,
+    getContract,
+    parseAbi,
+} from "viem";
 
 import { getTokenAddress } from "../config.ts";
 import type { Signer } from "../interfaces/signer.ts";
 import type { CctpSendParam } from "./types.ts";
 
-const tokenMessengerV2Abi = parseAbi([
+export const tokenMessengerV2Abi = parseAbi([
     "function depositForBurn(uint256 amount, uint32 destinationDomain, bytes32 mintRecipient, address burnToken, bytes32 destinationCaller, uint256 maxFee, uint32 minFinalityThreshold) external returns (uint64 nonce)",
     "function depositForBurnWithHook(uint256 amount, uint32 destinationDomain, bytes32 mintRecipient, address burnToken, bytes32 destinationCaller, uint256 maxFee, uint32 minFinalityThreshold, bytes hookData) external returns (uint64 nonce)",
+    "event DepositForBurn(address indexed burnToken, uint256 amount, address indexed depositor, bytes32 mintRecipient, uint32 destinationDomain, bytes32 destinationTokenMessenger, bytes32 destinationCaller, uint256 maxFee, uint32 indexed minFinalityThreshold, bytes hookData)",
 ]);
 
 // Shape is compatible with OftDirectSendTarget for the subset used by
@@ -50,6 +57,57 @@ const isEmptyHookData = (hookData: string): boolean => {
     }
 };
 
+const getDepositForBurnArgs = (
+    target: CctpDirectSendTarget,
+    sendParam: CctpSendParam,
+) =>
+    [
+        sendParam.amount,
+        sendParam.destinationDomain,
+        sendParam.mintRecipient,
+        getAddress(target.burnToken),
+        sendParam.destinationCaller,
+        sendParam.maxFee,
+        sendParam.minFinalityThreshold,
+    ] as const;
+
+const getDepositForBurnWithHookArgs = (
+    target: CctpDirectSendTarget,
+    sendParam: CctpSendParam,
+) => [...getDepositForBurnArgs(target, sendParam), sendParam.hookData] as const;
+
+export const populateCctpDirectSendTransaction = ({
+    target,
+    sendParam,
+}: {
+    target: CctpDirectSendTarget;
+    sendParam: CctpSendParam;
+}) => {
+    const address = getAddress(target.executionContract.address);
+
+    if (isEmptyHookData(sendParam.hookData)) {
+        return {
+            to: address,
+            value: 0n,
+            data: encodeFunctionData({
+                abi: tokenMessengerV2Abi,
+                functionName: "depositForBurn",
+                args: getDepositForBurnArgs(target, sendParam),
+            }),
+        };
+    }
+
+    return {
+        to: address,
+        value: 0n,
+        data: encodeFunctionData({
+            abi: tokenMessengerV2Abi,
+            functionName: "depositForBurnWithHook",
+            args: getDepositForBurnWithHookArgs(target, sendParam),
+        }),
+    };
+};
+
 export const sendCctpDirect = async ({
     target,
     runner,
@@ -70,15 +128,7 @@ export const sendCctpDirect = async ({
     if (isEmptyHookData(sendParam.hookData)) {
         return {
             hash: await messenger.write.depositForBurn(
-                [
-                    sendParam.amount,
-                    sendParam.destinationDomain,
-                    sendParam.mintRecipient,
-                    getAddress(target.burnToken),
-                    sendParam.destinationCaller,
-                    sendParam.maxFee,
-                    sendParam.minFinalityThreshold,
-                ],
+                getDepositForBurnArgs(target, sendParam),
                 writeOptions,
             ),
         };
@@ -86,16 +136,7 @@ export const sendCctpDirect = async ({
 
     return {
         hash: await messenger.write.depositForBurnWithHook(
-            [
-                sendParam.amount,
-                sendParam.destinationDomain,
-                sendParam.mintRecipient,
-                getAddress(target.burnToken),
-                sendParam.destinationCaller,
-                sendParam.maxFee,
-                sendParam.minFinalityThreshold,
-                sendParam.hookData,
-            ],
+            getDepositForBurnWithHookArgs(target, sendParam),
             writeOptions,
         ),
     };

--- a/packages/boltz-swaps/src/cctp/solana.ts
+++ b/packages/boltz-swaps/src/cctp/solana.ts
@@ -1,8 +1,17 @@
 import type { Provider as SolanaWalletProvider } from "@reown/appkit-utils/solana";
-import { base64, hex } from "@scure/base";
-import type { Connection, TransactionInstruction } from "@solana/web3.js";
+import { base58, hex } from "@scure/base";
+import type {
+    Connection,
+    SendOptions,
+    Transaction,
+    TransactionInstruction,
+    VersionedTransaction,
+} from "@solana/web3.js";
 
+import type { PendingSolanaCctpBridgeSend } from "../bridge/pendingSend.ts";
+import { PendingBridgeSendKind } from "../bridge/types.ts";
 import { getAssetBridge, getBoltzSwapsConfig } from "../config.ts";
+import { formatError, isWalletRejectionError } from "../errors.ts";
 import { constructRequestOptions } from "../helper.ts";
 import { getLogger } from "../logger.ts";
 import {
@@ -21,7 +30,7 @@ import {
     NetworkTransport,
 } from "../types.ts";
 import { cctpEmptyHookData } from "./evm.ts";
-import type { CctpSendParam } from "./types.ts";
+import type { CctpSendOverrides, CctpSendParam } from "./types.ts";
 
 type SolanaCctpModules = Awaited<ReturnType<(typeof lazySolanaCctp)["get"]>>;
 
@@ -33,7 +42,12 @@ export type SolanaCctpConfig = {
 
 export type SolanaCctpTransportClient = {
     transport: NetworkTransport.Solana;
-    send: (sendParam: CctpSendParam) => Promise<BridgeTransaction>;
+    send: (
+        sendParam: CctpSendParam,
+        msgFee: [bigint, bigint],
+        refundAddress: string,
+        overrides?: CctpSendOverrides,
+    ) => Promise<BridgeTransaction>;
 };
 
 type Context = {
@@ -178,6 +192,22 @@ const createTransaction = async (
     };
 };
 
+const getSignedTransactionSignature = (
+    signedTransaction: Transaction | VersionedTransaction,
+): string => {
+    const signature = signedTransaction.signatures[0];
+    const bytes =
+        signature instanceof Uint8Array ? signature : signature?.signature;
+    if (
+        bytes === undefined ||
+        bytes === null ||
+        bytes.every((byte) => byte === 0)
+    ) {
+        throw new Error("Solana wallet did not return a transaction signature");
+    }
+    return base58.encode(bytes);
+};
+
 const createDepositForBurnInstruction = async (
     context: Context,
     sendParam: CctpSendParam,
@@ -280,6 +310,7 @@ const createDepositForBurnInstruction = async (
 const send = async (
     context: Context,
     sendParam: CctpSendParam,
+    overrides?: CctpSendOverrides,
 ): Promise<BridgeTransaction> => {
     const { modules, walletProvider } = context;
     if (walletProvider === undefined) {
@@ -372,20 +403,110 @@ const send = async (
         );
     }
 
-    try {
-        const signedTransaction =
-            await walletProvider.signTransaction(transaction);
-        signedTransaction.sign(signers);
-
-        const signature = await context.connection.sendEncodedTransaction(
-            base64.encode(signedTransaction.serialize()),
-            {
-                skipPreflight: true,
-                preflightCommitment: "confirmed",
-            },
+    const sendOptions: SendOptions = {
+        skipPreflight: true,
+        preflightCommitment: "confirmed",
+    };
+    const sendWithWallet = async (): Promise<BridgeTransaction> => {
+        transaction.sign(signers);
+        const signature = await walletProvider.signAndSendTransaction(
+            transaction,
+            sendOptions,
         );
         return {
             hash: signature,
+            details: {
+                solana: {
+                    blockhash: latestBlockhash.blockhash,
+                },
+            },
+        };
+    };
+
+    const signTransaction =
+        walletProvider.signTransaction?.bind(walletProvider);
+    if (signTransaction === undefined) {
+        getLogger().warn("Falling back to wallet-managed Solana CCTP send", {
+            sourceAsset: context.asset,
+            sender: signerAddress,
+            reason: "Connected Solana wallet does not support signing transactions without broadcasting",
+        });
+        return await sendWithWallet();
+    }
+
+    try {
+        let signature: string;
+        let serializedSignedTransaction: Uint8Array;
+        try {
+            const signedTransaction = await signTransaction(transaction);
+            signature = getSignedTransactionSignature(signedTransaction);
+            signedTransaction.sign(signers);
+            serializedSignedTransaction = signedTransaction.serialize();
+        } catch (error) {
+            if (isWalletRejectionError(error)) {
+                throw error;
+            }
+
+            getLogger().warn(
+                "Falling back to wallet-managed Solana CCTP send",
+                {
+                    sourceAsset: context.asset,
+                    sender: signerAddress,
+                    reason: formatError(error),
+                },
+            );
+            return await sendWithWallet();
+        }
+
+        const pendingSend: PendingSolanaCctpBridgeSend = {
+            kind: PendingBridgeSendKind.SolanaCctp,
+            sourceAsset: context.asset,
+            lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+            signature,
+        };
+        getLogger().info("Signed pending Solana CCTP send", {
+            sourceAsset: context.asset,
+            sender: signerAddress,
+            signature,
+        });
+
+        const encodedTransaction = Buffer.from(
+            serializedSignedTransaction,
+        ).toString("base64");
+
+        getLogger().info("Broadcasting pending Solana CCTP send...", {
+            sourceAsset: context.asset,
+            sender: signerAddress,
+            encodedTransaction,
+        });
+        const broadcastSignature =
+            await context.connection.sendEncodedTransaction(
+                encodedTransaction,
+                sendOptions,
+            );
+        await overrides?.pendingSendCallbacks?.persist(pendingSend);
+
+        if (broadcastSignature !== signature) {
+            getLogger().warn(
+                "Solana RPC returned a different broadcast signature",
+                {
+                    expected: signature,
+                    broadcastSignature,
+                },
+            );
+            await overrides?.pendingSendCallbacks?.persist({
+                ...pendingSend,
+                signature: broadcastSignature,
+            });
+        }
+        getLogger().info("Broadcast pending Solana CCTP send", {
+            sourceAsset: context.asset,
+            sender: signerAddress,
+            signature: broadcastSignature,
+        });
+
+        return {
+            hash: broadcastSignature,
             details: {
                 solana: {
                     blockhash: latestBlockhash.blockhash,
@@ -439,6 +560,7 @@ export const createSolanaCctpContract = (
 
     return {
         transport: NetworkTransport.Solana,
-        send: async (sendParam) => await send(await contextPromise, sendParam),
+        send: async (sendParam, _msgFee, _refundAddress, overrides) =>
+            await send(await contextPromise, sendParam, overrides),
     };
 };

--- a/packages/boltz-swaps/src/cctp/types.ts
+++ b/packages/boltz-swaps/src/cctp/types.ts
@@ -1,5 +1,7 @@
 import type { Hex } from "viem";
 
+import type { PendingBridgeSendCallbacks } from "../bridge/pendingSend.ts";
+
 // Mirrors the on-chain Router.CctpData struct (see Router.sol). Used for
 // router-mediated flows (`executeCctp`, `claimERC20ExecuteCctp`, `hashCctpData`).
 export type CctpData = {
@@ -21,4 +23,8 @@ export type CctpData = {
 // `toCctpData`.
 export type CctpSendParam = CctpData & {
     amount: bigint;
+};
+
+export type CctpSendOverrides = {
+    pendingSendCallbacks?: PendingBridgeSendCallbacks;
 };

--- a/packages/boltz-swaps/tests/cctp/solana-send.spec.ts
+++ b/packages/boltz-swaps/tests/cctp/solana-send.spec.ts
@@ -1,3 +1,5 @@
+import { base58 } from "@scure/base";
+import { PendingBridgeSendKind } from "boltz-swaps/bridge";
 import {
     type CctpSendParam,
     cctpEmptyHookData,
@@ -27,9 +29,15 @@ const h = vi.hoisted(() => ({
     ALLOCATED_RENT_PAYER_ADDR: "ALLOCATED_RENT_PAYER_ADDR",
     SOLBURN_URL: "https://solburn.example",
     getDepositForBurnSpy: undefined as ReturnType<typeof vi.fn> | undefined,
+    fakeConnection: undefined as
+        | {
+              getLatestBlockhash: ReturnType<typeof vi.fn>;
+              simulateTransaction: ReturnType<typeof vi.fn>;
+              sendEncodedTransaction: ReturnType<typeof vi.fn>;
+          }
+        | undefined,
     lastBuiltInstructions: [] as unknown[],
     lastSignedWith: [] as unknown[],
-    walletSigned: false,
 }));
 
 vi.mock("../../src/solana/lazy.ts", () => {
@@ -89,17 +97,16 @@ vi.mock("../../src/solana/lazy.ts", () => {
             }
         },
         VersionedTransaction: class FakeVersionedTransaction {
+            signatures = [new Uint8Array(64), new Uint8Array(64)];
             constructor(public message: { instructions: unknown[] }) {
                 h.lastBuiltInstructions = message.instructions;
             }
             sign(signers: unknown[]) {
-                if (!h.walletSigned) {
-                    throw new Error("local sign before wallet sign");
-                }
                 h.lastSignedWith = signers;
+                this.signatures[1] = new Uint8Array(64).fill(2);
             }
             serialize() {
-                return new Uint8Array();
+                return new Uint8Array([1, 2, 3]);
             }
         },
         SendTransactionError: class FakeSendTransactionError extends Error {},
@@ -146,11 +153,12 @@ vi.mock("../../src/solana/index.ts", async () => {
             blockhash: "BLOCKHASH",
             lastValidBlockHeight: 1,
         }),
-        sendEncodedTransaction: vi.fn().mockResolvedValue("TX_SIGNATURE"),
         simulateTransaction: vi
             .fn()
             .mockResolvedValue({ value: { err: null, logs: [] } }),
+        sendEncodedTransaction: vi.fn(),
     };
+    h.fakeConnection = fakeConnection;
 
     return {
         ...actual,
@@ -167,6 +175,8 @@ vi.mock("../../src/solana/index.ts", async () => {
 });
 
 const mintRecipient32 = `0x${"ab".repeat(32)}` as const;
+const signedSignatureBytes = new Uint8Array(64).fill(1);
+const signedSignature = base58.encode(signedSignatureBytes);
 
 const makeSendParam = (): CctpSendParam => ({
     amount: 1_000_000n,
@@ -178,15 +188,35 @@ const makeSendParam = (): CctpSendParam => ({
     hookData: cctpEmptyHookData as `0x${string}`,
 });
 
-const makeWalletProvider = () =>
-    ({
-        signTransaction: async (transaction: unknown) => {
-            h.walletSigned = true;
-            return transaction;
-        },
-    }) as unknown as Parameters<
-        typeof createSolanaCctpContract
-    >[0]["walletProvider"];
+type FakeSignedTransaction = {
+    signatures: Uint8Array[];
+    serialize: () => Uint8Array;
+};
+
+type WalletProviderMock = NonNullable<
+    Parameters<typeof createSolanaCctpContract>[0]["walletProvider"]
+> & {
+    signAndSendTransaction: ReturnType<typeof vi.fn>;
+    signTransaction?: ReturnType<typeof vi.fn>;
+};
+
+const makeWalletProvider = ({
+    signTransaction = true,
+}: { signTransaction?: boolean } = {}): WalletProviderMock => {
+    const provider = {
+        signAndSendTransaction: vi.fn().mockResolvedValue("TX_SIGNATURE"),
+    } as WalletProviderMock;
+    if (signTransaction) {
+        provider.signTransaction = vi
+            .fn()
+            .mockImplementation((transaction: FakeSignedTransaction) => {
+                transaction.signatures[0] = signedSignatureBytes;
+                return transaction;
+            });
+    }
+
+    return provider;
+};
 
 const assets: Record<string, Asset> = {
     [h.ASSET]: {
@@ -240,8 +270,20 @@ describe("createSolanaCctpContract send()", () => {
         fetchSpy.mockReset();
         h.lastBuiltInstructions = [];
         h.lastSignedWith = [];
-        h.walletSigned = false;
         h.getDepositForBurnSpy?.mockClear();
+        h.fakeConnection?.getLatestBlockhash.mockReset();
+        h.fakeConnection?.getLatestBlockhash.mockResolvedValue({
+            blockhash: "BLOCKHASH",
+            lastValidBlockHeight: 1,
+        });
+        h.fakeConnection?.simulateTransaction.mockReset();
+        h.fakeConnection?.simulateTransaction.mockResolvedValue({
+            value: { err: null, logs: [] },
+        });
+        h.fakeConnection?.sendEncodedTransaction.mockReset();
+        h.fakeConnection?.sendEncodedTransaction.mockResolvedValue(
+            signedSignature,
+        );
         setBoltzSwapsConfig({ assets });
     });
 
@@ -250,19 +292,48 @@ describe("createSolanaCctpContract send()", () => {
         fetchSpy.mockReset();
     });
 
-    test("empty solburnUrl: compute-budget + burn ix only, user pays rent, single signer", async () => {
+    test("empty solburnUrl: compute-budget + burn ix only, user pays rent, single signer and pending send", async () => {
         setBoltzSwapsConfig({ assets, solburnUrl: "" });
 
+        const walletProvider = makeWalletProvider();
+        const persist = vi.fn().mockResolvedValue(undefined);
         const contract = createSolanaCctpContract({
             asset: h.ASSET,
             tokenMint: h.TOKEN_MINT,
-            walletProvider: makeWalletProvider(),
+            walletProvider,
         });
 
-        const result = await contract.send(makeSendParam());
+        const result = await contract.send(makeSendParam(), [0n, 0n], "", {
+            pendingSendCallbacks: { persist },
+        });
 
-        expect(result.hash).toBe("TX_SIGNATURE");
+        expect(result.hash).toBe(signedSignature);
+        expect(result.details?.solana).toEqual({ blockhash: "BLOCKHASH" });
         expect(fetchSpy).not.toHaveBeenCalled();
+
+        expect(h.fakeConnection?.simulateTransaction).toHaveBeenCalledWith(
+            expect.any(Object),
+            expect.objectContaining({
+                sigVerify: false,
+                replaceRecentBlockhash: true,
+                commitment: "confirmed",
+            }),
+        );
+        expect(walletProvider.signTransaction!).toHaveBeenCalledTimes(1);
+        expect(walletProvider.signAndSendTransaction).not.toHaveBeenCalled();
+        expect(h.fakeConnection?.sendEncodedTransaction).toHaveBeenCalledWith(
+            Buffer.from([1, 2, 3]).toString("base64"),
+            expect.objectContaining({
+                skipPreflight: true,
+                preflightCommitment: "confirmed",
+            }),
+        );
+        expect(persist).toHaveBeenCalledWith({
+            kind: PendingBridgeSendKind.SolanaCctp,
+            sourceAsset: h.ASSET,
+            lastValidBlockHeight: 1,
+            signature: signedSignature,
+        });
 
         expect(h.lastBuiltInstructions).toHaveLength(2);
         expect(h.lastBuiltInstructions[0]).toMatchObject({
@@ -279,6 +350,35 @@ describe("createSolanaCctpContract send()", () => {
         expect(accounts.owner.address).toBe(h.USER_ADDR);
     });
 
+    test("falls back to wallet-managed send when local signing is unavailable", async () => {
+        setBoltzSwapsConfig({ assets, solburnUrl: "" });
+
+        const walletProvider = makeWalletProvider({ signTransaction: false });
+        const contract = createSolanaCctpContract({
+            asset: h.ASSET,
+            tokenMint: h.TOKEN_MINT,
+            walletProvider,
+        });
+
+        const result = await contract.send(makeSendParam(), [0n, 0n], "");
+
+        expect(result.hash).toBe("TX_SIGNATURE");
+        expect(walletProvider.signAndSendTransaction).toHaveBeenCalledTimes(1);
+        expect(h.fakeConnection?.sendEncodedTransaction).not.toHaveBeenCalled();
+
+        const [transaction, sendOptions] =
+            walletProvider.signAndSendTransaction.mock.calls[0];
+        expect(sendOptions).toMatchObject({
+            skipPreflight: true,
+            preflightCommitment: "confirmed",
+        });
+        expect(
+            transaction.signatures.some((signature: Uint8Array) =>
+                signature.some((byte) => byte !== 0),
+            ),
+        ).toBe(true);
+    });
+
     test("solburnUrl + allocate 200: inserts rent prefund, two signers, allocated rent payer", async () => {
         fetchSpy.mockResolvedValueOnce(
             new Response(JSON.stringify(allocateBody()), { status: 200 }),
@@ -291,7 +391,7 @@ describe("createSolanaCctpContract send()", () => {
             walletProvider: makeWalletProvider(),
         });
 
-        await contract.send(makeSendParam());
+        await contract.send(makeSendParam(), [0n, 0n], "");
 
         expect(fetchSpy).toHaveBeenCalledTimes(1);
         expect(fetchSpy.mock.calls[0]![0]).toBe(`${h.SOLBURN_URL}/allocate`);
@@ -330,7 +430,7 @@ describe("createSolanaCctpContract send()", () => {
             walletProvider: makeWalletProvider(),
         });
 
-        await contract.send(makeSendParam());
+        await contract.send(makeSendParam(), [0n, 0n], "");
 
         expect(fetchSpy).toHaveBeenCalledTimes(1);
         expect(h.lastBuiltInstructions).toHaveLength(2);
@@ -344,8 +444,8 @@ describe("createSolanaCctpContract send()", () => {
             tokenMint: h.TOKEN_MINT,
         });
 
-        await expect(contract.send(makeSendParam())).rejects.toThrow(
-            /Missing connected Solana wallet/,
-        );
+        await expect(
+            contract.send(makeSendParam(), [0n, 0n], ""),
+        ).rejects.toThrow(/Missing connected Solana wallet/);
     });
 });

--- a/src/components/BridgeSendRecovery.ts
+++ b/src/components/BridgeSendRecovery.ts
@@ -3,7 +3,7 @@ import {
     type PendingBridgeSend,
     PendingBridgeSendKind,
     PendingBridgeSendRecoveryStatus,
-    type PendingEvmOftBridgeSend,
+    type PendingEvmBridgeSend,
     bridgeRegistry,
     recoverPendingBridgeSend,
 } from "boltz-swaps/bridge";
@@ -23,10 +23,16 @@ import type {
     PendingBridgeSendCallbacks,
 } from "../utils/swapCreator";
 
+type NonEvmPendingBridgeSend = Exclude<PendingBridgeSend, PendingEvmBridgeSend>;
+
 const getPendingSendTransaction = (pending: PendingBridgeSend) => {
     switch (pending.kind) {
+        case PendingBridgeSendKind.EvmCctp:
+            return pending.fromNonce;
         case PendingBridgeSendKind.EvmOft:
             return pending.fromNonce;
+        case PendingBridgeSendKind.SolanaCctp:
+            return pending.signature;
         case PendingBridgeSendKind.SolanaOft:
             return pending.signature;
         case PendingBridgeSendKind.TronOft:
@@ -40,6 +46,12 @@ const getPendingSendTransaction = (pending: PendingBridgeSend) => {
     }
 };
 
+const isEvmBridgeSend = (
+    pending: PendingBridgeSend | undefined,
+): pending is PendingEvmBridgeSend =>
+    pending?.kind === PendingBridgeSendKind.EvmOft ||
+    pending?.kind === PendingBridgeSendKind.EvmCctp;
+
 export const useBridgeSendRecovery = (params: {
     swapId: Accessor<string>;
     bridge: Accessor<BridgeDetail>;
@@ -50,18 +62,18 @@ export const useBridgeSendRecovery = (params: {
     const { getSwap, setSwapStorage } = useGlobalContext();
 
     const storedPendingSend = createMemo(() => swap()?.bridge?.pendingSend);
-    const pendingSend = createMemo(() => {
+    const pendingSend = createMemo<NonEvmPendingBridgeSend | undefined>(() => {
         const pending = storedPendingSend();
-        return pending?.kind === PendingBridgeSendKind.EvmOft
-            ? undefined
-            : pending;
+        return isEvmBridgeSend(pending) ? undefined : pending;
     });
-    const evmSendCandidate = createMemo(
-        () =>
-            swap()?.bridge?.evmSendCandidate ??
-            (storedPendingSend()?.kind === PendingBridgeSendKind.EvmOft
-                ? (storedPendingSend() as PendingEvmOftBridgeSend)
-                : undefined),
+    const evmSendCandidate = createMemo<PendingEvmBridgeSend | undefined>(
+        () => {
+            const stored = storedPendingSend();
+            return (
+                swap()?.bridge?.evmSendCandidate ??
+                (isEvmBridgeSend(stored) ? stored : undefined)
+            );
+        },
     );
     const [evmSendCandidateRecoveryFailed, setEvmSendCandidateRecoveryFailed] =
         createSignal(false);
@@ -105,7 +117,13 @@ export const useBridgeSendRecovery = (params: {
     };
 
     const setPendingSend = async (pending: PendingBridgeSend | undefined) => {
-        await updateBridge((bridge) => ({ ...bridge, pendingSend: pending }));
+        await updateBridge((bridge) => {
+            const next = { ...bridge, pendingSend: pending };
+            if (pending === undefined) {
+                delete next.pendingSend;
+            }
+            return next;
+        });
         if (pending !== undefined) {
             log.info("Persisted pending bridge send for recovery", {
                 swapId: params.swapId(),
@@ -118,15 +136,14 @@ export const useBridgeSendRecovery = (params: {
     };
 
     const setEvmSendCandidate = async (
-        candidate: PendingEvmOftBridgeSend | undefined,
+        candidate: PendingEvmBridgeSend | undefined,
     ) => {
         await updateBridge((bridge) => {
             const next: BridgeDetail = {
                 ...bridge,
-                pendingSend:
-                    bridge.pendingSend?.kind === PendingBridgeSendKind.EvmOft
-                        ? undefined
-                        : bridge.pendingSend,
+                pendingSend: isEvmBridgeSend(bridge.pendingSend)
+                    ? undefined
+                    : bridge.pendingSend,
                 evmSendCandidate: candidate,
             };
             if (next.pendingSend === undefined) {
@@ -144,6 +161,7 @@ export const useBridgeSendRecovery = (params: {
                 swapId: params.swapId(),
                 sourceAsset: params.bridge().sourceAsset,
                 destinationAsset: params.bridge().destinationAsset,
+                kind: candidate.kind,
                 fromNonce: candidate.fromNonce,
             });
         }
@@ -153,22 +171,28 @@ export const useBridgeSendRecovery = (params: {
         persist: (pending) => setPendingSend(pending),
     };
 
+    const getBridgeProvider = () => {
+        const bridge = params.bridge();
+        return bridgeRegistry
+            .requireDriverForRoute(bridge)
+            .getProvider(bridge.sourceAsset);
+    };
+
     let recovering = false;
-    const recover = async (pending: PendingBridgeSend) => {
+    const recover = async (pending: NonEvmPendingBridgeSend) => {
         if (recovering) {
             return;
         }
         recovering = true;
-        const bridge = params.bridge();
         try {
-            const result = await recoverPendingBridgeSend(
-                pending,
-                pending.kind === PendingBridgeSendKind.EvmOft
-                    ? bridgeRegistry
-                          .requireDriverForRoute(bridge)
-                          .getProvider(bridge.sourceAsset)
-                    : undefined,
-            );
+            const result = await recoverPendingBridgeSend(pending);
+            if (params.txSent() !== undefined) {
+                log.info("Skipping stale pending bridge recovery result", {
+                    swapId: params.swapId(),
+                    kind: pending.kind,
+                });
+                return;
+            }
             switch (result.status) {
                 case PendingBridgeSendRecoveryStatus.Recovered:
                     log.info("Recovered pending bridge send", {
@@ -209,7 +233,7 @@ export const useBridgeSendRecovery = (params: {
 
     let recoveringEvmCandidate = false;
     const recoverEvmSendCandidate = async (
-        candidate: PendingEvmOftBridgeSend | undefined,
+        candidate: PendingEvmBridgeSend | undefined,
     ) => {
         if (
             candidate === undefined ||
@@ -220,18 +244,26 @@ export const useBridgeSendRecovery = (params: {
         }
 
         recoveringEvmCandidate = true;
-        const bridge = params.bridge();
         try {
             const result = await recoverPendingBridgeSend(
                 candidate,
-                bridgeRegistry
-                    .requireDriverForRoute(bridge)
-                    .getProvider(bridge.sourceAsset),
+                getBridgeProvider(),
             );
+            if (params.txSent() !== undefined) {
+                log.info(
+                    "Skipping stale EVM bridge send candidate recovery result",
+                    {
+                        swapId: params.swapId(),
+                        kind: candidate.kind,
+                    },
+                );
+                return;
+            }
             switch (result.status) {
                 case PendingBridgeSendRecoveryStatus.Recovered:
                     log.info("Recovered EVM bridge send candidate", {
                         swapId: params.swapId(),
+                        kind: candidate.kind,
                         txHash: result.transactionHash,
                     });
                     await persistBridgeSend(result.transactionHash);
@@ -240,6 +272,7 @@ export const useBridgeSendRecovery = (params: {
                 case PendingBridgeSendRecoveryStatus.Failed:
                     log.warn("EVM bridge send candidate recovery failed", {
                         swapId: params.swapId(),
+                        kind: candidate.kind,
                     });
                     setEvmSendCandidateRecoveryFailed(true);
                     return;

--- a/src/components/RefundButton.tsx
+++ b/src/components/RefundButton.tsx
@@ -592,7 +592,12 @@ export const RefundEvm = (props: {
 
             log.debug("Fetching lockup data");
             const txHash = lockupTx ?? commitmentLockupTxHash;
-            if (txHash === undefined) {
+            if (
+                txHash === undefined ||
+                txHash === null ||
+                txHash === "" ||
+                !txHash.startsWith("0x")
+            ) {
                 throw new Error(
                     "missing lockup or commitment transaction hash",
                 );

--- a/src/components/SendToBridge.tsx
+++ b/src/components/SendToBridge.tsx
@@ -4,9 +4,15 @@ import {
     type BridgeTransaction,
     type BridgeTransportClient,
     PendingBridgeSendKind,
-    type PendingEvmOftBridgeSend,
+    type PendingEvmBridgeSend,
     bridgeRegistry,
 } from "boltz-swaps/bridge";
+import {
+    type CctpDirectSendTarget,
+    type CctpSendParam,
+    type SolanaCctpTransportClient,
+    populateCctpDirectSendTransaction,
+} from "boltz-swaps/cctp";
 import { createTokenContract } from "boltz-swaps/evm/contracts";
 import type { PopulatedEvmTransaction } from "boltz-swaps/evm/transaction";
 import {
@@ -53,6 +59,43 @@ import WaitForBridge from "./WaitForBridge";
 
 const evmSendCandidateBlockLookback = 5n;
 const evmSendCandidateRecoveryTimeoutMs = 120_000;
+const transactionHashPattern = /^0x[0-9a-fA-F]{64}$/;
+
+const getTransactionHashFromError = (
+    error: unknown,
+    depth = 0,
+): string | undefined => {
+    if (depth > 3 || typeof error !== "object" || error === null) {
+        return undefined;
+    }
+
+    for (const key of ["hash", "transactionHash"]) {
+        const value = Reflect.get(error, key);
+        if (typeof value === "string" && transactionHashPattern.test(value)) {
+            return value;
+        }
+    }
+
+    const value = Reflect.get(error, "value");
+    if (typeof value === "object" && value !== null) {
+        const hash = Reflect.get(value, "hash");
+        if (typeof hash === "string" && transactionHashPattern.test(hash)) {
+            return hash;
+        }
+    }
+
+    const cause = Reflect.get(error, "cause");
+    if (cause !== error) {
+        return getTransactionHashFromError(cause, depth + 1);
+    }
+
+    return undefined;
+};
+
+type PreparedEvmBridgeSend = {
+    candidate: PendingEvmBridgeSend;
+    txRequest: PopulatedEvmTransaction;
+};
 
 const EvmSendCandidateRecovery = (props: {
     failed: boolean;
@@ -170,23 +213,53 @@ const SendToBridge = (props: {
         evmSendActive: bridgeSendActive,
     });
 
-    // OFT transport sends (Solana/Tron) use callbacks to persist post-broadcast
-    // recovery state. Other bridges (CCTP) go through the driver as-is.
+    // Transport sends that leave the browser to sign persist post-broadcast
+    // recovery state. EVM sends use a candidate until the wallet returns a hash.
     const sendTransport = async (args: {
         contract: BridgeTransportClient;
         sendParam: BridgeSendParam;
         msgFee: BridgeMsgFee;
         refundAddress: string;
     }): Promise<BridgeTransaction> => {
-        if (props.bridge.kind !== BridgeKind.Oft) {
-            return await bridgeDriver().sendTransport(args);
+        if (props.bridge.kind === BridgeKind.Cctp && "send" in args.contract) {
+            return await (args.contract as SolanaCctpTransportClient).send(
+                args.sendParam as CctpSendParam,
+                args.msgFee,
+                args.refundAddress,
+                { pendingSendCallbacks },
+            );
         }
-        return await (args.contract as OftTransportClient).send(
-            args.sendParam as SendParam,
-            args.msgFee,
-            args.refundAddress,
-            { pendingSendCallbacks },
-        );
+        if (props.bridge.kind === BridgeKind.Oft) {
+            return await (args.contract as OftTransportClient).send(
+                args.sendParam as SendParam,
+                args.msgFee,
+                args.refundAddress,
+                { pendingSendCallbacks },
+            );
+        }
+        return await bridgeDriver().sendTransport(args);
+    };
+
+    const sendPreparedEvmBridgeTransaction = async (
+        connectedSigner: Signer,
+        prepared: PreparedEvmBridgeSend,
+    ): Promise<BridgeTransaction> => {
+        await setEvmSendCandidate(prepared.candidate);
+        try {
+            const hash = await sendPopulatedTransaction(
+                GasAbstractionType.None,
+                connectedSigner,
+                prepared.txRequest,
+            );
+            return { hash };
+        } catch (error) {
+            const hash = getTransactionHashFromError(error);
+            if (hash !== undefined) {
+                return { hash };
+            }
+            await setEvmSendCandidate(undefined);
+            throw error;
+        }
     };
 
     const [signerChainId] = createResource(signer, async (currentSigner) => {
@@ -700,67 +773,95 @@ const SendToBridge = (props: {
             lzTokenFee: msgFee[1].toString(),
         });
 
-        if (props.bridge.kind === BridgeKind.Oft) {
-            let prepared: {
-                candidate: PendingEvmOftBridgeSend;
-                txRequest: PopulatedEvmTransaction;
-            };
+        const sendDirect = async () =>
+            await bridgeDriver().sendDirect({
+                target: directSendTarget,
+                runner: connectedSigner,
+                sendParam,
+                msgFee,
+                refundAddress: signerAddress,
+            });
+
+        if (
+            props.bridge.kind === BridgeKind.Oft ||
+            props.bridge.kind === BridgeKind.Cctp
+        ) {
+            let prepared: PreparedEvmBridgeSend;
             try {
-                prepared = await prepareOftFromEvm({
-                    signer: connectedSigner,
-                    signerAddress,
-                    directSendTarget: directSendTarget as OftDirectSendTarget,
-                    sendParam: sendParam as SendParam,
-                    msgFee,
-                });
+                prepared =
+                    props.bridge.kind === BridgeKind.Oft
+                        ? await prepareOftFromEvm({
+                              signer: connectedSigner,
+                              signerAddress,
+                              directSendTarget:
+                                  directSendTarget as OftDirectSendTarget,
+                              sendParam: sendParam as SendParam,
+                              msgFee,
+                          })
+                        : await prepareCctpFromEvm({
+                              signer: connectedSigner,
+                              signerAddress,
+                              directSendTarget:
+                                  directSendTarget as CctpDirectSendTarget,
+                              sendParam: sendParam as CctpSendParam,
+                          });
             } catch (error) {
-                log.warn("Falling back to direct EVM OFT send", {
+                const label =
+                    props.bridge.kind === BridgeKind.Oft ? "OFT" : "CCTP";
+                log.warn(`Falling back to direct EVM ${label} send`, {
                     sourceAsset: props.bridge.sourceAsset,
                     destinationAsset: props.bridge.destinationAsset,
                     error,
                 });
-                return await bridgeDriver().sendDirect({
-                    target: directSendTarget,
-                    runner: connectedSigner,
-                    sendParam,
-                    msgFee,
-                    refundAddress: signerAddress,
-                });
+                return await sendDirect();
             }
 
-            await setEvmSendCandidate(prepared.candidate);
-            try {
-                const hash = await sendPopulatedTransaction(
-                    GasAbstractionType.None,
-                    connectedSigner,
-                    prepared.txRequest,
-                );
-                return { hash };
-            } catch (error) {
-                await setEvmSendCandidate(undefined);
-                throw error;
-            }
+            return await sendPreparedEvmBridgeTransaction(
+                connectedSigner,
+                prepared,
+            );
         }
 
-        return await bridgeDriver().sendDirect({
-            target: directSendTarget,
-            runner: connectedSigner,
-            sendParam,
-            msgFee,
-            refundAddress: signerAddress,
-        });
+        return await sendDirect();
     };
 
+    const getEvmCandidateFromBlock = (latestBlock: bigint) =>
+        Number(
+            latestBlock > evmSendCandidateBlockLookback
+                ? latestBlock - evmSendCandidateBlockLookback
+                : 0n,
+        );
+
+    const getEvmCandidateBase = async (args: {
+        signer: Signer;
+        signerAddress: Address;
+    }) => {
+        const [fromNonce, latestBlock] = await Promise.all([
+            args.signer.provider.getTransactionCount({
+                address: args.signerAddress,
+                blockTag: "latest",
+            }),
+            bridgeDriver()
+                .getProvider(props.bridge.sourceAsset)
+                .getBlockNumber(),
+        ]);
+
+        return {
+            fromNonce,
+            fromBlock: getEvmCandidateFromBlock(latestBlock),
+        };
+    };
+
+    // Capture the latest confirmed sender nonce as a lower bound. If the page is
+    // closed before the wallet returns we can find the resulting transaction by
+    // replaying bridge logs and matching the sender, target, nonce, and calldata.
     const prepareOftFromEvm = async (args: {
         signer: Signer;
         signerAddress: Address;
         directSendTarget: OftDirectSendTarget;
         sendParam: SendParam;
         msgFee: BridgeMsgFee;
-    }): Promise<{
-        candidate: PendingEvmOftBridgeSend;
-        txRequest: PopulatedEvmTransaction;
-    }> => {
+    }): Promise<PreparedEvmBridgeSend> => {
         const txRequest: PopulatedEvmTransaction =
             populateOftDirectSendTransaction({
                 target: args.directSendTarget,
@@ -772,27 +873,59 @@ const SendToBridge = (props: {
             throw new Error("OFT direct send transaction is missing call data");
         }
 
-        const [fromNonce, latestBlock] = await Promise.all([
-            args.signer.provider.getTransactionCount({
-                address: args.signerAddress,
-                blockTag: "latest",
-            }),
-            args.signer.provider.getBlockNumber(),
-        ]);
+        const candidateBase = await getEvmCandidateBase(args);
 
         return {
             candidate: {
                 kind: PendingBridgeSendKind.EvmOft,
                 createdAt: Date.now(),
                 sender: args.signerAddress,
-                fromNonce,
-                fromBlock: Number(
-                    latestBlock > evmSendCandidateBlockLookback
-                        ? latestBlock - evmSendCandidateBlockLookback
-                        : 0n,
-                ),
+                ...candidateBase,
                 oftContractAddress: args.directSendTarget.oftContract.address,
                 transactionTo: txRequest.to,
+                calldata: txRequest.data,
+            },
+            txRequest,
+        };
+    };
+
+    // CCTP burns emit MessageSent from the MessageTransmitter rather than an
+    // OFTSent event. Save the exact TokenMessenger calldata so recovery can
+    // replay burn logs against it.
+    const prepareCctpFromEvm = async (args: {
+        signer: Signer;
+        signerAddress: Address;
+        directSendTarget: CctpDirectSendTarget;
+        sendParam: CctpSendParam;
+    }): Promise<PreparedEvmBridgeSend> => {
+        const cctpBridge = config.assets?.[props.bridge.sourceAsset]?.bridge;
+        if (cctpBridge?.kind !== BridgeKind.Cctp) {
+            throw new Error(
+                `Missing CCTP config for ${props.bridge.sourceAsset}`,
+            );
+        }
+
+        const txRequest: PopulatedEvmTransaction =
+            populateCctpDirectSendTransaction({
+                target: args.directSendTarget,
+                sendParam: args.sendParam,
+            });
+        if (txRequest.to === undefined || txRequest.data === undefined) {
+            throw new Error(
+                "CCTP direct send transaction is missing call data",
+            );
+        }
+
+        const candidateBase = await getEvmCandidateBase(args);
+
+        return {
+            candidate: {
+                kind: PendingBridgeSendKind.EvmCctp,
+                createdAt: Date.now(),
+                sender: args.signerAddress,
+                ...candidateBase,
+                tokenMessenger: args.directSendTarget.executionContract.address,
+                messageTransmitter: cctpBridge.cctp.messageTransmitter,
                 calldata: txRequest.data,
             },
             txRequest,

--- a/src/utils/swapCreator.ts
+++ b/src/utils/swapCreator.ts
@@ -6,7 +6,7 @@ import type {
     BridgeDetails,
     BridgeRoute,
     PendingBridgeSend,
-    PendingEvmOftBridgeSend,
+    PendingEvmBridgeSend,
 } from "boltz-swaps/bridge";
 import {
     type ChainSwapCreatedResponse,
@@ -48,7 +48,7 @@ export type BridgeDetail = BridgeRoute & {
     txHash?: string;
     details?: BridgeDetails;
     pendingSend?: PendingBridgeSend;
-    evmSendCandidate?: PendingEvmOftBridgeSend;
+    evmSendCandidate?: PendingEvmBridgeSend;
 };
 
 export type PendingBridgeSendCallbacks = {

--- a/tests/utils/bridgePendingSend.spec.ts
+++ b/tests/utils/bridgePendingSend.spec.ts
@@ -1,13 +1,18 @@
 import {
     PendingBridgeSendKind,
     PendingBridgeSendRecoveryStatus,
+    type PendingEvmCctpBridgeSend,
     type PendingEvmOftBridgeSend,
+    type PendingSolanaCctpBridgeSend,
     type PendingSolanaOftBridgeSend,
     type PendingTronOftBridgeSend,
+    recoverPendingEvmCctpSend,
     recoverPendingEvmOftSend,
+    recoverPendingSolanaCctpSend,
     recoverPendingSolanaOftSend,
     recoverPendingTronOftSend,
 } from "boltz-swaps/bridge";
+import { cctpMessageSentTopic, tokenMessengerV2Abi } from "boltz-swaps/cctp";
 import { oftAbi } from "boltz-swaps/oft";
 import { getSolanaConnection } from "boltz-swaps/solana";
 import type * as TronChain from "boltz-swaps/tron";
@@ -17,6 +22,7 @@ import {
     type PublicClient,
     encodeAbiParameters,
     encodeEventTopics,
+    encodeFunctionData,
 } from "viem";
 import { describe, expect, test, vi } from "vitest";
 
@@ -33,9 +39,36 @@ vi.mock("boltz-swaps/tron", async (importOriginal) => ({
 const sender = "0x1000000000000000000000000000000000000000";
 const target = "0x2000000000000000000000000000000000000000";
 const oftContractAddress = "0x3000000000000000000000000000000000000000";
+const tokenMessenger = "0x4000000000000000000000000000000000000000";
+const messageTransmitter = "0x5000000000000000000000000000000000000000";
+const burnToken = "0x6000000000000000000000000000000000000000";
 const calldata = "0xabcdef";
 const transactionHash =
     "0x1111111111111111111111111111111111111111111111111111111111111111";
+const mintRecipient =
+    "0x000000000000000000000000060d01c512b89fbce38bb2b4ed77ee4258457bd6";
+const destinationCaller =
+    "0x0000000000000000000000000000000000000000000000000000000000000000";
+const destinationTokenMessenger =
+    "0x00000000000000000000000028b5a0e9c621a5badaa536219b3a228c8168cf5d";
+const cctpAmount = 482279779n;
+const cctpDestinationDomain = 1000;
+const cctpMaxFee = 0n;
+const cctpMinFinalityThreshold = 1000;
+const cctpHookData = "0x";
+const cctpCalldata = encodeFunctionData({
+    abi: tokenMessengerV2Abi,
+    functionName: "depositForBurn",
+    args: [
+        cctpAmount,
+        cctpDestinationDomain,
+        mintRecipient as Hex,
+        burnToken as Hex,
+        destinationCaller as Hex,
+        cctpMaxFee,
+        cctpMinFinalityThreshold,
+    ],
+});
 const solanaSignature =
     "4Z5XjC7hYw5Z5TFySTbRHzM2cTRkuzMCVYDn6H3CUf1W9EN2TRdLhXjFiKDLxx8FEh3zKfJQyTjU3KFiKxVYjR7m";
 const tronTransactionHash =
@@ -50,6 +83,17 @@ const pendingSend: PendingEvmOftBridgeSend = {
     oftContractAddress,
     transactionTo: target,
     calldata,
+};
+
+const cctpPendingSend: PendingEvmCctpBridgeSend = {
+    kind: PendingBridgeSendKind.EvmCctp,
+    createdAt: 1,
+    sender,
+    fromNonce: 7,
+    fromBlock: 100,
+    tokenMessenger,
+    messageTransmitter,
+    calldata: cctpCalldata,
 };
 
 const createOftSentLog = (
@@ -89,6 +133,101 @@ const createProvider = ({
     receipt = {
         status: "success",
         logs: [createOftSentLog()],
+    },
+    latestNonce = 7,
+    pendingNonce = latestNonce,
+}: {
+    logs?: unknown[];
+    transaction?: unknown;
+    receipt?: unknown;
+    latestNonce?: number;
+    pendingNonce?: number;
+} = {}) =>
+    ({
+        getLogs: vi.fn().mockResolvedValue(logs),
+        getTransaction: vi.fn().mockResolvedValue(transaction),
+        getTransactionReceipt: vi.fn().mockResolvedValue(receipt),
+        getTransactionCount: vi
+            .fn()
+            .mockImplementation(({ blockTag }: { blockTag: string }) =>
+                Promise.resolve(
+                    blockTag === "pending" ? pendingNonce : latestNonce,
+                ),
+            ),
+    }) as unknown as PublicClient;
+
+const createCctpDepositForBurnLog = (
+    overrides: Partial<{
+        transactionHash: string;
+        address: string;
+        burnToken: string;
+        depositor: string;
+        amount: bigint;
+        destinationDomain: number;
+        mintRecipient: string;
+        destinationCaller: string;
+        maxFee: bigint;
+        minFinalityThreshold: number;
+        hookData: string;
+    }> = {},
+) => ({
+    address: overrides.address ?? tokenMessenger,
+    transactionHash: overrides.transactionHash ?? transactionHash,
+    data: encodeAbiParameters(
+        [
+            { type: "uint256" },
+            { type: "bytes32" },
+            { type: "uint32" },
+            { type: "bytes32" },
+            { type: "bytes32" },
+            { type: "uint256" },
+            { type: "bytes" },
+        ],
+        [
+            overrides.amount ?? cctpAmount,
+            (overrides.mintRecipient ?? mintRecipient) as Hex,
+            overrides.destinationDomain ?? cctpDestinationDomain,
+            destinationTokenMessenger as Hex,
+            (overrides.destinationCaller ?? destinationCaller) as Hex,
+            overrides.maxFee ?? cctpMaxFee,
+            (overrides.hookData ?? cctpHookData) as Hex,
+        ],
+    ),
+    topics: encodeEventTopics({
+        abi: tokenMessengerV2Abi,
+        eventName: "DepositForBurn",
+        args: {
+            burnToken: (overrides.burnToken ?? burnToken) as Hex,
+            depositor: (overrides.depositor ?? sender) as Hex,
+            minFinalityThreshold:
+                overrides.minFinalityThreshold ?? cctpMinFinalityThreshold,
+        },
+    }),
+    blockNumber: 101,
+    index: 0,
+});
+
+const createCctpMessageSentLog = () => ({
+    address: messageTransmitter,
+    transactionHash,
+    data: "0x",
+    topics: [cctpMessageSentTopic],
+    blockNumber: 101,
+    index: 1,
+});
+
+const createCctpProvider = ({
+    logs = [createCctpDepositForBurnLog()],
+    transaction = {
+        nonce: 7,
+        from: sender,
+        to: tokenMessenger,
+        value: 0n,
+        input: cctpCalldata,
+    },
+    receipt = {
+        status: "success",
+        logs: [createCctpDepositForBurnLog(), createCctpMessageSentLog()],
     },
     latestNonce = 7,
     pendingNonce = latestNonce,
@@ -271,6 +410,157 @@ describe("recoverPendingEvmOftSend", () => {
     });
 });
 
+describe("recoverPendingEvmCctpSend", () => {
+    test("recovers a tx matching sender calldata and MessageSent", async () => {
+        const result = await recoverPendingEvmCctpSend(
+            cctpPendingSend,
+            createCctpProvider(),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Recovered,
+            transactionHash,
+        });
+    });
+
+    test("filters DepositForBurn logs by indexed burn fields", async () => {
+        const provider = createCctpProvider();
+
+        await recoverPendingEvmCctpSend(cctpPendingSend, provider);
+
+        expect(provider.getLogs).toHaveBeenCalledWith(
+            expect.objectContaining({
+                args: {
+                    burnToken,
+                    depositor: sender,
+                    minFinalityThreshold: 1000,
+                },
+            }),
+        );
+    });
+
+    test("recovers when the wallet broadcasts with a higher nonce", async () => {
+        const result = await recoverPendingEvmCctpSend(
+            cctpPendingSend,
+            createCctpProvider({
+                transaction: {
+                    nonce: 8,
+                    from: sender,
+                    to: tokenMessenger,
+                    value: 0n,
+                    input: cctpCalldata,
+                },
+                latestNonce: 8,
+            }),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Recovered,
+            transactionHash,
+        });
+    });
+
+    test("keeps pending while no CCTP burn is found before expiry", async () => {
+        const result = await recoverPendingEvmCctpSend(
+            { ...cctpPendingSend, createdAt: Date.now() },
+            createCctpProvider({ logs: [], latestNonce: 7 }),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Pending,
+        });
+    });
+
+    test("keeps pending while the nonce is still in the mempool", async () => {
+        const result = await recoverPendingEvmCctpSend(
+            { ...cctpPendingSend, createdAt: Date.now() },
+            createCctpProvider({
+                logs: [],
+                latestNonce: 7,
+                pendingNonce: 8,
+            }),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Pending,
+        });
+    });
+
+    test("fails when no CCTP burn is found before expiry", async () => {
+        const result = await recoverPendingEvmCctpSend(
+            cctpPendingSend,
+            createCctpProvider({ logs: [], latestNonce: 7 }),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Failed,
+        });
+    });
+
+    test("fails when calldata differs and the nonce is mined", async () => {
+        const result = await recoverPendingEvmCctpSend(
+            cctpPendingSend,
+            createCctpProvider({
+                transaction: {
+                    nonce: 7,
+                    from: sender,
+                    to: tokenMessenger,
+                    value: 0n,
+                    input: "0x123456",
+                },
+                latestNonce: 8,
+            }),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Failed,
+        });
+    });
+
+    test("keeps pending when multiple matching burns are found", async () => {
+        const result = await recoverPendingEvmCctpSend(
+            cctpPendingSend,
+            createCctpProvider({
+                logs: [
+                    createCctpDepositForBurnLog(),
+                    createCctpDepositForBurnLog({
+                        transactionHash:
+                            "0x2222222222222222222222222222222222222222222222222222222222222222",
+                    }),
+                ],
+                transaction: {
+                    nonce: 7,
+                    from: sender,
+                    to: tokenMessenger,
+                    value: 0n,
+                    input: cctpCalldata,
+                },
+            }),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Pending,
+        });
+    });
+
+    test("ignores burns without a CCTP MessageSent log", async () => {
+        const result = await recoverPendingEvmCctpSend(
+            cctpPendingSend,
+            createCctpProvider({
+                latestNonce: 8,
+                receipt: {
+                    status: "success",
+                    logs: [createCctpDepositForBurnLog()],
+                },
+            }),
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Failed,
+        });
+    });
+});
+
 const mockedGetSolanaConnection = vi.mocked(getSolanaConnection);
 const mockedGetTronTransaction = vi.mocked(getTronTransaction);
 const mockedGetTronTransactionInfo = vi.mocked(getTronTransactionInfo);
@@ -278,6 +568,13 @@ const mockedGetTronTransactionInfo = vi.mocked(getTronTransactionInfo);
 const solanaPendingSend: PendingSolanaOftBridgeSend = {
     kind: PendingBridgeSendKind.SolanaOft,
     sourceAsset: "USDT0-SOL",
+    lastValidBlockHeight: 100,
+    signature: solanaSignature,
+};
+
+const solanaCctpPendingSend: PendingSolanaCctpBridgeSend = {
+    kind: PendingBridgeSendKind.SolanaCctp,
+    sourceAsset: "USDC-SOL",
     lastValidBlockHeight: 100,
     signature: solanaSignature,
 };
@@ -334,6 +631,40 @@ describe("recoverPendingSolanaOftSend", () => {
             status: PendingBridgeSendRecoveryStatus.Failed,
         });
         expect(connection.sendRawTransaction).not.toHaveBeenCalled();
+    });
+});
+
+describe("recoverPendingSolanaCctpSend", () => {
+    test("recovers a signed tx already found on-chain", async () => {
+        const connection = createSolanaConnection({
+            status: { err: null },
+        });
+        mockedGetSolanaConnection.mockResolvedValue(connection as never);
+
+        const result = await recoverPendingSolanaCctpSend(
+            solanaCctpPendingSend,
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Recovered,
+            transactionHash: solanaSignature,
+        });
+        expect(connection.sendRawTransaction).not.toHaveBeenCalled();
+    });
+
+    test("fails when the signed tx blockhash has expired", async () => {
+        const connection = createSolanaConnection({
+            blockHeight: 101,
+        });
+        mockedGetSolanaConnection.mockResolvedValue(connection as never);
+
+        const result = await recoverPendingSolanaCctpSend(
+            solanaCctpPendingSend,
+        );
+
+        expect(result).toEqual({
+            status: PendingBridgeSendRecoveryStatus.Failed,
+        });
     });
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added EVM CCTP direct-send support and unified pending-send handling for EVM and Solana CCTP.
  * Added helper to populate CCTP direct-send transactions and expanded CCTP ABI exposure.
  * Send flow improvements: EVM error hash recovery, unified candidate persistence, and Solana local-sign pending-send path.

* **Bug Fixes**
  * Stricter validation for refund/lockup transaction hashes.

* **Tests**
  * Expanded tests for EVM and Solana CCTP send/recovery scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoltzExchange/boltz-web-app/pull/1459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->