### PR TITLE
refactor: gas sponsor wrapper

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,11 +16,6 @@ VITE_WALLETCONNECT_PROJECT_ID=
 # The chat widget will not be loaded if not set
 VITE_CHATWOOT_TOKEN=
 
-# Alchemy credentials for the smart-wallet gasless transaction flow
-# Both must be set together; the app throws at runtime if a flow reaches them unset
-VITE_ALCHEMY_API_KEY=
-VITE_ALCHEMY_GAS_POLICY_ID=
-
 # Per-network RPC overrides
 # When set, the URL is inserted as the first entry in the network's RPC list,
 # ahead of the hardcoded public defaults. Every network supports this pattern.

--- a/build.py
+++ b/build.py
@@ -67,8 +67,6 @@ if network != "regtest":
         "VITE_RSK_FALLBACK_ENDPOINT",
         "VITE_WALLETCONNECT_PROJECT_ID",
         "VITE_CHATWOOT_TOKEN",
-        "VITE_ALCHEMY_API_KEY",
-        "VITE_ALCHEMY_GAS_POLICY_ID",
     ]:
         if var not in env:
             print(f"WARN: {var} not in .env or .env.local")

--- a/src/alchemy/Alchemy.ts
+++ b/src/alchemy/Alchemy.ts
@@ -18,27 +18,6 @@ const alchemyHeaders = {
 const jsonRpcVersion = "2.0";
 const jsonRpcId = 1;
 
-const getAlchemyApiKey = (): string => {
-    const key = import.meta.env.VITE_ALCHEMY_API_KEY as string | undefined;
-    if (key === undefined) {
-        throw new Error("VITE_ALCHEMY_API_KEY is not defined");
-    }
-    return key;
-};
-
-const alchemyUrl = () => {
-    const baseUrl = `https://api.g.alchemy.com/v2/${getAlchemyApiKey()}`;
-    return isTor() ? `${config.corsProxyUrl}${baseUrl}` : baseUrl;
-};
-
-const getAlchemyGasPolicyId = (): string => {
-    const id = import.meta.env.VITE_ALCHEMY_GAS_POLICY_ID as string | undefined;
-    if (id === undefined) {
-        throw new Error("VITE_ALCHEMY_GAS_POLICY_ID is not defined");
-    }
-    return id;
-};
-
 type JsonRpcError = {
     code: number;
     message: string;
@@ -101,7 +80,7 @@ const requestAlchemy = async <T extends JsonRpcSuccessResponse<unknown>>(
     );
 
     try {
-        response = await fetch(alchemyUrl(), opts);
+        response = await fetch(config.gasSponsor, opts);
     } catch (error) {
         const isAbortError =
             (error instanceof DOMException && error.name === "AbortError") ||
@@ -171,11 +150,6 @@ const prepareCalls = async (
 ) => {
     return await requestAlchemy<PrepareCallsResponse>("wallet_prepareCalls", [
         {
-            capabilities: {
-                paymasterService: {
-                    policyId: getAlchemyGasPolicyId(),
-                },
-            },
             calls,
             from: signerAddress,
             chainId,

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -22,7 +22,7 @@ const defaults = {
 
     loglevel: "info" as log.LogLevelDesc,
     defaultLanguage: "en",
-    corsProxyUrl: "https://cors-proxy.m1011at.workers.dev/",
+    gasSponsor: "https://sponsor.ccxp.space/",
     supportUrl: "https://support.boltz.exchange/hc/center",
     twitterUrl: "https://twitter.com/boltzhq",
     githubUrl: "https://github.com/BoltzExchange",

--- a/tests/alchemy/Alchemy.spec.ts
+++ b/tests/alchemy/Alchemy.spec.ts
@@ -41,11 +41,6 @@ describe("Alchemy", () => {
         return JSON.parse(init.body) as T;
     };
 
-    beforeEach(() => {
-        vi.stubEnv("VITE_ALCHEMY_API_KEY", "alchemy-test-key");
-        vi.stubEnv("VITE_ALCHEMY_GAS_POLICY_ID", "alchemy-policy-id");
-    });
-
     afterEach(() => {
         vi.unstubAllEnvs();
         vi.restoreAllMocks();


### PR DESCRIPTION
To avoid exposing API keys and gas policy ids in the web app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed reliance on Alchemy credentials for the gasless transaction flow.
  * Updated required environment variables to include a fallback RPC endpoint, WalletConnect project ID, and chat token.
  * Switched the gas sponsorship mechanism to an external gas sponsor service.

* **Tests**
  * Simplified tests to stop stubbing the removed Alchemy credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoltzExchange/boltz-web-app/pull/1494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->