### PR TITLE
style: dim down focused input border color

### DIFF
--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -553,7 +553,7 @@ textarea::placeholder {
 input:focus,
 textarea:focus {
     outline: none;
-    border-color: var(--color-primary);
+    border-color: var(--color-primary-60);
 }
 input.invalid,
 textarea.invalid {
@@ -858,11 +858,11 @@ textarea.invalid {
         // for keyboard navigation
         &:focus-visible {
             outline: none;
-            border: 1px solid var(--color-primary);
+            border: 1px solid var(--color-primary-60);
         }
         &.active:focus-visible {
             outline: none;
-            border: 1px solid var(--color-primary);
+            border: 1px solid var(--color-primary-60);
         }
     }
 }
@@ -886,7 +886,7 @@ textarea.invalid {
     background-position: right 0.7rem center;
     &:focus-visible {
         outline: none;
-        border-color: var(--color-primary);
+        border-color: var(--color-primary-60);
     }
     @media (hover: hover) {
         &:hover {
@@ -1197,7 +1197,7 @@ textarea.invalid {
         }
 
         &:focus {
-            border-color: var(--color-primary);
+            border-color: var(--color-primary-60);
         }
     }
 }

--- a/src/style/rescueExternal.scss
+++ b/src/style/rescueExternal.scss
@@ -193,7 +193,7 @@
                 border-radius: 0;
             }
             .mnemonic-input:focus {
-                border-bottom: 1px solid var(--color-primary);
+                border-bottom: 1px solid var(--color-primary-60);
 
                 &.invalid {
                     border-bottom: 1px solid var(--color-error-500);

--- a/src/style/rescueFileInput.scss
+++ b/src/style/rescueFileInput.scss
@@ -39,7 +39,7 @@
     justify-content: center;
     min-height: 2.625rem;
     padding: 0.375rem 2.75rem;
-    border: 0.0625rem dashed var(--color-white-30);
+    border: 0.0625rem solid var(--color-white-15);
     border-radius: 0.625rem;
     background-color: var(--color-black-20);
     cursor: pointer;
@@ -47,9 +47,12 @@
     overflow: hidden;
 }
 
-.rescue-file-input-area:hover,
+.rescue-file-input-area:hover {
+    border-color: var(--color-primary-60);
+}
+
 .rescue-file-input-control:focus-visible + .rescue-file-input-area {
-    border-color: var(--color-primary);
+    border-color: var(--color-primary-60);
 }
 
 .rescue-file-input-area[aria-disabled="true"] {

--- a/src/style/settings.scss
+++ b/src/style/settings.scss
@@ -234,7 +234,7 @@
         outline: none;
 
         &:focus {
-            border-color: var(--color-primary);
+            border-color: var(--color-primary-60);
         }
 
         &::-webkit-outer-spin-button,

--- a/src/style/theme.scss
+++ b/src/style/theme.scss
@@ -87,6 +87,11 @@ $boltz_icon: url(/boltz-icon.svg);
 
 :root[boltz-theme="default"] {
     --color-primary: #e8cb2b;
+    --color-primary-60: color-mix(
+        in srgb,
+        var(--color-primary) 60%,
+        transparent
+    );
     --color-primary-lighter: #fee86b;
     --color-primary-glow: color-mix(
         in srgb,
@@ -126,6 +131,11 @@ $boltz_icon: url(/boltz-icon.svg);
 
 :root[boltz-theme="pro"] {
     --color-primary: #c47835;
+    --color-primary-60: color-mix(
+        in srgb,
+        var(--color-primary) 60%,
+        transparent
+    );
     --color-primary-glow: color-mix(
         in srgb,
         var(--color-primary) 80%,


### PR DESCRIPTION
makes the "focused" border softer and fixes a theme inconsistency on the "select rescue key" component

before
<img width="525" height="344" alt="image" src="https://github.com/user-attachments/assets/2dc69bf8-187b-4292-b22c-381e5c91b66c" />

after
<img width="525" height="344" alt="image" src="https://github.com/user-attachments/assets/82474af2-0d02-4b80-91b9-7908fe468b28" />

before
<img width="598" height="285" alt="image" src="https://github.com/user-attachments/assets/a7513205-b6e5-4184-a5e9-834349df2f1c" />

after
<img width="598" height="285" alt="image" src="https://github.com/user-attachments/assets/bd13e70f-daa9-4677-ae2f-65c7b9402ae3" />

