### PR TITLE
fix: allow refunding 'transaction.claim.pending' swap with extra utxos

### DIFF
--- a/src/utils/rescue.ts
+++ b/src/utils/rescue.ts
@@ -566,9 +566,15 @@ export const createRescueList = async (
                     return { ...swap, action: RescueAction.Claim };
                 }
 
+                const pendingFromUserPerspective = Object.values(
+                    swapStatusPending,
+                ).filter(
+                    (status) =>
+                        status !== swapStatusPending.TransactionClaimPending,
+                );
                 if (
                     isRefundableSwapType(swap) &&
-                    !Object.values(swapStatusPending).includes(status) &&
+                    !pendingFromUserPerspective.includes(status) &&
                     utxos.length > 0
                 ) {
                     return {

--- a/tests/utils/rescue.spec.ts
+++ b/tests/utils/rescue.spec.ts
@@ -361,6 +361,22 @@ describe("rescue", () => {
             expect(result[0].timedOut).toBe(true);
         });
 
+        test("should allow refunding claim-pending swaps with extra UTXOs", async () => {
+            const swaps = [
+                createMockSubmarineSwap({
+                    status: swapStatusPending.TransactionClaimPending,
+                    timeoutBlockHeight: 1200,
+                    assetSend: BTC,
+                }),
+            ];
+
+            mockGetSwapUTXOs.mockResolvedValue([{ hex: "mock-tx" }]);
+
+            const result = await createRescueList(swaps, zeroConf);
+            expect(result).toHaveLength(1);
+            expect(result[0].action).toBe(RescueAction.Refund);
+        });
+
         test("should not show RBTC as Refundable", async () => {
             const swaps = [
                 createMockSubmarineSwap({
@@ -386,15 +402,25 @@ describe("rescue", () => {
                 action: RescueAction.Successful,
                 createSwap: createMockSubmarineSwap,
             },
-            ...Object.values(swapStatusPending).map((status) => ({
-                status,
-                action: RescueAction.Pending,
-                createSwap: createMockSubmarineSwap,
-            })),
+            ...Object.values(swapStatusPending)
+                .filter(
+                    (status) =>
+                        status !== swapStatusPending.TransactionClaimPending,
+                )
+                .map((status) => ({
+                    status,
+                    action: RescueAction.Pending,
+                    createSwap: createMockSubmarineSwap,
+                })),
             {
                 status: swapStatusPending.TransactionConfirmed,
                 action: RescueAction.Claim,
                 createSwap: createMockReverseSwap,
+            },
+            {
+                status: swapStatusPending.TransactionClaimPending,
+                action: RescueAction.Refund,
+                createSwap: createMockSubmarineSwap,
             },
             {
                 status: swapStatusFailed.TransactionFailed,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap rescue mechanism to enable refunding of swaps awaiting transaction completion when additional UTXOs are available, allowing users to recover funds more effectively in rescue scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoltzExchange/boltz-web-app/pull/1478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->