### PR TITLE
Embed styles and lock output

### DIFF
--- a/src/components/Asset.tsx
+++ b/src/components/Asset.tsx
@@ -30,6 +30,7 @@ const Asset = (props: {
     return (
         <button
             type="button"
+            disabled={props.disabled}
             class={`asset-wrap${
                 bitcoinOnly() || props.disabled ? " no-select" : ""
             }`}

--- a/src/components/Asset.tsx
+++ b/src/components/Asset.tsx
@@ -7,12 +7,18 @@ import { useCreateContext } from "../context/Create";
 import { useGlobalContext } from "../context/Global";
 import "../style/asset.scss";
 
-const Asset = (props: { side: Side; signal: Accessor<string> }) => {
+const Asset = (props: {
+    side: Side;
+    signal: Accessor<string>;
+    disabled?: boolean;
+}) => {
     const { bitcoinOnly, notify, t } = useGlobalContext();
 
     const openSelect = () => {
-        if (bitcoinOnly()) {
-            notify("error", t("bitcoin_only_warning"));
+        if (props.disabled || bitcoinOnly()) {
+            if (bitcoinOnly()) {
+                notify("error", t("bitcoin_only_warning"));
+            }
             return;
         }
         setAssetSelected(props.side);
@@ -24,7 +30,9 @@ const Asset = (props: { side: Side; signal: Accessor<string> }) => {
     return (
         <button
             type="button"
-            class={`asset-wrap${bitcoinOnly() ? " no-select" : ""}`}
+            class={`asset-wrap${
+                bitcoinOnly() || props.disabled ? " no-select" : ""
+            }`}
             onClick={openSelect}>
             <div
                 data-testid={`asset-${props.side}`}

--- a/src/components/AssetSelect.tsx
+++ b/src/components/AssetSelect.tsx
@@ -41,6 +41,7 @@ const SelectAsset = () => {
         setInvoice,
         setOnchainAddress,
         setNetworkSelectCanonical,
+        destinationLocked,
     } = useCreateContext();
 
     const [focusedIndex, setFocusedIndex] = createSignal(0);
@@ -94,8 +95,10 @@ const SelectAsset = () => {
             return;
         }
 
-        // clear invoice every time asset changes
-        setInvoice("");
+        // clear invoice every time asset changes (unless destination is locked)
+        if (!destinationLocked()) {
+            setInvoice("");
+        }
 
         let nextPair: Pair;
 

--- a/src/components/NetworkSelect.tsx
+++ b/src/components/NetworkSelect.tsx
@@ -44,6 +44,7 @@ const NetworkSelect = () => {
         setInvoice,
         setOnchainAddress,
         networkSelectCanonical,
+        destinationLocked,
     } = useCreateContext();
 
     const [search, setSearch] = createSignal("");
@@ -134,7 +135,9 @@ const NetworkSelect = () => {
             return;
         }
 
-        setInvoice("");
+        if (!destinationLocked()) {
+            setInvoice("");
+        }
 
         let nextPair: Pair;
 

--- a/src/components/Reverse.tsx
+++ b/src/components/Reverse.tsx
@@ -19,6 +19,7 @@ const Reverse = () => {
         setReceiveAmount,
         amountChanged,
         setAmountChanged,
+        destinationLocked,
     } = useCreateContext();
 
     const setDirection = () => {
@@ -36,7 +37,9 @@ const Reverse = () => {
         }
 
         setOnchainAddress("");
-        setInvoice("");
+        if (!destinationLocked()) {
+            setInvoice("");
+        }
         setPair(
             new Pair(pairs(), pair().toAsset, pair().fromAsset, regularPairs()),
         );

--- a/src/consts/Enums.ts
+++ b/src/consts/Enums.ts
@@ -17,6 +17,9 @@ export enum UrlParam {
     Lang = "lang",
     Ref = "ref",
     FiatCurrency = "fiatCurrency",
+    Embedded = "embedded",
+    Theme = "theme",
+    LockOutput = "lockOutput",
 }
 
 export enum AssetSelection {

--- a/src/context/Create.tsx
+++ b/src/context/Create.tsx
@@ -230,14 +230,6 @@ const handleUrlParams = async (
         isInvoice(destination) &&
         !isLnurl(destination)
     ) {
-        if (
-            embedded === "true" &&
-            getUrlParam(UrlParam.LockOutput) === "true"
-        ) {
-            setDestinationLocked(true);
-        }
-
-        // Extract fixed-amount lightning invoice and pre-populate amounts
         try {
             const sats = decodeInvoice(destination).satoshis;
             if (sats > 0) {
@@ -249,9 +241,17 @@ const handleUrlParams = async (
                     minerFee(),
                 );
                 setSendAmount(sendAmt);
+                if (
+                    embedded === "true" &&
+                    getUrlParam(UrlParam.LockOutput) === "true"
+                ) {
+                    setDestinationLocked(true);
+                }
             }
         } catch {
             // Invalid invoice, ignore
+        } finally {
+            setQuoteLoading(false);
         }
     }
 

--- a/src/context/Create.tsx
+++ b/src/context/Create.tsx
@@ -26,7 +26,7 @@ import { type AssetSelection, Side, UrlParam } from "../consts/Enums";
 import type { DictKey } from "../i18n/i18n";
 import Pair, { RequiredInput } from "../utils/Pair";
 import { validateAddress } from "../utils/compat";
-import { isInvoice, isLnurl } from "../utils/invoice";
+import { decodeInvoice, isInvoice, isLnurl } from "../utils/invoice";
 import { getUrlParam, resetUrlParam, urlParamIsSet } from "../utils/urlParams";
 import { useGlobalContext } from "./Global";
 
@@ -151,7 +151,7 @@ const parseAmount = (amount: string): BigNumber | undefined => {
     return parsedAmount;
 };
 
-const handleUrlParams = (
+const handleUrlParams = async (
     pair: Accessor<Pair>,
     setPair: Setter<Pair>,
     setInvoice: Setter<string>,
@@ -161,6 +161,9 @@ const handleUrlParams = (
     setReceiveAmount: Setter<BigNumber>,
     setAddressValid: Setter<boolean>,
     setInvoiceValid: Setter<boolean>,
+    setDestinationLocked: Setter<boolean>,
+    setQuoteLoading: Setter<boolean>,
+    minerFee: Accessor<number>,
     navigate: Navigator,
 ) => {
     const setAssetReceive = (asset: string) => {
@@ -169,6 +172,7 @@ const handleUrlParams = (
 
     const sendAsset = getUrlParam(UrlParam.SendAsset);
     const receiveAsset = getUrlParam(UrlParam.ReceiveAsset);
+    const embedded = getUrlParam(UrlParam.Embedded);
     const { destinationAsset, destination } = setDestination(
         setAssetReceive,
         setInvoice,
@@ -220,6 +224,35 @@ const handleUrlParams = (
                 setReceiveAmount(BigNumber(receiveAmount));
             }
         }
+    } else if (
+        destinationAsset === LN &&
+        destination !== undefined &&
+        isInvoice(destination) &&
+        !isLnurl(destination)
+    ) {
+        if (
+            embedded === "true" &&
+            getUrlParam(UrlParam.LockOutput) === "true"
+        ) {
+            setDestinationLocked(true);
+        }
+
+        // Extract fixed-amount lightning invoice and pre-populate amounts
+        try {
+            const sats = decodeInvoice(destination).satoshis;
+            if (sats > 0) {
+                setAmountChanged(Side.Receive);
+                setReceiveAmount(BigNumber(sats));
+                setQuoteLoading(true);
+                const sendAmt = await pair().calculateSendAmount(
+                    BigNumber(sats),
+                    minerFee(),
+                );
+                setSendAmount(sendAmt);
+            }
+        } catch {
+            // Invalid invoice, ignore
+        }
     }
 
     const params = [
@@ -228,6 +261,9 @@ const handleUrlParams = (
         UrlParam.ReceiveAsset,
         UrlParam.SendAmount,
         UrlParam.ReceiveAmount,
+        UrlParam.Embedded,
+        UrlParam.Theme,
+        UrlParam.LockOutput,
     ];
 
     if (
@@ -297,6 +333,8 @@ export type CreateContextType = {
     setBolt12Loading: Setter<boolean>;
     quoteLoading: Accessor<boolean>;
     setQuoteLoading: Setter<boolean>;
+    destinationLocked: Accessor<boolean>;
+    setDestinationLocked: Setter<boolean>;
 };
 
 const CreateContext = createContext<CreateContextType>();
@@ -347,8 +385,12 @@ const CreateProvider = (props: { children: JSX.Element }) => {
     );
     const [bolt12Loading, setBolt12Loading] = createSignal(false);
     const [quoteLoading, setQuoteLoading] = createSignal(false);
+    const [destinationLocked, setDestinationLocked] = createSignal(false);
 
     const resetDestinationState = () => {
+        if (destinationLocked()) {
+            return;
+        }
         setInvoice("");
         setInvoiceValid(false);
         setInvoiceError(undefined);
@@ -448,7 +490,7 @@ const CreateProvider = (props: { children: JSX.Element }) => {
     const [minerFee, setMinerFee] = createSignal(0);
 
     // eslint-disable-next-line solid/reactivity
-    handleUrlParams(
+    void handleUrlParams(
         pair,
         setPair,
         setInvoice,
@@ -458,6 +500,9 @@ const CreateProvider = (props: { children: JSX.Element }) => {
         setReceiveAmount,
         setAddressValid,
         setInvoiceValid,
+        setDestinationLocked,
+        setQuoteLoading,
+        minerFee,
         navigate,
     );
 
@@ -516,6 +561,8 @@ const CreateProvider = (props: { children: JSX.Element }) => {
                 setBolt12Loading,
                 quoteLoading,
                 setQuoteLoading,
+                destinationLocked,
+                setDestinationLocked,
             }}>
             {props.children}
         </CreateContext.Provider>

--- a/src/context/Global.tsx
+++ b/src/context/Global.tsx
@@ -100,6 +100,8 @@ export type GlobalContextType = {
     setZeroConf: Setter<boolean>;
     bitcoinOnly: Accessor<boolean>;
     setBitcoinOnly: Setter<boolean>;
+    embeddedMode: Accessor<boolean>;
+    setEmbeddedMode: Setter<boolean>;
     // functions
     t: tFn;
     notify: notifyFn;
@@ -142,7 +144,10 @@ export type GlobalContextType = {
 
 const GlobalContext = createContext<GlobalContextType>();
 
-const GlobalProvider = (props: { children: JSX.Element }) => {
+const GlobalProvider = (props: {
+    children: JSX.Element;
+    initialEmbeddedMode?: boolean;
+}) => {
     const [online, setOnline] = createSignal<boolean>(true);
     const [pairs, setPairs] = createSignal<Pairs | undefined>(undefined);
     const [regularPairs, setRegularPairs] = createSignal<Pairs | undefined>(
@@ -502,6 +507,10 @@ const GlobalProvider = (props: { children: JSX.Element }) => {
         },
     );
 
+    const [embeddedMode, setEmbeddedMode] = createSignal<boolean>(
+        props.initialEmbeddedMode ?? false,
+    );
+
     createEffect(() => {
         if (isMobile()) {
             setZeroConf(true);
@@ -583,6 +592,8 @@ const GlobalProvider = (props: { children: JSX.Element }) => {
                 setZeroConf,
                 bitcoinOnly,
                 setBitcoinOnly,
+                embeddedMode,
+                setEmbeddedMode,
                 // functions
                 t,
                 notify,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,12 +4,12 @@ import "@fontsource/noto-sans/200.css";
 import "@fontsource/noto-sans/800.css";
 import "@fontsource/noto-sans/index.css";
 import {
-  Navigate,
-  Route,
-  type RouteSectionProps,
-  Router,
-  useLocation,
-  useParams,
+    Navigate,
+    Route,
+    type RouteSectionProps,
+    Router,
+    useLocation,
+    useParams,
 } from "@solidjs/router";
 import { setLogger } from "boltz-swaps/logger";
 import log from "loglevel";
@@ -56,11 +56,11 @@ setLogger(log);
 configureBoltzSwaps();
 
 if ("serviceWorker" in navigator) {
-  void navigator.serviceWorker
-    .register("/service-worker.js", { scope: "/" })
-    .then((reg) => {
-      log.info(`Registration succeeded. Scope is ${reg.scope}`);
-    });
+    void navigator.serviceWorker
+        .register("/service-worker.js", { scope: "/" })
+        .then((reg) => {
+            log.info(`Registration succeeded. Scope is ${reg.scope}`);
+        });
 }
 
 log.setLevel(config.loglevel as log.LogLevelDesc);
@@ -72,130 +72,130 @@ const themeParam = urlParams.get("theme");
 const isEmbedded = embeddedParam === "true";
 const validThemes = ["default", "pro", "light"];
 const initialTheme = isEmbedded
-  ? validThemes.includes(themeParam || "")
-    ? themeParam!
-    : "default"
-  : config.isPro
-    ? "pro"
-    : "default";
+    ? validThemes.includes(themeParam || "")
+        ? themeParam!
+        : "default"
+    : config.isPro
+      ? "pro"
+      : "default";
 document.documentElement.setAttribute("boltz-theme", initialTheme);
 document.body.classList.remove("loading");
 
 const App = (props: RouteSectionProps) => {
-  const isEmbedded = embeddedParam === "true";
-  const location = useLocation();
+    const isEmbedded = embeddedParam === "true";
+    const location = useLocation();
 
-  const isSwapRoute = () => location.pathname.startsWith("/swap");
+    const isSwapRoute = () => location.pathname.startsWith("/swap");
 
-  return (
-    <GlobalProvider initialEmbeddedMode={isEmbedded}>
-      <FiatProvider>
-        <Web3SignerProvider>
-          <WalletConnect />
-          <CreateProvider>
-            <PayProvider>
-              <RescueProvider>
-                <SwapChecker />
-                <SwapExecutionWorker />
-                <Chatwoot />
-                <Show when={!isEmbedded}>
-                  <Nav
-                    isPro={config.isPro}
-                    network={config.network}
-                  />
-                </Show>
-                <Show when={!isEmbedded || isSwapRoute()}>
-                  {props.children}
-                </Show>
-                <Show when={isEmbedded && !isSwapRoute()}>
-                  <Create />
-                </Show>
-                <Notification />
-                <Show when={!isEmbedded}>
-                  <Footer />
-                </Show>
-              </RescueProvider>
-            </PayProvider>
-          </CreateProvider>
-        </Web3SignerProvider>
-      </FiatProvider>
-    </GlobalProvider>
-  );
+    return (
+        <GlobalProvider initialEmbeddedMode={isEmbedded}>
+            <FiatProvider>
+                <Web3SignerProvider>
+                    <WalletConnect />
+                    <CreateProvider>
+                        <PayProvider>
+                            <RescueProvider>
+                                <SwapChecker />
+                                <SwapExecutionWorker />
+                                <Chatwoot />
+                                <Show when={!isEmbedded}>
+                                    <Nav
+                                        isPro={config.isPro}
+                                        network={config.network}
+                                    />
+                                </Show>
+                                <Show when={!isEmbedded || isSwapRoute()}>
+                                    {props.children}
+                                </Show>
+                                <Show when={isEmbedded && !isSwapRoute()}>
+                                    <Create />
+                                </Show>
+                                <Notification />
+                                <Show when={!isEmbedded}>
+                                    <Footer />
+                                </Show>
+                            </RescueProvider>
+                        </PayProvider>
+                    </CreateProvider>
+                </Web3SignerProvider>
+            </FiatProvider>
+        </GlobalProvider>
+    );
 };
 
 const redirectRefundToRescue = () => {
-  const search = window.location.search;
+    const search = window.location.search;
 
-  return (
-    <>
-      <Route
-        path="/refund"
-        component={() => <Navigate href={`/rescue${search}`} />}
-      />
-      <Route
-        path="/refund/external"
-        component={() => (
-          <Navigate href={`/rescue/external${search}`} />
-        )}
-      />
-      <Route
-        path="/refund/external/:type"
-        component={() => {
-          const params = useParams<{ type: string }>();
-          return (
-            <Navigate
-              href={`/rescue/external/${params.type}${search}`}
+    return (
+        <>
+            <Route
+                path="/refund"
+                component={() => <Navigate href={`/rescue${search}`} />}
             />
-          );
-        }}
-      />
-    </>
-  );
+            <Route
+                path="/refund/external"
+                component={() => (
+                    <Navigate href={`/rescue/external${search}`} />
+                )}
+            />
+            <Route
+                path="/refund/external/:type"
+                component={() => {
+                    const params = useParams<{ type: string }>();
+                    return (
+                        <Navigate
+                            href={`/rescue/external/${params.type}${search}`}
+                        />
+                    );
+                }}
+            />
+        </>
+    );
 };
 
 const cleanup = render(
-  () => (
-    <Router root={App}>
-      <Route path="/" component={Hero} />
-      <Route path="/swap" component={Create} />
-      <Route path="/products" component={Products} />
-      <Route path="/products/btcpay" component={Btcpay} />
-      <Route path="/products/client" component={Client} />
-      <Route path="/products/pro" component={Pro} />
-      {/* Compatibility with link in Breez:
+    () => (
+        <Router root={App}>
+            <Route path="/" component={Hero} />
+            <Route path="/swap" component={Create} />
+            <Route path="/products" component={Products} />
+            <Route path="/products/btcpay" component={Btcpay} />
+            <Route path="/products/client" component={Client} />
+            <Route path="/products/pro" component={Pro} />
+            {/* Compatibility with link in Breez:
                                 https://github.com/breez/breezmobile/blob/a1b0ffff902dfa2210af8fdb047b715535ff11e9/src/json/vendors.json#L30 */}
-      <Route path="/swapbox" component={Create} />
-      <Route path="/swap/:id" component={Pay} />
-      <Route path="/swap/:id/claim" component={ClaimRescue} />
-      <Route
-        path="/swap/rescue/evm/gas-abstraction/:asset/:address/:action"
-        component={GasAbstractionSweepRescue}
-      />
-      <Route
-        path="/swap/rescue/evm/:asset/:txHash/:action"
-        component={RescueEvm}
-      />
-      <Route path="/error" component={() => <Error />} />
-      <Route path="/rescue" component={Rescue} />
-      <Route path="/rescue/external" component={RescueExternal} />
-      <Route path="/rescue/external/:type" component={RescueExternal} />
-      <Route
-        path="/rescue/external/:type/:mode"
-        component={RescueExternal}
-      />
-      <Route path="/rescue/claim/:id" component={ClaimRescue} />
-      <Route path="/rescue/refund/:id" component={RefundRescue} />
-      {redirectRefundToRescue()}
-      <Route path="/history" component={History} />
-      <Route path="/terms" component={Terms} />
-      <Route path="/privacy" component={Privacy} />
-      <Route path="*404" component={NotFound} />
-    </Router>
-  ),
-  document.getElementById("root")!,
+            <Route path="/swapbox" component={Create} />
+            <Route path="/swap/:id" component={Pay} />
+            <Route path="/swap/:id/claim" component={ClaimRescue} />
+            <Route
+                path="/swap/rescue/evm/gas-abstraction/:asset/:address/:action"
+                component={GasAbstractionSweepRescue}
+            />
+            <Route
+                path="/swap/rescue/evm/:asset/:txHash/:action"
+                component={RescueEvm}
+            />
+            <Route path="/error" component={() => <Error />} />
+            <Route path="/rescue" component={Rescue} />
+            <Route path="/rescue/external" component={RescueExternal} />
+            <Route path="/rescue/external/:type" component={RescueExternal} />
+            <Route
+                path="/rescue/external/:type/:mode"
+                component={RescueExternal}
+            />
+            <Route path="/rescue/claim/:id" component={ClaimRescue} />
+            <Route path="/rescue/refund/:id" component={RefundRescue} />
+            {redirectRefundToRescue()}
+            <Route path="/history" component={History} />
+            <Route path="/terms" component={Terms} />
+            <Route path="/privacy" component={Privacy} />
+            <Route path="*404" component={NotFound} />
+        </Router>
+    ),
+    document.getElementById("root")!,
 );
 
 if (import.meta.hot) {
-  log.info("Hot reload");
-  import.meta.hot.dispose(cleanup);
+    log.info("Hot reload");
+    import.meta.hot.dispose(cleanup);
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,8 +21,6 @@ import Chatwoot from "./chatwoot";
 import Footer from "./components/Footer";
 import Nav from "./components/Nav";
 import Notification from "./components/Notification";
-import { SwapChecker } from "./components/SwapChecker";
-import { SwapExecutionWorker } from "./components/SwapExecutionWorker";
 import { WalletConnect } from "./components/WalletConnect";
 import { config } from "./config";
 import { CreateProvider } from "./context/Create";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,12 +4,12 @@ import "@fontsource/noto-sans/200.css";
 import "@fontsource/noto-sans/800.css";
 import "@fontsource/noto-sans/index.css";
 import {
-    Navigate,
-    Route,
-    type RouteSectionProps,
-    Router,
-    useLocation,
-    useParams,
+  Navigate,
+  Route,
+  type RouteSectionProps,
+  Router,
+  useLocation,
+  useParams,
 } from "@solidjs/router";
 import { setLogger } from "boltz-swaps/logger";
 import log from "loglevel";
@@ -21,6 +21,8 @@ import Chatwoot from "./chatwoot";
 import Footer from "./components/Footer";
 import Nav from "./components/Nav";
 import Notification from "./components/Notification";
+import { SwapChecker } from "./components/SwapChecker";
+import { SwapExecutionWorker } from "./components/SwapExecutionWorker";
 import { WalletConnect } from "./components/WalletConnect";
 import { config } from "./config";
 import { CreateProvider } from "./context/Create";
@@ -54,11 +56,11 @@ setLogger(log);
 configureBoltzSwaps();
 
 if ("serviceWorker" in navigator) {
-    void navigator.serviceWorker
-        .register("/service-worker.js", { scope: "/" })
-        .then((reg) => {
-            log.info(`Registration succeeded. Scope is ${reg.scope}`);
-        });
+  void navigator.serviceWorker
+    .register("/service-worker.js", { scope: "/" })
+    .then((reg) => {
+      log.info(`Registration succeeded. Scope is ${reg.scope}`);
+    });
 }
 
 log.setLevel(config.loglevel as log.LogLevelDesc);
@@ -68,126 +70,132 @@ const embeddedParam = urlParams.get("embedded");
 const themeParam = urlParams.get("theme");
 
 const isEmbedded = embeddedParam === "true";
+const validThemes = ["default", "pro", "light"];
 const initialTheme = isEmbedded
-    ? (themeParam ?? "default")
-    : config.isPro
-      ? "pro"
-      : "default";
+  ? validThemes.includes(themeParam || "")
+    ? themeParam!
+    : "default"
+  : config.isPro
+    ? "pro"
+    : "default";
 document.documentElement.setAttribute("boltz-theme", initialTheme);
 document.body.classList.remove("loading");
 
 const App = (props: RouteSectionProps) => {
-    const isEmbedded = embeddedParam === "true";
-    const location = useLocation();
+  const isEmbedded = embeddedParam === "true";
+  const location = useLocation();
 
-    const isSwapRoute = () => location.pathname.startsWith("/swap");
+  const isSwapRoute = () => location.pathname.startsWith("/swap");
 
-    return (
-        <GlobalProvider initialEmbeddedMode={isEmbedded}>
-            <FiatProvider>
-                <Web3SignerProvider>
-                    <WalletConnect />
-                    <CreateProvider>
-                        <PayProvider>
-                            <RescueProvider>
-                            <Show when={!isEmbedded}>
-                                <Nav
-                                    isPro={config.isPro}
-                                    network={config.network}
-                                />
-                            </Show>
-                            <Show when={!isEmbedded || isSwapRoute()}>
-                                {props.children}
-                            </Show>
-                            <Show when={isEmbedded && !isSwapRoute()}>
-                                <Create />
-                            </Show>
-                            <Notification />
-                            <Show when={!isEmbedded}>
-                                <Footer />
-                            </Show>
-                            </RescueProvider>
-                        </PayProvider>
-                    </CreateProvider>
-                </Web3SignerProvider>
-            </FiatProvider>
-        </GlobalProvider>
-    );
+  return (
+    <GlobalProvider initialEmbeddedMode={isEmbedded}>
+      <FiatProvider>
+        <Web3SignerProvider>
+          <WalletConnect />
+          <CreateProvider>
+            <PayProvider>
+              <RescueProvider>
+                <SwapChecker />
+                <SwapExecutionWorker />
+                <Chatwoot />
+                <Show when={!isEmbedded}>
+                  <Nav
+                    isPro={config.isPro}
+                    network={config.network}
+                  />
+                </Show>
+                <Show when={!isEmbedded || isSwapRoute()}>
+                  {props.children}
+                </Show>
+                <Show when={isEmbedded && !isSwapRoute()}>
+                  <Create />
+                </Show>
+                <Notification />
+                <Show when={!isEmbedded}>
+                  <Footer />
+                </Show>
+              </RescueProvider>
+            </PayProvider>
+          </CreateProvider>
+        </Web3SignerProvider>
+      </FiatProvider>
+    </GlobalProvider>
+  );
 };
 
 const redirectRefundToRescue = () => {
-    const search = window.location.search;
+  const search = window.location.search;
 
-    return (
-        <>
-            <Route
-                path="/refund"
-                component={() => <Navigate href={`/rescue${search}`} />}
+  return (
+    <>
+      <Route
+        path="/refund"
+        component={() => <Navigate href={`/rescue${search}`} />}
+      />
+      <Route
+        path="/refund/external"
+        component={() => (
+          <Navigate href={`/rescue/external${search}`} />
+        )}
+      />
+      <Route
+        path="/refund/external/:type"
+        component={() => {
+          const params = useParams<{ type: string }>();
+          return (
+            <Navigate
+              href={`/rescue/external/${params.type}${search}`}
             />
-            <Route
-                path="/refund/external"
-                component={() => (
-                    <Navigate href={`/rescue/external${search}`} />
-                )}
-            />
-            <Route
-                path="/refund/external/:type"
-                component={() => {
-                    const params = useParams<{ type: string }>();
-                    return (
-                        <Navigate
-                            href={`/rescue/external/${params.type}${search}`}
-                        />
-                    );
-                }}
-            />
-        </>
-    );
+          );
+        }}
+      />
+    </>
+  );
 };
 
 const cleanup = render(
-    () => (
-        <Router root={App}>
-            <Route path="/" component={Hero} />
-            <Route path="/swap" component={Create} />
-            <Route path="/products" component={Products} />
-            <Route path="/products/btcpay" component={Btcpay} />
-            <Route path="/products/client" component={Client} />
-            <Route path="/products/pro" component={Pro} />
-            {/* Compatibility with link in Breez:
+  () => (
+    <Router root={App}>
+      <Route path="/" component={Hero} />
+      <Route path="/swap" component={Create} />
+      <Route path="/products" component={Products} />
+      <Route path="/products/btcpay" component={Btcpay} />
+      <Route path="/products/client" component={Client} />
+      <Route path="/products/pro" component={Pro} />
+      {/* Compatibility with link in Breez:
                                 https://github.com/breez/breezmobile/blob/a1b0ffff902dfa2210af8fdb047b715535ff11e9/src/json/vendors.json#L30 */}
-            <Route path="/swapbox" component={Create} />
-            <Route path="/swap/:id" component={Pay} />
-            <Route path="/swap/:id/claim" component={ClaimRescue} />
-            <Route
-                path="/swap/rescue/evm/gas-abstraction/:asset/:address/:action"
-                component={GasAbstractionSweepRescue}
-            />
-            <Route
-                path="/swap/rescue/evm/:asset/:txHash/:action"
-                component={RescueEvm}
-            />
-            <Route path="/error" component={() => <Error />} />
-            <Route path="/rescue" component={Rescue} />
-            <Route path="/rescue/external" component={RescueExternal} />
-            <Route path="/rescue/external/:type" component={RescueExternal} />
-            <Route
-                path="/rescue/external/:type/:mode"
-                component={RescueExternal}
-            />
-            <Route path="/rescue/claim/:id" component={ClaimRescue} />
-            <Route path="/rescue/refund/:id" component={RefundRescue} />
-            {redirectRefundToRescue()}
-            <Route path="/history" component={History} />
-            <Route path="/terms" component={Terms} />
-            <Route path="/privacy" component={Privacy} />
-            <Route path="*404" component={NotFound} />
-        </Router>
-    ),
-    document.getElementById("root")!,
+      <Route path="/swapbox" component={Create} />
+      <Route path="/swap/:id" component={Pay} />
+      <Route path="/swap/:id/claim" component={ClaimRescue} />
+      <Route
+        path="/swap/rescue/evm/gas-abstraction/:asset/:address/:action"
+        component={GasAbstractionSweepRescue}
+      />
+      <Route
+        path="/swap/rescue/evm/:asset/:txHash/:action"
+        component={RescueEvm}
+      />
+      <Route path="/error" component={() => <Error />} />
+      <Route path="/rescue" component={Rescue} />
+      <Route path="/rescue/external" component={RescueExternal} />
+      <Route path="/rescue/external/:type" component={RescueExternal} />
+      <Route
+        path="/rescue/external/:type/:mode"
+        component={RescueExternal}
+      />
+      <Route path="/rescue/claim/:id" component={ClaimRescue} />
+      <Route path="/rescue/refund/:id" component={RefundRescue} />
+      {redirectRefundToRescue()}
+      <Route path="/history" component={History} />
+      <Route path="/terms" component={Terms} />
+      <Route path="/privacy" component={Privacy} />
+      <Route path="*404" component={NotFound} />
+    </Router>
+  ),
+  document.getElementById("root")!,
 );
 
 if (import.meta.hot) {
-    log.info("Hot reload");
-    import.meta.hot.dispose(cleanup);
+  log.info("Hot reload");
+  import.meta.hot.dispose(cleanup);
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,10 +8,12 @@ import {
     Route,
     type RouteSectionProps,
     Router,
+    useLocation,
     useParams,
 } from "@solidjs/router";
 import { setLogger } from "boltz-swaps/logger";
 import log from "loglevel";
+import { Show } from "solid-js";
 import { render } from "solid-js/web";
 
 import { configureBoltzSwaps } from "./boltzSwapsConfig";
@@ -62,31 +64,50 @@ if ("serviceWorker" in navigator) {
 }
 
 log.setLevel(config.loglevel as log.LogLevelDesc);
-document.documentElement.setAttribute(
-    "boltz-theme",
-    config.isPro ? "pro" : "default",
-);
+
+const urlParams = new URLSearchParams(window.location.search);
+const embeddedParam = urlParams.get("embedded");
+const themeParam = urlParams.get("theme");
+
+const isEmbedded = embeddedParam === "true";
+const initialTheme = isEmbedded
+    ? (themeParam ?? "default")
+    : config.isPro
+      ? "pro"
+      : "default";
+document.documentElement.setAttribute("boltz-theme", initialTheme);
 document.body.classList.remove("loading");
 
 const App = (props: RouteSectionProps) => {
+    const isEmbedded = embeddedParam === "true";
+    const location = useLocation();
+
+    const isSwapRoute = () => location.pathname.startsWith("/swap");
+
     return (
-        <GlobalProvider>
+        <GlobalProvider initialEmbeddedMode={isEmbedded}>
             <FiatProvider>
                 <Web3SignerProvider>
                     <WalletConnect />
                     <CreateProvider>
                         <PayProvider>
                             <RescueProvider>
-                                <SwapChecker />
-                                <SwapExecutionWorker />
-                                <Chatwoot />
+                            <Show when={!isEmbedded}>
                                 <Nav
                                     isPro={config.isPro}
                                     network={config.network}
                                 />
+                            </Show>
+                            <Show when={!isEmbedded || isSwapRoute()}>
                                 {props.children}
-                                <Notification />
+                            </Show>
+                            <Show when={isEmbedded && !isSwapRoute()}>
+                                <Create />
+                            </Show>
+                            <Notification />
+                            <Show when={!isEmbedded}>
                                 <Footer />
+                            </Show>
                             </RescueProvider>
                         </PayProvider>
                     </CreateProvider>

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -906,7 +906,7 @@ const Create = () => {
                     </Show>
                     <div classList={{ hidden: destinationLocked() }}>
                         <InvoiceInput />
-                    <hr class="spacer" />
+                        <hr class="spacer" />
                     </div>
                 </Show>
                 <Show

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -928,8 +928,10 @@ const Create = () => {
                             pair().toAsset !== RBTC &&
                             !connectedDestination()
                         }>
-                        <AddressInput />
-                        <hr class="spacer" />
+                        <div classList={{ hidden: destinationLocked() }}>
+                            <hr class="spacer" />
+                            <AddressInput />
+                        </div>
                     </Show>
                     <ConnectWallet
                         asset={walletConnectAsset()}

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -78,6 +78,7 @@ const Create = () => {
         pairs,
         regularPairs,
         gasTopUp,
+        embeddedMode,
     } = useGlobalContext();
     const { fetchBtcPrice } = useFiatContext();
     const {
@@ -111,6 +112,7 @@ const Create = () => {
         onchainAddress,
         quoteLoading,
         setQuoteLoading,
+        destinationLocked,
     } = useCreateContext();
     const { connectedWallet } = useWeb3Signer();
 
@@ -708,7 +710,13 @@ const Create = () => {
                 <h2 class="frame-title" data-testid="create-swap-title">
                     {t("create_swap")}
                 </h2>
-                <Show when={config.isPro && pairs() && regularPairs()}>
+                <Show
+                    when={
+                        config.isPro &&
+                        pairs() &&
+                        regularPairs() &&
+                        !embeddedMode()
+                    }>
                     <Accordion
                         title={t("swap_opportunities_accordion")}
                         isOpen={isAccordionOpen()}
@@ -782,7 +790,10 @@ const Create = () => {
                                     id="sendAmount"
                                     data-testid="sendAmount"
                                     autocomplete="off"
-                                    disabled={sendAmountQuoteLoading()}
+                                    disabled={
+                                        sendAmountQuoteLoading() ||
+                                        destinationLocked()
+                                    }
                                     classList={{
                                         "amount-input--quote-pending":
                                             sendAmountQuoteLoading(),
@@ -803,11 +814,14 @@ const Create = () => {
                             />
                         </div>
                     </div>
-                    <Reverse />
+                    <Show when={!destinationLocked()}>
+                        <Reverse />
+                    </Show>
                     <div>
                         <Asset
                             side={Side.Receive}
                             signal={() => pair().toAsset}
+                            disabled={destinationLocked()}
                         />
                         <div class="amount-field input-with-label">
                             <div class="amount-input-wrap">
@@ -841,7 +855,10 @@ const Create = () => {
                                     id="receiveAmount"
                                     data-testid="receiveAmount"
                                     autocomplete="off"
-                                    disabled={receiveAmountQuoteLoading()}
+                                    disabled={
+                                        receiveAmountQuoteLoading() ||
+                                        destinationLocked()
+                                    }
                                     classList={{
                                         "amount-input--quote-pending":
                                             receiveAmountQuoteLoading(),
@@ -872,8 +889,10 @@ const Create = () => {
                                 pair().toAsset !== LN)) &&
                         !isWalletConnectableAsset(pair().toAsset)
                     }>
-                    <AddressInput />
-                    <hr class="spacer" />
+                    <div classList={{ hidden: destinationLocked() }}>
+                        <AddressInput />
+                        <hr class="spacer" />
+                    </div>
                 </Show>
                 <Show
                     when={
@@ -885,8 +904,10 @@ const Create = () => {
                         <WeblnButton />
                         <hr class="spacer" />
                     </Show>
-                    <InvoiceInput />
+                    <div classList={{ hidden: destinationLocked() }}>
+                        <InvoiceInput />
                     <hr class="spacer" />
+                    </div>
                 </Show>
                 <Show
                     when={
@@ -918,9 +939,31 @@ const Create = () => {
                         }
                         disabled={() => !pair().isRoutable}
                     />
+                    {/* We have no gas abstraction for RBTC */}
+                    <Show
+                        when={
+                            isWalletConnectableAsset(pair().toAsset) &&
+                            pair().toAsset !== RBTC &&
+                            !connectedDestination()
+                        }>
+                        <div classList={{ hidden: destinationLocked() }}>
+                            <hr class="spacer" />
+                            <AddressInput />
+                        </div>
+                    </Show>
                     <hr class="spacer" />
                 </Show>
                 <CreateButton />
+                <Show when={embeddedMode()}>
+                    <div class="embedded-branding">
+                        <a
+                            href="https://boltz.exchange"
+                            target="_blank"
+                            rel="noopener noreferrer">
+                            Powered by Boltz
+                        </a>
+                    </div>
+                </Show>
                 <AssetSelect />
                 <NetworkSelect />
                 <SettingsMenu />

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -939,18 +939,6 @@ const Create = () => {
                         }
                         disabled={() => !pair().isRoutable}
                     />
-                    {/* We have no gas abstraction for RBTC */}
-                    <Show
-                        when={
-                            isWalletConnectableAsset(pair().toAsset) &&
-                            pair().toAsset !== RBTC &&
-                            !connectedDestination()
-                        }>
-                        <div classList={{ hidden: destinationLocked() }}>
-                            <hr class="spacer" />
-                            <AddressInput />
-                        </div>
-                    </Show>
                     <hr class="spacer" />
                 </Show>
                 <CreateButton />

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -1741,15 +1741,15 @@ header {
     text-align: center;
     margin-top: 12px;
     font-size: 12px;
-    opacity: 0.6;
 
     a {
         color: var(--color-text);
         text-decoration: none;
+        opacity: 0.6;
         transition: opacity 0.2s ease;
 
         &:hover {
-            opacity: 0.8;
+            opacity: 1;
             text-decoration: underline;
         }
     }

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -905,7 +905,7 @@ textarea.invalid {
     }
 }
 .denomination img {
-    filter: brightness(10);
+    filter: var(--icon-filter);
     cursor: pointer;
     width: 28px;
 }
@@ -915,7 +915,7 @@ textarea.invalid {
 }
 
 .denominator {
-    filter: brightness(10);
+    filter: var(--icon-filter);
     width: 15px;
     height: 11px;
     background-repeat: no-repeat;
@@ -1735,4 +1735,22 @@ header {
     align-items: center;
     opacity: 0.5;
     border-bottom: 1px dotted var(--color-white-50);
+}
+
+.embedded-branding {
+    text-align: center;
+    margin-top: 12px;
+    font-size: 12px;
+    opacity: 0.6;
+
+    a {
+        color: var(--color-text);
+        text-decoration: none;
+        transition: opacity 0.2s ease;
+
+        &:hover {
+            opacity: 0.8;
+            text-decoration: underline;
+        }
+    }
 }

--- a/src/style/theme.scss
+++ b/src/style/theme.scss
@@ -43,6 +43,7 @@ $boltz_icon: url(/boltz-icon.svg);
     // Black opacity levels
     --color-black-10: color-mix(in srgb, var(--color-black) 10%, transparent);
     --color-black-20: color-mix(in srgb, var(--color-black) 20%, transparent);
+    --color-black-25: color-mix(in srgb, var(--color-black) 25%, transparent);
     --color-black-30: color-mix(in srgb, var(--color-black) 30%, transparent);
     --color-black-40: color-mix(in srgb, var(--color-black) 40%, transparent);
     --color-black-50: color-mix(in srgb, var(--color-black) 50%, transparent);

--- a/src/style/theme.scss
+++ b/src/style/theme.scss
@@ -127,6 +127,8 @@ $boltz_icon: url(/boltz-icon.svg);
         var(--color-link-hover) 80%,
         transparent
     );
+
+    --icon-filter: brightness(10);
 }
 
 :root[boltz-theme="pro"] {
@@ -171,4 +173,82 @@ $boltz_icon: url(/boltz-icon.svg);
         var(--color-link-hover) 80%,
         transparent
     );
+
+    --icon-filter: brightness(10);
+}
+
+:root[boltz-theme="light"] {
+    --color-primary: #c47835;
+    --color-primary-lighter: #da9457;
+    --color-primary-glow: color-mix(
+        in srgb,
+        var(--color-primary) 40%,
+        transparent
+    );
+
+    --color-secondary-100: #3a3a4a;
+    --color-secondary-200: #5a5a6a;
+    --color-secondary-300: #8a8a9a;
+    --color-secondary-500: #c0c0d0;
+    --color-secondary-600: #f5f5f7;
+    --color-secondary-700: #ffffff;
+    --color-secondary-800: #e8e8ec;
+    --color-secondary-900: #d8d8de;
+
+    --color-tertiary: #7a5aad;
+
+    --color-text: #2d2d3d;
+    --color-text-glow: color-mix(in srgb, var(--color-text) 35%, transparent);
+    --color-dark-gray: #d0d0d8;
+    --color-hero-gradient-1: #da9457;
+    --color-hero-gradient-2: #c47835;
+    --color-error-500: #ffcccc;
+    --color-error-700: #ffaaaa;
+    --color-success-400: #90ee90;
+    --color-success-500: #228b22;
+    --color-success-700: #006400;
+
+    --color-link: #0066cc;
+    --color-link-hover: #0088ff;
+    --color-link-glow: color-mix(
+        in srgb,
+        var(--color-link-hover) 80%,
+        transparent
+    );
+
+    // Invert white opacities to black opacities for visible borders on light bg
+    --color-white-05: color-mix(in srgb, var(--color-black) 5%, transparent);
+    --color-white-10: color-mix(in srgb, var(--color-black) 10%, transparent);
+    --color-white-15: color-mix(in srgb, var(--color-black) 15%, transparent);
+    --color-white-25: color-mix(in srgb, var(--color-black) 25%, transparent);
+    --color-white-30: color-mix(in srgb, var(--color-black) 30%, transparent);
+    --color-white-50: color-mix(in srgb, var(--color-black) 50%, transparent);
+    --color-white-60: color-mix(in srgb, var(--color-black) 60%, transparent);
+    --color-white-80: color-mix(in srgb, var(--color-black) 80%, transparent);
+    --color-white-90: color-mix(in srgb, var(--color-black) 90%, transparent);
+
+    --icon-filter: none;
+
+    .asset-select-modal {
+        background: var(--color-secondary-700);
+        box-shadow: 0 8px 32px var(--color-black-25);
+    }
+
+    .asset-select-item[data-selected="true"] {
+        background: var(--color-secondary-800);
+    }
+
+    .asset-select-item[data-focused="true"],
+    .asset-select-item:hover {
+        background: var(--color-secondary-900);
+    }
+
+    .asset-select-search input {
+        background: var(--color-secondary-800);
+    }
+
+    // Settings menu and dropdown overlays: need white backdrop in light theme
+    .assets-select:after {
+        background: rgba(255, 255, 255, 0.95);
+    }
 }


### PR DESCRIPTION
This adds the following new features
- A light theme that currently only activates in embed mode and re-styles the swap form. It re-uses colors from default and pro. Can be activated via query param
- A `embedded` query param that reduces the full page view to only the swap form. Allows to show just the form in iFrame embeds
- A `lockOutput` query param. Currently this is only respected if the swap destination is an LN invoice. It disables the destination form element and hides the `paste invoice` input. It also prevents the destination (invoice) from being cleared when changing the sendAsset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedded mode for Lightning invoices with URL-driven destination locking and automatic pre-fill of amounts
  * New light theme option

* **Improvements**
  * Inputs, controls and asset selectors disable or hide when destination is locked to prevent edits
  * Invoice/amounts preserved when destination is locked (no unintended resets)
  * Layout adapts when embedded; embedded branding relocated
  * Icon/filter and asset selection styling refined

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoltzExchange/boltz-web-app/pull/1470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->