### PR TITLE
test(e2e): Arbitrum USDT0 chain swaps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,6 +74,7 @@ jobs:
 
             - name: Start regtest
               env:
+                  ARBITRUM_E2E_RPC_URL: ${{ vars.ARBITRUM_E2E_RPC_URL }}
                   COMPOSE_PROFILES: webapp-ci
               run: |
                   git submodule init

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -106,7 +106,9 @@ jobs:
 
             - name: Start regtest
               env:
-                  COMPOSE_PROFILES: webapp-ci
+                  ARBITRUM_E2E_RPC_URL: ${{ vars.ARBITRUM_E2E_RPC_URL }}
+                  ETHEREUM_E2E_RPC_URL: ${{ vars.ETHEREUM_E2E_RPC_URL }}
+                  COMPOSE_PROFILES: webapp-ci,stables-e2e
               run: |
                   git submodule init
                   git submodule update
@@ -123,6 +125,8 @@ jobs:
 
             - name: Run Playwright tests
               env:
+                  ARBITRUM_E2E_RPC_URL: ${{ vars.ARBITRUM_E2E_RPC_URL }}
+                  ETHEREUM_E2E_RPC_URL: ${{ vars.ETHEREUM_E2E_RPC_URL }}
                   CI: true
                   VITE_RSK_LOG_SCAN_ENDPOINT: "http://localhost:8545"
               run:

--- a/boltz.conf.patch
+++ b/boltz.conf.patch
@@ -1,5 +1,5 @@
 diff --git a/regtest/data/backend/boltz.conf b/regtest/data/backend/boltz.conf
-index a07ff9d..4d83f3a 100755
+index a819adf..830c155 100755
 --- a/regtest/data/backend/boltz.conf
 +++ b/regtest/data/backend/boltz.conf
 @@ -39,11 +39,11 @@ maxSwapAmount = 40_294_967
@@ -40,7 +40,7 @@ index a07ff9d..4d83f3a 100755
  minSwapAmount = 50_000
  
    [pairs.timeoutDelta]
--  chain= 1440
+-  chain = 1440
 -  reverse = 1440
 -  swapMinimal = 1440
 -  swapMaximal = 2880
@@ -57,7 +57,7 @@ index a07ff9d..4d83f3a 100755
    minSwapAmount = 25_000
  
    [pairs.timeoutDelta]
--  chain= 1440
+-  chain = 1440
 -  reverse = 1440
 -  swapMinimal = 1440
 -  swapMaximal = 2880
@@ -68,5 +68,5 @@ index a07ff9d..4d83f3a 100755
 +  swapMaximal = 200
 +  swapTaproot = 500
  
- [[currencies]]
- symbol = "BTC"
+ [[pairs]]
+ base = "TBTC"

--- a/e2e/arbitrum/lbtcUsdt0.spec.ts
+++ b/e2e/arbitrum/lbtcUsdt0.spec.ts
@@ -1,0 +1,203 @@
+import type { Page } from "@playwright/test";
+import {
+    type Address,
+    type PublicClient,
+    getAddress,
+    parseAbi,
+    parseUnits,
+} from "viem";
+
+import { config } from "../../src/config";
+import { expect, shouldRunArbitrumE2e, test } from "../fixtures/arbitrum";
+import {
+    elementsSendToAddress,
+    generateBitcoinBlock,
+    generateLiquidBlock,
+    verifyRescueFile,
+} from "../utils";
+
+const describeArbitrumE2e = (title: string, callback: () => void) => {
+    if (shouldRunArbitrumE2e()) {
+        test.describe(title, callback);
+    } else {
+        test.describe.skip(title, callback);
+    }
+};
+
+const erc20Abi = parseAbi([
+    "function balanceOf(address owner) view returns (uint256)",
+]);
+
+const lbtcSendAmount = "0.001";
+const quoteRequestTimeout = 60_000;
+const quoteReadinessTimeout = 90_000;
+const swapClaimTimeout = 75_000;
+const swapClaimTestTimeout = 150_000;
+
+const getRegtestTokenAddress = (asset: "USDT0" | "TBTC"): Address => {
+    const address = config.assets?.[asset]?.token?.address;
+    if (address === undefined) {
+        throw new Error(`missing ${asset} token address`);
+    }
+
+    return getAddress(address);
+};
+
+const waitForDexQuote = async (args: {
+    tokenIn: Address;
+    tokenOut: Address;
+    amountIn: bigint;
+    label: string;
+}) => {
+    const params = new URLSearchParams({
+        tokenIn: args.tokenIn,
+        tokenOut: args.tokenOut,
+        amountIn: args.amountIn.toString(),
+    });
+    const url = `${config.apiUrl.normal}/v2/quote/ARB/in?${params}`;
+    const deadline = Date.now() + quoteReadinessTimeout;
+    let lastError: unknown;
+
+    while (Date.now() < deadline) {
+        try {
+            const response = await fetch(url, {
+                signal: AbortSignal.timeout(quoteRequestTimeout),
+            });
+            if (response.ok) {
+                const quotes = await response.json();
+                if (Array.isArray(quotes) && quotes.length > 0) {
+                    return;
+                }
+            }
+            lastError = `${response.status} ${response.statusText}`;
+        } catch (error) {
+            lastError = error;
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 1_000));
+    }
+
+    throw new Error(`quote not ready for ${args.label}: ${String(lastError)}`);
+};
+
+const chooseAsset = async (page: Page, asset: string) => {
+    await page.getByTestId(`select-${asset}`).click();
+    await expect(page.locator(".asset-select-overlay")).toBeHidden({
+        timeout: 5_000,
+    });
+};
+
+const selectAssets = async (
+    page: Page,
+    sendAsset: string,
+    receiveAsset: string,
+) => {
+    const assetSelectors = page.locator("div[class^='asset asset-']");
+    await assetSelectors.first().click();
+    await chooseAsset(page, sendAsset);
+    await assetSelectors.last().click();
+    await chooseAsset(page, receiveAsset);
+};
+
+const createSwap = async (
+    page: Page,
+    sendAsset: string,
+    receiveAsset: string,
+    destinationAddress: string,
+    sendAmount: string,
+    options?: { skipGoto?: boolean },
+) => {
+    if (options?.skipGoto !== true) {
+        await page.goto("/");
+    }
+    await selectAssets(page, sendAsset, receiveAsset);
+    await page.getByTestId("onchainAddress").fill(destinationAddress);
+    await page.getByTestId("sendAmount").fill(sendAmount);
+
+    const receiveAmount = page.getByTestId("receiveAmount");
+    await expect(receiveAmount).not.toHaveValue("", { timeout: 60_000 });
+    await expect(receiveAmount).not.toHaveValue("0", { timeout: 60_000 });
+
+    const createButton = page.getByTestId("create-swap-button");
+    await expect(createButton).toBeEnabled({ timeout: 60_000 });
+    await createButton.click();
+
+    await verifyRescueFile(page);
+    await expect(page.locator("div[data-status='swap.created']")).toBeVisible({
+        timeout: 60_000,
+    });
+};
+
+const getTokenBalance = async (
+    publicClient: PublicClient,
+    token: Address,
+    owner: Address,
+) =>
+    await publicClient.readContract({
+        address: token,
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [owner],
+    });
+
+describeArbitrumE2e("Arbitrum stablecoin e2e", () => {
+    test.describe.configure({ mode: "serial" });
+
+    test.beforeEach(async () => {
+        await generateBitcoinBlock();
+        await generateLiquidBlock();
+    });
+
+    test("claims an L-BTC to USDT0-Arbitrum chain swap", async ({
+        arbitrum,
+        recipientAddress,
+        page,
+    }) => {
+        test.setTimeout(swapClaimTestTimeout);
+
+        const token = getRegtestTokenAddress("USDT0");
+        const balanceBefore = await getTokenBalance(
+            arbitrum.publicClient,
+            token,
+            recipientAddress,
+        );
+
+        await waitForDexQuote({
+            tokenIn: getRegtestTokenAddress("TBTC"),
+            tokenOut: getRegtestTokenAddress("USDT0"),
+            amountIn: parseUnits(lbtcSendAmount, 18),
+            label: "TBTC -> USDT0",
+        });
+        await createSwap(
+            page,
+            "L-BTC",
+            "USDT0",
+            recipientAddress,
+            lbtcSendAmount,
+        );
+
+        await page
+            .locator("div[data-testid='pay-onchain-buttons']")
+            .getByText("address")
+            .click();
+
+        const lockupAddress = await page.evaluate(() =>
+            navigator.clipboard.readText(),
+        );
+        expect(lockupAddress).toBeDefined();
+
+        await elementsSendToAddress(lockupAddress, lbtcSendAmount);
+        await generateLiquidBlock();
+
+        await expect(
+            page.locator("div[data-status='transaction.claimed']"),
+        ).toBeVisible({ timeout: swapClaimTimeout });
+
+        const balanceAfter = await getTokenBalance(
+            arbitrum.publicClient,
+            token,
+            recipientAddress,
+        );
+        expect(balanceAfter).toBeGreaterThan(balanceBefore);
+    });
+});

--- a/e2e/fixtures/arbitrum.ts
+++ b/e2e/fixtures/arbitrum.ts
@@ -1,0 +1,213 @@
+import { test as base, expect } from "@playwright/test";
+import {
+    type Address,
+    type Chain,
+    type PublicClient,
+    createPublicClient,
+    createWalletClient,
+    defineChain,
+    getAddress,
+    http,
+    parseAbi,
+    parseEther,
+    parseUnits,
+} from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+
+const rpcTimeout = 120_000;
+// First account from the fixed regtest backend seed.
+const regtestBackendWalletAddress = getAddress(
+    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+);
+// TBTC/WETH Uniswap V3 pool at the pinned Arbitrum fork block.
+const tbtcFundingSourceAddress = getAddress(
+    "0xCb198a55e2a88841E855bE4EAcaad99422416b33",
+);
+const tbtcTokenAddress = getAddress(
+    "0x6c84a8f1c29108F47a79964b5Fe888D4f4D0dE40",
+);
+const backendTbtcLiquidity = parseUnits("0.1", 18);
+
+const erc20Abi = parseAbi([
+    "function balanceOf(address owner) view returns (uint256)",
+    "function transfer(address recipient, uint256 amount) returns (bool)",
+]);
+
+const arbitrumRpcUrl = () =>
+    `http://127.0.0.1:${process.env.ARBITRUM_E2E_PORT ?? "18545"}`;
+
+const arbitrumE2eChain = defineChain({
+    id: 42161,
+    name: "Arbitrum One E2E",
+    nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+    rpcUrls: { default: { http: [arbitrumRpcUrl()] } },
+});
+
+type ArbitrumE2e = {
+    chain: Chain;
+    publicClient: PublicClient;
+    rpcUrl: string;
+};
+
+type ArbitrumFixtures = {
+    arbitrum: ArbitrumE2e;
+    recipientAddress: Address;
+};
+
+type ArbitrumWorkerFixtures = {
+    arbitrumWorker: ArbitrumE2e;
+};
+
+const envValue = (...names: string[]) =>
+    names
+        .map((name) => process.env[name])
+        .find((value): value is string => value !== undefined && value !== "");
+
+export const hasArbitrumE2eConfig = () =>
+    envValue("ARBITRUM_E2E_RPC_URL") !== undefined &&
+    envValue("ETHEREUM_E2E_RPC_URL") !== undefined;
+
+export const shouldRunArbitrumE2e = () =>
+    process.env.CI === "true" || hasArbitrumE2eConfig();
+
+const waitForRpc = async (rpcUrl: string) => {
+    await expect
+        .poll(
+            async () => {
+                try {
+                    const response = await fetch(rpcUrl, {
+                        method: "POST",
+                        headers: { "content-type": "application/json" },
+                        body: JSON.stringify({
+                            id: 1,
+                            jsonrpc: "2.0",
+                            method: "eth_chainId",
+                            params: [],
+                        }),
+                    });
+                    if (!response.ok) {
+                        return false;
+                    }
+
+                    const body = (await response.json()) as {
+                        result?: string;
+                    };
+                    return body.result === "0xa4b1";
+                } catch {
+                    return false;
+                }
+            },
+            { timeout: 60_000, message: "Arbitrum e2e RPC is ready" },
+        )
+        .toBe(true);
+};
+
+const createArbitrum = (): ArbitrumE2e => {
+    const rpcUrl = arbitrumRpcUrl();
+    return {
+        chain: arbitrumE2eChain,
+        publicClient: createPublicClient({
+            chain: {
+                ...arbitrumE2eChain,
+                rpcUrls: { default: { http: [rpcUrl] } },
+            },
+            transport: http(rpcUrl, { timeout: rpcTimeout }),
+        }),
+        rpcUrl,
+    };
+};
+
+const tbtcBalance = async (publicClient: PublicClient, owner: Address) =>
+    await publicClient.readContract({
+        address: tbtcTokenAddress,
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [owner],
+    });
+
+const ensureBackendTbtcLiquidity = async ({
+    chain,
+    publicClient,
+    rpcUrl,
+}: ArbitrumE2e) => {
+    const tokenCode = await publicClient.getCode({ address: tbtcTokenAddress });
+    if (tokenCode === undefined || tokenCode === "0x") {
+        throw new Error("Arbitrum e2e fork is missing the TBTC token contract");
+    }
+
+    if (
+        (await tbtcBalance(publicClient, regtestBackendWalletAddress)) >=
+        backendTbtcLiquidity
+    ) {
+        return;
+    }
+
+    if (
+        (await tbtcBalance(publicClient, tbtcFundingSourceAddress)) <
+        backendTbtcLiquidity
+    ) {
+        throw new Error(
+            "Arbitrum e2e TBTC funding source has insufficient balance",
+        );
+    }
+
+    await publicClient.request({
+        method: "anvil_setBalance" as never,
+        params: [
+            tbtcFundingSourceAddress,
+            "0x" + parseEther("1").toString(16),
+        ] as never,
+    });
+    await publicClient.request({
+        method: "anvil_impersonateAccount" as never,
+        params: [tbtcFundingSourceAddress] as never,
+    });
+
+    try {
+        const walletClient = createWalletClient({
+            account: tbtcFundingSourceAddress,
+            chain,
+            transport: http(rpcUrl, { timeout: rpcTimeout }),
+        });
+        const hash = await walletClient.writeContract({
+            address: tbtcTokenAddress,
+            abi: erc20Abi,
+            functionName: "transfer",
+            args: [regtestBackendWalletAddress, backendTbtcLiquidity],
+        });
+        await publicClient.waitForTransactionReceipt({ hash });
+    } finally {
+        await publicClient.request({
+            method: "anvil_stopImpersonatingAccount" as never,
+            params: [tbtcFundingSourceAddress] as never,
+        });
+    }
+};
+
+export const test = base.extend<ArbitrumFixtures, ArbitrumWorkerFixtures>({
+    arbitrumWorker: [
+        // eslint-disable-next-line no-empty-pattern
+        async ({}, use) => {
+            if (!hasArbitrumE2eConfig()) {
+                throw new Error("missing Arbitrum e2e RPC config");
+            }
+
+            const arbitrum = createArbitrum();
+            await waitForRpc(arbitrum.rpcUrl);
+            await ensureBackendTbtcLiquidity(arbitrum);
+            await use(arbitrum);
+        },
+        { scope: "worker", timeout: rpcTimeout },
+    ],
+
+    arbitrum: async ({ arbitrumWorker }, use) => {
+        await use(arbitrumWorker);
+    },
+
+    // eslint-disable-next-line no-empty-pattern
+    recipientAddress: async ({}, use) => {
+        await use(privateKeyToAccount(generatePrivateKey()).address);
+    },
+});
+
+export { expect } from "@playwright/test";

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,11 @@
 import { defineConfig, devices } from "@playwright/test";
+import { loadEnv } from "vite";
+
+Object.entries(loadEnv("development", __dirname, "")).forEach(
+    ([key, value]) => {
+        process.env[key] ??= value;
+    },
+);
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/src/configs/regtest.ts
+++ b/src/configs/regtest.ts
@@ -5,7 +5,7 @@ import { type Config, baseConfig, chooseUrl } from "src/configs/base";
 const mainnetPreset = buildMainnetConfig({
     filterAssets: (asset) => asset === "TBTC" || asset === "USDT0",
     rpcUrls: {
-        ARB: ["http://127.0.0.1:18545"],
+        ARB: [`http://127.0.0.1:${process.env.ARBITRUM_E2E_PORT ?? "18545"}`],
     },
 });
 
@@ -85,8 +85,8 @@ const config = {
         ...stablecoins,
     },
     gasSponsor: {
-        normal: "http://localhost:18547/alchemy",
-        tor: "http://localhost:18547/alchemy",
+        normal: `http://localhost:${process.env.GAS_SPONSOR_EMULATOR_PORT ?? "18547"}/alchemy`,
+        tor: `http://localhost:${process.env.GAS_SPONSOR_EMULATOR_PORT ?? "18547"}/alchemy`,
     },
 } as Config;
 

--- a/src/configs/regtest.ts
+++ b/src/configs/regtest.ts
@@ -1,5 +1,24 @@
+import { buildMainnetConfig } from "boltz-swaps/presets/mainnet";
 import { AssetKind, Explorer, NetworkTransport } from "boltz-swaps/types";
 import { type Config, baseConfig, chooseUrl } from "src/configs/base";
+
+const mainnetPreset = buildMainnetConfig({
+    filterAssets: (asset) => asset === "TBTC" || asset === "USDT0",
+    rpcUrls: {
+        ARB: ["http://127.0.0.1:18545"],
+    },
+});
+
+const stablecoins = {
+    TBTC: {
+        ...mainnetPreset.assets.TBTC,
+        contracts: {
+            ...mainnetPreset.assets.TBTC.contracts,
+            deployHeight: 465600400,
+        },
+    },
+    USDT0: mainnetPreset.assets.USDT0,
+};
 
 const config = {
     ...baseConfig,
@@ -63,6 +82,11 @@ const config = {
                 deployVerifier: "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
             },
         },
+        ...stablecoins,
+    },
+    gasSponsor: {
+        normal: "http://localhost:18547/alchemy",
+        tor: "http://localhost:18547/alchemy",
     },
 } as Config;
 


### PR DESCRIPTION
Depends on https://github.com/BoltzExchange/regtest/pull/105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Playwright Arbitrum E2E stablecoin end-to-end claim test for the L-BTC → USDT0 onchain flow.
  * Introduced Arbitrum regtest-style test fixtures, including recipient setup, backend readiness checks, and ensuring sufficient TBTC liquidity.

* **CI**
  * Updated the E2E workflow to use consistent Arbitrum/Ethereum RPC endpoints during regtest startup and Playwright execution.

* **Chores**
  * Tuned regtest asset selection to TBTC and USDT0 and adjusted swap/backend timing plus Arbitrum swap/quoters configuration for the test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->