### PR TITLE
fix: Pro opportunity click not updating assets

### DIFF
--- a/e2e/urlParams.spec.ts
+++ b/e2e/urlParams.spec.ts
@@ -119,6 +119,27 @@ test.describe("URL params", () => {
         );
     });
 
+    test("should apply asset params via client-side navigation to /swap", async ({
+        page,
+    }) => {
+        await page.goto("/products");
+
+        await page.evaluate(() => {
+            const a = document.createElement("a");
+            a.href = "/swap?sendAsset=L-BTC&receiveAsset=LN";
+            document.body.appendChild(a);
+            a.click();
+        });
+
+        await expect(page.getByTestId("asset-send")).toContainClass(
+            `asset-${getAssetDisplaySymbol(LBTC)}`,
+        );
+        await expect(page.getByTestId("asset-receive")).toContainClass(
+            `asset-${getAssetDisplaySymbol(LN)}`,
+        );
+        await expect(page).toHaveURL(/\/swap$/);
+    });
+
     test("should use `?mode=rescue-key` param to display mnemonic input", async ({
         page,
     }) => {

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -63,7 +63,7 @@ const Create = () => {
     let receiveAmountRef: HTMLInputElement | undefined;
     let sendAmountRef: HTMLInputElement | undefined;
 
-    const [searchParams] = useSearchParams();
+    const [searchParams, setSearchParams] = useSearchParams();
     const [isAccordionOpen, setIsAccordionOpen] = createSignal(false);
 
     const {
@@ -667,8 +667,11 @@ const Create = () => {
 
                     return new Pair(current.pairs, fromAsset, toAsset);
                 });
+                setSearchParams(
+                    { sendAsset: null, receiveAsset: null },
+                    { replace: true },
+                );
             },
-            { defer: true },
         ),
     );
 

--- a/tests/pages/Create.spec.tsx
+++ b/tests/pages/Create.spec.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "@solidjs/router";
 import {
     fireEvent,
     render,
@@ -7,6 +8,7 @@ import {
 } from "@solidjs/testing-library";
 import { BigNumber } from "bignumber.js";
 import { SwapType } from "boltz-swaps/types";
+import { Show, createSignal, onMount } from "solid-js";
 
 import { config as runtimeConfig } from "../../src/config";
 import { config as mainnetConfig } from "../../src/configs/mainnet";
@@ -53,6 +55,111 @@ const flushQuoteDebounce = async () => {
 };
 
 describe("Create", () => {
+    test("should apply asset url params when Create mounts after navigation", async () => {
+        const NavigateToCreate = () => {
+            const navigate = useNavigate();
+            const [showCreate, setShowCreate] = createSignal(false);
+
+            onMount(() => {
+                navigate(`/?sendAsset=${LBTC}&receiveAsset=${LN}`);
+                setShowCreate(true);
+            });
+
+            return (
+                <>
+                    <TestComponent />
+                    <Show when={showCreate()}>
+                        <Create />
+                    </Show>
+                </>
+            );
+        };
+
+        render(() => <NavigateToCreate />, {
+            wrapper: contextWrapper,
+        });
+
+        await waitFor(() => {
+            expect(signals.pair().fromAsset).toEqual(LBTC);
+            expect(signals.pair().toAsset).toEqual(LN);
+        });
+        expect(window.location.search).toEqual("");
+
+        window.history.replaceState({}, "", "/");
+    });
+
+    test("should preserve toAsset when only sendAsset is in URL", async () => {
+        let initialToAsset: string | undefined;
+
+        const NavigateToCreate = () => {
+            const navigate = useNavigate();
+            const [showCreate, setShowCreate] = createSignal(false);
+
+            onMount(() => {
+                initialToAsset = signals.pair().toAsset;
+                navigate(`/?sendAsset=${LBTC}`);
+                setShowCreate(true);
+            });
+
+            return (
+                <>
+                    <TestComponent />
+                    <Show when={showCreate()}>
+                        <Create />
+                    </Show>
+                </>
+            );
+        };
+
+        render(() => <NavigateToCreate />, {
+            wrapper: contextWrapper,
+        });
+
+        await waitFor(() => {
+            expect(signals.pair().fromAsset).toEqual(LBTC);
+        });
+        expect(signals.pair().toAsset).toEqual(initialToAsset);
+        expect(window.location.search).toEqual("");
+
+        window.history.replaceState({}, "", "/");
+    });
+
+    test("should preserve fromAsset when only receiveAsset is in URL", async () => {
+        let initialFromAsset: string | undefined;
+
+        const NavigateToCreate = () => {
+            const navigate = useNavigate();
+            const [showCreate, setShowCreate] = createSignal(false);
+
+            onMount(() => {
+                initialFromAsset = signals.pair().fromAsset;
+                navigate(`/?receiveAsset=${LBTC}`);
+                setShowCreate(true);
+            });
+
+            return (
+                <>
+                    <TestComponent />
+                    <Show when={showCreate()}>
+                        <Create />
+                    </Show>
+                </>
+            );
+        };
+
+        render(() => <NavigateToCreate />, {
+            wrapper: contextWrapper,
+        });
+
+        await waitFor(() => {
+            expect(signals.pair().toAsset).toEqual(LBTC);
+        });
+        expect(signals.pair().fromAsset).toEqual(initialFromAsset);
+        expect(window.location.search).toEqual("");
+
+        window.history.replaceState({}, "", "/");
+    });
+
     test("should render Create", async () => {
         render(
             () => (


### PR DESCRIPTION
clicking on the "Pro opportunities" of the home page was navigating to the swap box, but not updating the assets accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL-parameter handling in the Create/Swap flow so asset query parameters are reliably applied then cleared after processing.

* **Tests**
  * Added unit tests covering navigation-driven parameter handling, preservation behavior, and clearing of query parameters.
  * Added end-to-end test validating SPA navigation applies asset URL parameters and updates the UI accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoltzExchange/boltz-web-app/pull/1481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->