### PR TITLE
fix: missing "rescue method connected" color on Pro theme

### DIFF
--- a/src/style/theme.scss
+++ b/src/style/theme.scss
@@ -150,6 +150,7 @@ $boltz_icon: url(/boltz-icon.svg);
     --color-hero-gradient-2: #c47835;
     --color-error-500: #77211b;
     --color-error-700: #570d1c;
+    --color-success-400: #2c913f;
     --color-success-500: #0a5217;
     --color-success-700: #043017;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Added a new success color shade to the pro theme, enhancing visual consistency for success-related UI elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoltzExchange/boltz-web-app/pull/1479?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->