### PR TITLE
style: ensure connect wallet modal fits in view

### DIFF
--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -123,10 +123,12 @@ const Modal = (props: {
     return (
         <div
             data-testid="wallet-connect-modal"
-            class="frame assets-select"
+            class="wallet-select-overlay"
             onClick={() => props.setShow(false)}
-            style={props.show() ? "display: block;" : "display: none;"}>
-            <div onClick={(e) => e.stopPropagation()}>
+            style={props.show() ? "display: grid;" : "display: none;"}>
+            <div
+                class="frame assets-select wallet-select-modal"
+                onClick={(e) => e.stopPropagation()}>
                 <h2>{t("select_wallet")}</h2>
                 <span class="close" onClick={() => props.setShow(false)}>
                     <IoClose />

--- a/src/style/web3.scss
+++ b/src/style/web3.scss
@@ -1,3 +1,29 @@
+.wallet-select-overlay {
+    position: fixed;
+    inset: 0;
+    place-items: start center;
+    padding: clamp(3.5rem, 14vh, 8rem) 1rem 1rem;
+    overflow: hidden;
+    z-index: 2147483001;
+    overscroll-behavior: contain;
+}
+
+.assets-select.wallet-select-modal {
+    display: block;
+    position: relative;
+    top: auto;
+    left: auto;
+    z-index: 0;
+    width: min(100%, 420px);
+    max-height: 100%;
+    overflow-y: auto;
+    margin: 0;
+}
+
+.assets-select.wallet-select-modal::after {
+    pointer-events: none;
+}
+
 .provider-modal-entry-wrapper {
     padding-bottom: 5px;
 
@@ -59,4 +85,10 @@
 .paginator .disabled {
     opacity: 0.6;
     cursor: not-allowed;
+}
+
+@media (max-width: 488px) {
+    .wallet-select-overlay {
+        padding-block: 1.75rem 0.5rem;
+    }
 }


### PR DESCRIPTION
on small screens, it is necessary to scroll the entire page to see all wallets; this PR gives the connect wallet modal the same behavior we have on the Settings menu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated wallet selection modal styling and layout for improved visual presentation
  * Enhanced mobile responsiveness with optimized spacing and sizing for smaller screens
* **UX**
  * Improved modal overlay behavior: centered, full-screen layout and clearer scroll handling
  * Clicking outside the modal now reliably closes it while internal interactions remain unaffected

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoltzExchange/boltz-web-app/pull/1491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->