### PR TITLE
feat: make max button respect wallet balance

### DIFF
--- a/e2e/arbitrum/commitment.spec.ts
+++ b/e2e/arbitrum/commitment.spec.ts
@@ -1,0 +1,168 @@
+import type { Page } from "@playwright/test";
+import { type Address, createWalletClient, http, parseUnits } from "viem";
+
+import { config } from "../../src/config";
+import dict from "../../src/i18n/i18n";
+import { expect, test } from "../fixtures/arbitrum";
+import { injectWalletProvider } from "../fixtures/ethereum";
+import {
+    generateBitcoinBlock,
+    generateInvoiceLnd,
+    getCurrentSwapId,
+    lookupInvoiceLnd,
+    verifyRescueFile,
+    waitForNodesToSync,
+} from "../utils";
+import {
+    actionTimeout,
+    clickSendBridge,
+    connectWallet,
+    describeArbitrumE2e,
+    expectArbitrumWalletReady,
+    fullFlowTestTimeout,
+    fundArbitrumStablesE2eWallet,
+    getCodeFreeStablesE2eWalletAddress,
+    getRegtestTokenAddress,
+    probeTimeout,
+    selectAssets,
+    usdt0ArbitrumSendAmount,
+    waitForDexQuote,
+} from "./shared";
+
+const hasCommitmentSubmarinePair = async (): Promise<boolean> => {
+    const response = await fetch(`${config.apiUrl.normal}/v2/swap/submarine`);
+    if (!response.ok) {
+        return false;
+    }
+
+    const pairs = (await response.json()) as {
+        TBTC?: { BTC?: unknown };
+    };
+    return pairs.TBTC?.BTC !== undefined;
+};
+
+const createCommitmentSwap = async (
+    page: Page,
+    walletAddress: Address,
+): Promise<string> => {
+    await page.goto("/swap");
+    await selectAssets(page, "USDT0", "LN");
+    await page.getByTestId("sendAmount").fill(usdt0ArbitrumSendAmount);
+
+    await expect(page.getByTestId("committed-invoice-row")).toBeVisible({
+        timeout: actionTimeout,
+    });
+
+    await connectWallet(page, walletAddress);
+
+    const createButton = page.getByTestId("create-swap-button");
+    await expect(createButton).toBeEnabled({ timeout: actionTimeout });
+    await createButton.click();
+
+    await expect(
+        page
+            .getByRole("button", { name: /^approve$/i })
+            .or(page.getByRole("button", { name: /^send$/i })),
+    ).toBeVisible({ timeout: actionTimeout });
+
+    return getCurrentSwapId(page);
+};
+
+const copyCommitmentInvoiceSats = async (page: Page): Promise<number> => {
+    const copyAmount = page.getByTestId("copy_amount");
+    await expect(copyAmount).toBeVisible({ timeout: actionTimeout * 2 });
+    await copyAmount.click();
+
+    const rawAmount = await page.evaluate(() => navigator.clipboard.readText());
+    const sats = Number(rawAmount.replace(/\D/g, ""));
+    expect(Number.isSafeInteger(sats)).toBe(true);
+    expect(sats).toBeGreaterThan(0);
+
+    return sats;
+};
+
+describeArbitrumE2e("Arbitrum commitment swap e2e", () => {
+    test.describe.configure({
+        timeout: fullFlowTestTimeout + actionTimeout * 2,
+    });
+
+    test.beforeEach(async () => {
+        await generateBitcoinBlock();
+        await waitForNodesToSync();
+    });
+
+    test("settles a USDT0-Arbitrum to LN commitment swap", async ({
+        arbitrum,
+        page,
+    }) => {
+        test.skip(
+            !(await hasCommitmentSubmarinePair()),
+            "default regtest does not expose the TBTC/BTC submarine pair required by commitment swaps",
+        );
+
+        const walletAddress = await getCodeFreeStablesE2eWalletAddress(
+            arbitrum.publicClient,
+        );
+        const walletClient = createWalletClient({
+            account: walletAddress,
+            chain: arbitrum.chain,
+            transport: http(arbitrum.rpcUrl, { timeout: actionTimeout }),
+        });
+
+        await fundArbitrumStablesE2eWallet(
+            arbitrum.publicClient,
+            walletAddress,
+        );
+        await expectArbitrumWalletReady(arbitrum.publicClient, walletAddress);
+        await injectWalletProvider({
+            page,
+            publicClient: arbitrum.publicClient,
+            walletClient,
+            chain: arbitrum.chain,
+        });
+
+        await waitForDexQuote({
+            tokenIn: getRegtestTokenAddress("USDT0"),
+            tokenOut: getRegtestTokenAddress("TBTC"),
+            amountIn: parseUnits(usdt0ArbitrumSendAmount, 6),
+            label: "USDT0 -> TBTC",
+        });
+
+        const commitmentId = await createCommitmentSwap(page, walletAddress);
+        await clickSendBridge(page, walletAddress);
+
+        const invoice = await generateInvoiceLnd(
+            await copyCommitmentInvoiceSats(page),
+        );
+        await page.getByTestId("invoice").fill(invoice);
+        const invoiceSubmitButton = page.getByTestId(
+            "commitment-invoice-submit",
+        );
+        await expect(invoiceSubmitButton).toBeEnabled({
+            timeout: actionTimeout,
+        });
+        await invoiceSubmitButton.click();
+
+        await expect
+            .poll(() => getCurrentSwapId(page), { timeout: actionTimeout })
+            .not.toBe(commitmentId);
+        const downloadButton = page.getByRole("button", {
+            name: dict.en.download_new_key,
+        });
+        if (
+            await downloadButton
+                .isVisible({ timeout: probeTimeout })
+                .catch(() => false)
+        ) {
+            await verifyRescueFile(page);
+        }
+
+        await expect(
+            page
+                .locator("div[data-status='transaction.claimed']")
+                .or(page.locator("div[data-status='invoice.settled']")),
+        ).toBeVisible({ timeout: fullFlowTestTimeout });
+
+        expect((await lookupInvoiceLnd(invoice)).state).toEqual("SETTLED");
+    });
+});

--- a/e2e/arbitrum/lbtcUsdt0.spec.ts
+++ b/e2e/arbitrum/lbtcUsdt0.spec.ts
@@ -1,20 +1,15 @@
 import type { Page } from "@playwright/test";
-import { oftAbi } from "boltz-swaps/oft";
 import {
     type Address,
-    type Chain,
-    type Hex,
     type PublicClient,
     createWalletClient,
     getAddress,
     http,
-    isAddressEqual,
-    parseEther,
-    parseEventLogs,
     parseUnits,
 } from "viem";
 
 import dict from "../../src/i18n/i18n";
+import { expect, test } from "../fixtures/arbitrum";
 import { injectWalletProvider } from "../fixtures/ethereum";
 import {
     elementsSendToAddress,
@@ -24,136 +19,29 @@ import {
 } from "../utils";
 import {
     actionTimeout,
-    approveAndSend,
+    clearEoaDelegation,
+    clickSendBridge,
     connectWallet,
     createEthereumClient,
     createSwap,
     describeArbitrumE2e,
-    erc20Abi,
     ethereumE2eChain,
     ethereumRpcUrl,
-    expect,
+    expectEthereumWalletReady,
+    expectOftSendTx,
+    fullFlowTestTimeout,
+    fundArbitrumStablesE2eWallet,
+    fundEthereumStablesE2eWallet,
     getRegtestTokenAddress,
     getStablesE2eWalletAddress,
     getTokenBalance,
     lbtcSendAmount,
-    stablesFundingAmount,
-    stablesFundingSource,
-    test,
     testTimeout,
     usdt0EthSendAmount,
     waitForBridgeTxHash,
     waitForDexQuote,
     waitForEthereumRpc,
 } from "./shared";
-
-// Funds the test wallet with gas + USDT0-ETH by impersonating a whale on the
-// Anvil fork, so the test does not depend on an external funding container.
-const fundStablesE2eWallet = async (
-    publicClient: PublicClient,
-    wallet: Address,
-) => {
-    const token = getRegtestTokenAddress("USDT0-ETH");
-    const tokenCode = await publicClient.getCode({ address: token });
-    if (tokenCode === undefined || tokenCode === "0x") {
-        throw new Error("Ethereum e2e fork is missing the USDT0-ETH contract");
-    }
-
-    if (
-        (await getTokenBalance(publicClient, token, wallet)) >=
-        parseUnits(usdt0EthSendAmount, 6)
-    ) {
-        return;
-    }
-
-    await publicClient.request({
-        method: "anvil_setBalance" as never,
-        params: [wallet, "0x" + parseEther("10").toString(16)] as never,
-    });
-    await publicClient.request({
-        method: "anvil_setBalance" as never,
-        params: [
-            stablesFundingSource,
-            "0x" + parseEther("1").toString(16),
-        ] as never,
-    });
-    await publicClient.request({
-        method: "anvil_impersonateAccount" as never,
-        params: [stablesFundingSource] as never,
-    });
-
-    try {
-        const walletClient = createWalletClient({
-            account: stablesFundingSource,
-            chain: ethereumE2eChain,
-            transport: http(ethereumRpcUrl(), { timeout: actionTimeout }),
-        });
-        const hash = await walletClient.writeContract({
-            address: token,
-            abi: erc20Abi,
-            functionName: "transfer",
-            args: [wallet, stablesFundingAmount],
-        });
-        await publicClient.waitForTransactionReceipt({ hash });
-    } finally {
-        await publicClient.request({
-            method: "anvil_stopImpersonatingAccount" as never,
-            params: [stablesFundingSource] as never,
-        });
-    }
-};
-
-const expectEthereumWalletReady = async (
-    publicClient: PublicClient,
-    owner: Address,
-) => {
-    const token = getRegtestTokenAddress("USDT0-ETH");
-
-    expect(await publicClient.getBalance({ address: owner })).toBeGreaterThan(
-        0n,
-    );
-    expect(
-        await getTokenBalance(publicClient, token, owner),
-    ).toBeGreaterThanOrEqual(parseUnits(usdt0EthSendAmount, 6));
-};
-
-const expectOftSendTx = async (
-    publicClient: PublicClient,
-    txHash: Hex,
-    walletAddress: Address,
-) => {
-    const transaction = await publicClient.getTransaction({
-        hash: txHash,
-    });
-    const receipt = await publicClient.waitForTransactionReceipt({
-        hash: txHash,
-        timeout: actionTimeout,
-    });
-    expect(receipt.status).toBe("success");
-
-    const [sent] = parseEventLogs({
-        abi: oftAbi,
-        eventName: "OFTSent",
-        logs: receipt.logs,
-    });
-
-    expect(sent).toBeDefined();
-    expect(isAddressEqual(sent.address, getAddress(transaction.to!))).toBe(
-        true,
-    );
-    expect(isAddressEqual(sent.args.fromAddress, walletAddress)).toBe(true);
-    expect(sent.args.amountSentLD).toBeGreaterThan(0n);
-    expect(sent.args.amountReceivedLD).toBeGreaterThan(0n);
-};
-
-// Whale holding USD₮0 on the Arbitrum fork; impersonated to fund the test
-// wallet so it can send a native USDT0 (Arbitrum) commitment swap.
-const usdt0FundingSource = getAddress(
-    "0xF977814e90dA44bFA03b6295A0616a897441aceC",
-);
-const usdt0FundingAmount = parseUnits("500", 6);
-
-type ArbitrumE2e = { chain: Chain; publicClient: PublicClient; rpcUrl: string };
 
 const arbWalletAccountIndex = 3;
 
@@ -171,58 +59,6 @@ const getArbWalletAddress = async (
         );
     }
     return getAddress(walletAddress);
-};
-
-const clearEoaDelegation = async (
-    publicClient: PublicClient,
-    account: Address,
-) => {
-    await publicClient.request({
-        method: "anvil_setCode" as never,
-        params: [account, "0x"] as never,
-    });
-};
-
-const fundArbUsdt0Wallet = async (arbitrum: ArbitrumE2e, wallet: Address) => {
-    const token = getRegtestTokenAddress("USDT0");
-    if (
-        (await getTokenBalance(arbitrum.publicClient, token, wallet)) >=
-        parseUnits(usdt0EthSendAmount, 6)
-    ) {
-        return;
-    }
-
-    await arbitrum.publicClient.request({
-        method: "anvil_setBalance" as never,
-        params: [
-            usdt0FundingSource,
-            `0x${parseEther("1").toString(16)}`,
-        ] as never,
-    });
-    await arbitrum.publicClient.request({
-        method: "anvil_impersonateAccount" as never,
-        params: [usdt0FundingSource] as never,
-    });
-
-    try {
-        const walletClient = createWalletClient({
-            account: usdt0FundingSource,
-            chain: arbitrum.chain,
-            transport: http(arbitrum.rpcUrl, { timeout: actionTimeout }),
-        });
-        const hash = await walletClient.writeContract({
-            address: token,
-            abi: erc20Abi,
-            functionName: "transfer",
-            args: [wallet, usdt0FundingAmount],
-        });
-        await arbitrum.publicClient.waitForTransactionReceipt({ hash });
-    } finally {
-        await arbitrum.publicClient.request({
-            method: "anvil_stopImpersonatingAccount" as never,
-            params: [usdt0FundingSource] as never,
-        });
-    }
 };
 
 const lockupCommitment = async (page: Page, walletAddress: Address) => {
@@ -254,7 +90,7 @@ describeArbitrumE2e("Arbitrum stablecoin e2e", () => {
         recipientAddress,
         page,
     }) => {
-        test.setTimeout(testTimeout);
+        test.setTimeout(fullFlowTestTimeout);
 
         const token = getRegtestTokenAddress("USDT0");
         const balanceBefore = await getTokenBalance(
@@ -292,7 +128,7 @@ describeArbitrumE2e("Arbitrum stablecoin e2e", () => {
 
         await expect(
             page.locator("div[data-status='transaction.claimed']"),
-        ).toBeVisible({ timeout: actionTimeout });
+        ).toBeVisible({ timeout: fullFlowTestTimeout });
 
         const balanceAfter = await getTokenBalance(
             arbitrum.publicClient,
@@ -308,9 +144,9 @@ describeArbitrumE2e("Arbitrum stablecoin e2e", () => {
     }) => {
         test.setTimeout(testTimeout);
 
-        // Requesting the arbitrum fixture runs the worker setup (RPC wait and
-        // backend TBTC liquidity) needed before the USDT0 -> TBTC DEX hop.
-        void arbitrum;
+        expect(await arbitrum.publicClient.getChainId()).toBe(
+            arbitrum.chain.id,
+        );
 
         const ethereum = createEthereumClient();
         await waitForEthereumRpc(ethereum);
@@ -322,7 +158,7 @@ describeArbitrumE2e("Arbitrum stablecoin e2e", () => {
             transport: http(ethereumRpcUrl(), { timeout: actionTimeout }),
         });
 
-        await fundStablesE2eWallet(ethereum, walletAddress);
+        await fundEthereumStablesE2eWallet(ethereum, walletAddress);
         await expectEthereumWalletReady(ethereum, walletAddress);
         await injectWalletProvider({
             page,
@@ -346,7 +182,7 @@ describeArbitrumE2e("Arbitrum stablecoin e2e", () => {
             usdt0EthSendAmount,
             { walletAddress },
         );
-        await approveAndSend(page, walletAddress);
+        await clickSendBridge(page, walletAddress);
 
         await expectOftSendTx(
             ethereum,
@@ -363,7 +199,10 @@ describeArbitrumE2e("Arbitrum stablecoin e2e", () => {
 
         const walletAddress = await getArbWalletAddress(arbitrum.publicClient);
         await clearEoaDelegation(arbitrum.publicClient, walletAddress);
-        await fundArbUsdt0Wallet(arbitrum, walletAddress);
+        await fundArbitrumStablesE2eWallet(
+            arbitrum.publicClient,
+            walletAddress,
+        );
         await injectWalletProvider({
             page,
             publicClient: arbitrum.publicClient,

--- a/e2e/arbitrum/lbtcUsdt0.spec.ts
+++ b/e2e/arbitrum/lbtcUsdt0.spec.ts
@@ -34,6 +34,7 @@ import {
     fundEthereumStablesE2eWallet,
     getRegtestTokenAddress,
     getStablesE2eWalletAddress,
+    getStoredSwap,
     getTokenBalance,
     lbtcSendAmount,
     testTimeout,
@@ -41,6 +42,7 @@ import {
     waitForBridgeTxHash,
     waitForDexQuote,
     waitForEthereumRpc,
+    waitForLockupTxHash,
 } from "./shared";
 
 const arbWalletAccountIndex = 3;
@@ -189,6 +191,59 @@ describeArbitrumE2e("Arbitrum stablecoin e2e", () => {
             await waitForBridgeTxHash(page, swapId),
             walletAddress,
         );
+    });
+
+    test("claims a USDT0-Arbitrum to L-BTC chain swap", async ({
+        arbitrum,
+        page,
+    }) => {
+        test.setTimeout(fullFlowTestTimeout);
+
+        const walletAddress = await getArbWalletAddress(arbitrum.publicClient);
+        await clearEoaDelegation(arbitrum.publicClient, walletAddress);
+        await fundArbitrumStablesE2eWallet(
+            arbitrum.publicClient,
+            walletAddress,
+        );
+        await injectWalletProvider({
+            page,
+            publicClient: arbitrum.publicClient,
+            walletClient: createWalletClient({
+                account: walletAddress,
+                chain: arbitrum.chain,
+                transport: http(arbitrum.rpcUrl, { timeout: actionTimeout }),
+            }),
+            chain: arbitrum.chain,
+        });
+
+        await waitForDexQuote({
+            tokenIn: getRegtestTokenAddress("USDT0"),
+            tokenOut: getRegtestTokenAddress("TBTC"),
+            amountIn: parseUnits("39.996", 6),
+            label: "USDT0 -> TBTC",
+        });
+
+        const swapId = await createSwap(
+            page,
+            "USDT0",
+            "L-BTC",
+            await getLiquidAddress(),
+            usdt0EthSendAmount,
+            { walletAddress },
+        );
+        await expect
+            .poll(
+                async () => (await getStoredSwap(page, swapId))?.dex?.position,
+                { timeout: actionTimeout },
+            )
+            .toBe("pre");
+
+        await lockupCommitment(page, walletAddress);
+        await waitForLockupTxHash(page, swapId);
+
+        await expect(
+            page.locator("div[data-status='transaction.claimed']"),
+        ).toBeVisible({ timeout: fullFlowTestTimeout });
     });
 
     test("offers a source-asset refund when the backend rejects the commitment", async ({

--- a/e2e/arbitrum/shared.ts
+++ b/e2e/arbitrum/shared.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { oftAbi } from "boltz-swaps/oft";
 import {
     type Address,
     type Hex,
@@ -9,8 +10,10 @@ import {
     defineChain,
     getAddress,
     http,
+    isAddressEqual,
     parseAbi,
     parseEther,
+    parseEventLogs,
     parseUnits,
 } from "viem";
 
@@ -36,10 +39,12 @@ export const erc20Abi = parseAbi([
 
 export const lbtcSendAmount = "0.001";
 export const usdt0EthSendAmount = "40";
+export const usdt0ArbitrumSendAmount = "40";
 export const actionTimeout = 60_000;
 export const probeTimeout = 1_000;
 export const quoteRequestTimeout = 10_000;
 export const testTimeout = 150_000;
+export const fullFlowTestTimeout = 300_000;
 
 const isVisibleWithin = (locator: Locator, timeout = probeTimeout) =>
     locator
@@ -49,6 +54,10 @@ const isVisibleWithin = (locator: Locator, timeout = probeTimeout) =>
 
 export const stablesFundingSource = getAddress(
     process.env.STABLES_E2E_USDT0_ETH_FUNDING_SOURCE ??
+        "0xF977814e90dA44bFA03b6295A0616a897441aceC",
+);
+const arbitrumStablesFundingSource = getAddress(
+    process.env.STABLES_E2E_USDT0_FUNDING_SOURCE ??
         "0xF977814e90dA44bFA03b6295A0616a897441aceC",
 );
 export const stablesFundingAmount = parseUnits("500", 6);
@@ -137,6 +146,25 @@ export const getStablesE2eWalletAddress = async (
     }
 
     return getAddress(walletAddress);
+};
+
+export const getCodeFreeStablesE2eWalletAddress = async (
+    publicClient: PublicClient,
+): Promise<Address> => {
+    const accounts = (await publicClient.request({
+        method: "eth_accounts",
+        params: [],
+    } as never)) as Address[];
+
+    for (const account of accounts) {
+        const address = getAddress(account);
+        const code = await publicClient.getCode({ address });
+        if (code === undefined || code === "0x") {
+            return address;
+        }
+    }
+
+    throw new Error("no code-free Anvil account is available");
 };
 
 export const waitForDexQuote = async (args: {
@@ -443,6 +471,124 @@ export const fundErc20FromWhale = async (args: {
     }
 };
 
+const fundStablesE2eWallet = async ({
+    asset,
+    chain,
+    fundingSource,
+    minimumAmount,
+    publicClient,
+    rpcUrl,
+    wallet,
+}: {
+    asset: "USDT0" | "USDT0-ETH";
+    chain: typeof arbitrumE2eChain | typeof ethereumE2eChain;
+    fundingSource: Address;
+    minimumAmount: bigint;
+    publicClient: PublicClient;
+    rpcUrl: string;
+    wallet: Address;
+}) => {
+    const token = getRegtestTokenAddress(asset);
+    const tokenCode = await publicClient.getCode({ address: token });
+    if (tokenCode === undefined || tokenCode === "0x") {
+        throw new Error(`${asset} e2e fork is missing the token contract`);
+    }
+
+    await publicClient.request({
+        method: "anvil_setBalance" as never,
+        params: [wallet, "0x" + parseEther("10").toString(16)] as never,
+    });
+
+    if ((await getTokenBalance(publicClient, token, wallet)) >= minimumAmount) {
+        return;
+    }
+
+    await publicClient.request({
+        method: "anvil_setBalance" as never,
+        params: [fundingSource, "0x" + parseEther("1").toString(16)] as never,
+    });
+    await publicClient.request({
+        method: "anvil_impersonateAccount" as never,
+        params: [fundingSource] as never,
+    });
+
+    try {
+        const walletClient = createWalletClient({
+            account: fundingSource,
+            chain,
+            transport: http(rpcUrl, { timeout: actionTimeout }),
+        });
+        const hash = await walletClient.writeContract({
+            address: token,
+            abi: erc20Abi,
+            functionName: "transfer",
+            args: [wallet, stablesFundingAmount],
+        });
+        await publicClient.waitForTransactionReceipt({ hash });
+    } finally {
+        await publicClient.request({
+            method: "anvil_stopImpersonatingAccount" as never,
+            params: [fundingSource] as never,
+        });
+    }
+};
+
+export const fundEthereumStablesE2eWallet = async (
+    publicClient: PublicClient,
+    wallet: Address,
+) =>
+    await fundStablesE2eWallet({
+        asset: "USDT0-ETH",
+        chain: ethereumE2eChain,
+        fundingSource: stablesFundingSource,
+        minimumAmount: parseUnits(usdt0EthSendAmount, 6),
+        publicClient,
+        rpcUrl: ethereumRpcUrl(),
+        wallet,
+    });
+
+export const fundArbitrumStablesE2eWallet = async (
+    publicClient: PublicClient,
+    wallet: Address,
+) =>
+    await fundStablesE2eWallet({
+        asset: "USDT0",
+        chain: arbitrumE2eChain,
+        fundingSource: arbitrumStablesFundingSource,
+        minimumAmount: parseUnits(usdt0ArbitrumSendAmount, 6),
+        publicClient,
+        rpcUrl: arbitrumRpcUrl(),
+        wallet,
+    });
+
+export const expectEthereumWalletReady = async (
+    publicClient: PublicClient,
+    owner: Address,
+) => {
+    const token = getRegtestTokenAddress("USDT0-ETH");
+
+    expect(await publicClient.getBalance({ address: owner })).toBeGreaterThan(
+        0n,
+    );
+    expect(
+        await getTokenBalance(publicClient, token, owner),
+    ).toBeGreaterThanOrEqual(parseUnits(usdt0EthSendAmount, 6));
+};
+
+export const expectArbitrumWalletReady = async (
+    publicClient: PublicClient,
+    owner: Address,
+) => {
+    const token = getRegtestTokenAddress("USDT0");
+
+    expect(await publicClient.getBalance({ address: owner })).toBeGreaterThan(
+        0n,
+    );
+    expect(
+        await getTokenBalance(publicClient, token, owner),
+    ).toBeGreaterThanOrEqual(parseUnits(usdt0ArbitrumSendAmount, 6));
+};
+
 // Clears an EIP-7702 delegation inherited from forked mainnet state, which would
 // otherwise make Permit2 verify the lockup permit via EIP-1271 instead of ECDSA.
 export const clearEoaDelegation = async (
@@ -509,6 +655,37 @@ export const approveAndSend = async (page: Page, walletAddress: Address) => {
 
     await expect(send).toBeEnabled({ timeout: actionTimeout });
     await send.click();
+};
+
+export const clickSendBridge = approveAndSend;
+
+export const expectOftSendTx = async (
+    publicClient: PublicClient,
+    txHash: Hex,
+    walletAddress: Address,
+) => {
+    const transaction = await publicClient.getTransaction({
+        hash: txHash,
+    });
+    const receipt = await publicClient.waitForTransactionReceipt({
+        hash: txHash,
+        timeout: actionTimeout,
+    });
+    expect(receipt.status).toBe("success");
+
+    const [sent] = parseEventLogs({
+        abi: oftAbi,
+        eventName: "OFTSent",
+        logs: receipt.logs,
+    });
+
+    expect(sent).toBeDefined();
+    expect(isAddressEqual(sent.address, getAddress(transaction.to!))).toBe(
+        true,
+    );
+    expect(isAddressEqual(sent.args.fromAddress, walletAddress)).toBe(true);
+    expect(sent.args.amountSentLD).toBeGreaterThan(0n);
+    expect(sent.args.amountReceivedLD).toBeGreaterThan(0n);
 };
 
 export type { Address, Hex, PublicClient, WalletClient };

--- a/e2e/arbitrum/shared.ts
+++ b/e2e/arbitrum/shared.ts
@@ -205,6 +205,10 @@ export const waitForDexQuote = async (args: {
 };
 
 type StoredSwap = {
+    dex?: {
+        position?: string;
+        quoteAmount?: number | string;
+    };
     bridge?: { txHash?: Hex };
     lockupTx?: Hex;
     commitmentLockupTxHash?: Hex;

--- a/e2e/bolt12.spec.ts
+++ b/e2e/bolt12.spec.ts
@@ -17,17 +17,19 @@ test.describe("BOLT12", () => {
         const divFlipAssets = page.locator("#flip-assets");
         await divFlipAssets.click();
 
+        const invoiceInput = page.locator("input[data-testid='invoice']");
+        await invoiceInput.fill(await getBolt12Offer());
+
         const receiveAmount = "0.01";
         const inputReceiveAmount = page.locator(
             "input[data-testid='receiveAmount']",
         );
         await inputReceiveAmount.fill(receiveAmount);
 
-        const invoiceInput = page.locator("input[data-testid='invoice']");
-        await invoiceInput.fill(await getBolt12Offer());
         const buttonCreateSwap = page.locator(
             "button[data-testid='create-swap-button']",
         );
+        await expect(buttonCreateSwap).toBeEnabled();
         await buttonCreateSwap.click();
 
         await verifyRescueFile(page);

--- a/packages/boltz-swaps/src/solana/lazy.ts
+++ b/packages/boltz-swaps/src/solana/lazy.ts
@@ -37,10 +37,8 @@ type SolanaOftModules = {
 export const solana: Loader<SolanaModules> = new Loader(
     "Solana",
     async (): Promise<SolanaModules> => {
-        const [web3, splToken] = await Promise.all([
-            import("@solana/web3.js"),
-            import("@solana/spl-token"),
-        ]);
+        const web3 = await import("@solana/web3.js");
+        const splToken = await import("@solana/spl-token");
 
         return { web3, splToken };
     },
@@ -49,9 +47,9 @@ export const solana: Loader<SolanaModules> = new Loader(
 export const solanaCctp: Loader<SolanaCctpModules> = new Loader(
     "Solana CCTP",
     async (): Promise<SolanaCctpModules> => {
-        const [solanaKit, web3, generated] = await Promise.all([
+        const web3 = await import("@solana/web3.js");
+        const [solanaKit, generated] = await Promise.all([
             import("@solana/kit"),
-            import("@solana/web3.js"),
             import("../generated/solana-cctp-token-messenger-minter/src/generated/index.ts"),
         ]);
 
@@ -66,6 +64,7 @@ export const solanaCctp: Loader<SolanaCctpModules> = new Loader(
 export const solanaOft: Loader<SolanaOftModules> = new Loader(
     "Solana OFT",
     async (): Promise<SolanaOftModules> => {
+        const web3 = await import("@solana/web3.js");
         const [
             lzSolanaUmi,
             mplToolbox,
@@ -74,7 +73,6 @@ export const solanaOft: Loader<SolanaOftModules> = new Loader(
             umiWalletAdapters,
             solanaKit,
             splToken,
-            web3,
             generated,
         ] = await Promise.all([
             import("@layerzerolabs/lz-solana-sdk-v2/umi"),
@@ -84,7 +82,6 @@ export const solanaOft: Loader<SolanaOftModules> = new Loader(
             import("@metaplex-foundation/umi-signer-wallet-adapters"),
             import("@solana/kit"),
             import("@solana/spl-token"),
-            import("@solana/web3.js"),
             import("../generated/solana-oft/src/generated/index.ts"),
         ]);
 

--- a/packages/boltz-swaps/src/types.ts
+++ b/packages/boltz-swaps/src/types.ts
@@ -10,6 +10,7 @@ export enum SwapType {
     Submarine = "submarine",
     Reverse = "reverse",
     Chain = "chain",
+    Commitment = "commitment",
     Dex = "dex",
 }
 

--- a/src/components/BlockExplorerLink.tsx
+++ b/src/components/BlockExplorerLink.tsx
@@ -26,12 +26,16 @@ const claimTxLabel = (explorer: ExplorerKind | undefined) =>
         ? "bridge_status"
         : undefined;
 
+const getLockupTxHash = (swap: SomeSwap) =>
+    swap.lockupTx ?? swap.commitmentLockupTxHash;
+
 const ChainSwapLink = (props: {
     swap: Accessor<SomeSwap>;
     swapStatus: Accessor<string>;
     blinded: Accessor<string | undefined>;
 }) => {
     const hasBeenClaimed = () => props.swap().claimTx !== undefined;
+    const lockupTxHash = () => getLockupTxHash(props.swap());
 
     const asset = () =>
         hasBeenClaimed() ? props.swap().assetReceive : props.swap().assetSend;
@@ -67,11 +71,11 @@ const ChainSwapLink = (props: {
             }>
             {/* Showing addresses makes no sense for EVM based chains.
                 The lockup tx is a regular EVM tx, not a LayerZero message. */}
-            <Show when={props.swap().lockupTx}>
+            <Show when={lockupTxHash()}>
                 <BlockExplorer
                     asset={asset()}
                     kind={BlockExplorerTargetKind.Tx}
-                    id={props.swap().lockupTx!}
+                    id={lockupTxHash()!}
                     typeLabel={"lockup_tx"}
                 />
             </Show>
@@ -84,7 +88,7 @@ const BlockExplorerLinkInner = (props: {
     swapStatus: Accessor<string>;
 }) => {
     const { deriveKey } = useGlobalContext();
-
+    const lockupTxHash = () => getLockupTxHash(props.swap());
     const bridgeSendPending = () => {
         const s = props.swap();
         return (
@@ -163,13 +167,13 @@ const BlockExplorerLinkInner = (props: {
                         <Show
                             when={props.swap().claimTx !== undefined}
                             fallback={
-                                <Show when={props.swap().lockupTx}>
+                                <Show when={lockupTxHash()}>
                                     <BlockExplorer
                                         asset={getRelevantAssetForSwap(
                                             props.swap(),
                                         )}
                                         kind={BlockExplorerTargetKind.Tx}
-                                        id={props.swap().lockupTx!}
+                                        id={lockupTxHash()!}
                                         typeLabel={"lockup_tx"}
                                     />
                                 </Show>

--- a/src/components/BridgeSendRecovery.ts
+++ b/src/components/BridgeSendRecovery.ts
@@ -92,6 +92,7 @@ export const useBridgeSendRecovery = (params: {
     const persistBridgeSend = async (
         txHash: string,
         details?: BridgeTransaction["details"],
+        sourceAmount?: bigint,
     ) => {
         await updateBridge((bridge) => {
             const next: BridgeDetail = {
@@ -100,6 +101,9 @@ export const useBridgeSendRecovery = (params: {
                 pendingSend: undefined,
                 evmSendCandidate: undefined,
             };
+            if (sourceAmount !== undefined) {
+                next.sourceAmount = sourceAmount.toString();
+            }
             if (details === undefined) {
                 delete next.details;
             } else {

--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -580,6 +580,14 @@ const CreateButton = () => {
                     "hops" | "hopsPosition" | "sendAmount" | "receiveAmount"
                 >,
             ): Promise<string | undefined> => {
+                const sourceAmount =
+                    amountChanged() === Side.Send ? sendAmount() : undefined;
+                bridge =
+                    buildBridgeDetail(
+                        assetSend(),
+                        SwapPosition.Pre,
+                        sourceAmount,
+                    ) ?? buildBridgeDetail(assetReceive(), SwapPosition.Post);
                 dex =
                     creationData?.hops !== undefined &&
                     creationData?.hopsPosition !== undefined
@@ -588,16 +596,11 @@ const CreateButton = () => {
                               creationData.hopsPosition,
                               creationData.sendAmount,
                               creationData.receiveAmount,
+                              // If the bridge is involved, the source amount is already
+                              // persisted on the bridge and isn't involved in the DEX quote.
+                              bridge === undefined ? sourceAmount : undefined,
                           )
                         : undefined;
-                bridge =
-                    buildBridgeDetail(
-                        assetSend(),
-                        SwapPosition.Pre,
-                        amountChanged() === Side.Send
-                            ? sendAmount()
-                            : undefined,
-                    ) ?? buildBridgeDetail(assetReceive(), SwapPosition.Post);
 
                 const payload = buildSwapMetadataPayload({ dex, bridge });
                 const mnemonic = rescueFile()?.mnemonic;

--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -29,6 +29,7 @@ import {
     getRouteViaAsset,
     isEvmAsset,
 } from "../consts/Assets";
+import { Side } from "../consts/Enums";
 import type { ButtonLabelParams } from "../consts/Types";
 import { useCreateContext } from "../context/Create";
 import { useGlobalContext } from "../context/Global";
@@ -39,8 +40,13 @@ import {
 } from "../context/Web3";
 import type { DictKey } from "../i18n/i18n";
 import { GasNeededToClaim, getSmartWalletAddress } from "../rif/Signer";
-import Pair, { type CreationData } from "../utils/Pair";
+import Pair, {
+    type CreationData,
+    type EncodedHop,
+    toDexAmount,
+} from "../utils/Pair";
 import { calculateSendAmount } from "../utils/calculate";
+import { canCommitSubmarineSendAmount } from "../utils/commitmentSwap";
 import { validateAddress as validateOnchainAddress } from "../utils/compat";
 import {
     btcToSat,
@@ -60,10 +66,14 @@ import { gasTopUpSupported } from "../utils/quoter";
 import { canSendAsset } from "../utils/selectableAsset";
 import {
     type BridgeDetail,
+    type ChainSwap,
+    type DexDetail,
     type GasAbstraction,
     GasAbstractionType,
-    type SomeSwap,
+    type ReverseSwap,
+    type SubmarineSwap,
     createChain,
+    createCommitmentSwap,
     createReverse,
     createSubmarine,
 } from "../utils/swapCreator";
@@ -91,6 +101,7 @@ const userErrorLabelKeys = new Set<DictKey>([
 const buildBridgeDetail = (
     asset: string,
     position: SwapPosition,
+    sourceAmount?: BigNumber,
 ): BridgeDetail | undefined => {
     const route =
         position === SwapPosition.Pre
@@ -105,7 +116,45 @@ const buildBridgeDetail = (
         return undefined;
     }
 
-    return driver.getRoutePosition(route, position);
+    const bridge = driver.getRoutePosition(route, position);
+    if (position !== SwapPosition.Pre || sourceAmount === undefined) {
+        return bridge;
+    }
+
+    return {
+        ...bridge,
+        sourceAmount: sourceAmount.toFixed(0),
+    };
+};
+
+const buildDexDetail = (
+    hops: EncodedHop[],
+    position: SwapPosition | undefined,
+    sendAmount: BigNumber,
+    receiveAmount: BigNumber,
+    amountChanged: Side,
+): DexDetail | undefined => {
+    if (position === undefined) {
+        return undefined;
+    }
+
+    const dex = {
+        hops,
+        position,
+        quoteAmount:
+            position === SwapPosition.Post
+                ? Number(receiveAmount)
+                : Number(sendAmount),
+    };
+
+    if (position !== SwapPosition.Pre || amountChanged !== Side.Send) {
+        return dex;
+    }
+
+    return {
+        ...dex,
+        sourceAmount: toDexAmount(sendAmount, hops[0].from).toString(),
+    };
 };
 
 const getLockupGasAbstraction = (assetSend: string): GasAbstractionType => {
@@ -224,6 +273,7 @@ const CreateButton = () => {
         onchainAddress,
         receiveAmount,
         sendAmount,
+        amountChanged,
         amountValid,
         setInvoice,
         setInvoiceValid,
@@ -276,6 +326,14 @@ const CreateButton = () => {
     const swapType = () => pair().swapToCreate?.type;
     const assetSend = () => pair().fromAsset;
     const assetReceive = () => pair().toAsset;
+    const deferredInvoiceDestination = () => lnurl() || bolt12Offer();
+    const canCreateCommitmentSwap = () =>
+        canCommitSubmarineSendAmount(pair(), amountChanged()) &&
+        amountValid() &&
+        invoiceError() === undefined &&
+        (invoice() === "" || deferredInvoiceDestination() !== undefined);
+    const canCreateSwap = () =>
+        valid() || validWayToFetchInvoice() || canCreateCommitmentSwap();
     const getSwapCreationLogContext = (
         claimAddress?: string,
         gasAbstraction?: GasAbstraction,
@@ -303,6 +361,7 @@ const CreateButton = () => {
                 addressValid,
                 invoiceValid,
                 invoiceError,
+                amountChanged,
                 pair,
                 lnurl,
                 online,
@@ -358,6 +417,7 @@ const CreateButton = () => {
                     // Chain swaps with 0-amount that do not have RBTC as sending asset
                     // can skip this check
                     !isChainSwapWithZeroAmount() &&
+                    !canCreateCommitmentSwap() &&
                     (isSubmarineSwapInvoiceValid() ||
                         swapType() !== SwapType.Submarine) &&
                     !(sendAmount().isZero() && hasInvalidDestinationInput());
@@ -403,6 +463,10 @@ const CreateButton = () => {
                         return;
                     }
                 } else {
+                    if (canCreateCommitmentSwap()) {
+                        setButtonLabel({ key: "create_swap" });
+                        return;
+                    }
                     if (validWayToFetchInvoice()) {
                         setButtonLabel({ key: "create_swap" });
                         return;
@@ -422,7 +486,7 @@ const CreateButton = () => {
     const validWayToFetchInvoice = (): boolean => {
         return (
             swapType() === SwapType.Submarine &&
-            (lnurl() !== "" || bolt12Offer() !== undefined) &&
+            deferredInvoiceDestination() !== undefined &&
             amountValid() &&
             sendAmount().isGreaterThan(0) &&
             assetReceive() !== assetSend()
@@ -446,22 +510,33 @@ const CreateButton = () => {
     };
 
     const fetchInvoice = async (): Promise<boolean> => {
-        const destination = lnurl() || bolt12Offer();
-        if (destination === undefined || destination === "") {
-            return true;
+        const destination = deferredInvoiceDestination();
+        if (destination === undefined) {
+            return false;
         }
+        const fetchingLnurl = lnurl() !== "";
 
-        log.info("Resolving invoice for destination", destination);
+        log.info(
+            fetchingLnurl
+                ? "Resolving invoice for LNURL or BIP-353"
+                : "Resolving invoice for bolt12 offer",
+            destination,
+        );
+
         try {
             const { invoice } = await resolveInvoice(
                 destination,
                 Number(receiveAmount()),
                 { timeoutMs: invoiceFetchTimeout },
             );
+
             setOriginalDestination(destination);
             setInvoice(invoice);
-            setLnurl("");
-            setBolt12Offer(undefined);
+            if (fetchingLnurl) {
+                setLnurl("");
+            } else {
+                setBolt12Offer(undefined);
+            }
             setInvoiceValid(true);
             return true;
         } catch (e) {
@@ -496,7 +571,7 @@ const CreateButton = () => {
         gasAbstraction: GasAbstraction,
     ): Promise<boolean> => {
         try {
-            let data!: SomeSwap;
+            let data!: SubmarineSwap | ReverseSwap | ChainSwap;
             let dex: SwapMetadataSource["dex"];
             let bridge: SwapMetadataSource["bridge"];
             const buildCreationMetadata = async (
@@ -506,20 +581,24 @@ const CreateButton = () => {
                 >,
             ): Promise<string | undefined> => {
                 dex =
+                    creationData?.hops !== undefined &&
                     creationData?.hopsPosition !== undefined
-                        ? {
-                              hops: creationData.hops,
-                              position: creationData.hopsPosition,
-                              quoteAmount:
-                                  creationData.hopsPosition ===
-                                  SwapPosition.Post
-                                      ? Number(creationData.receiveAmount)
-                                      : Number(creationData.sendAmount),
-                          }
+                        ? buildDexDetail(
+                              creationData.hops,
+                              creationData.hopsPosition,
+                              creationData.sendAmount,
+                              creationData.receiveAmount,
+                              amountChanged(),
+                          )
                         : undefined;
                 bridge =
-                    buildBridgeDetail(assetSend(), SwapPosition.Pre) ??
-                    buildBridgeDetail(assetReceive(), SwapPosition.Post);
+                    buildBridgeDetail(
+                        assetSend(),
+                        SwapPosition.Pre,
+                        amountChanged() === Side.Send
+                            ? sendAmount()
+                            : undefined,
+                    ) ?? buildBridgeDetail(assetReceive(), SwapPosition.Post);
 
                 const payload = buildSwapMetadataPayload({ dex, bridge });
                 const mnemonic = rescueFile()?.mnemonic;
@@ -853,9 +932,73 @@ const CreateButton = () => {
         }
     };
 
+    const createLocalCommitmentSwap = async () => {
+        const creationData = await pair().creationData(
+            sendAmount(),
+            pair().minerFees,
+        );
+        if (creationData === undefined) {
+            throw new Error("missing swap creation data");
+        }
+        if (
+            creationData.hopsPosition !== SwapPosition.Pre ||
+            creationData.hops.length === 0
+        ) {
+            throw new Error("commitment swap requires a pre-swap DEX route");
+        }
+
+        const { gasAbstraction } = await getClaimAddress(
+            assetReceive,
+            assetSend,
+            signer,
+            onchainAddress,
+            getGasAbstractionSigner,
+            getGasToken(),
+        );
+
+        const dex = buildDexDetail(
+            creationData.hops,
+            SwapPosition.Pre,
+            sendAmount(),
+            BigNumber(0),
+            Side.Send,
+        );
+        const bridge = buildBridgeDetail(
+            assetSend(),
+            SwapPosition.Pre,
+            sendAmount(),
+        );
+        if (pair().hasPreBridge && bridge === undefined) {
+            throw new Error("missing pre-bridge details for commitment swap");
+        }
+
+        const commitmentSwap = createCommitmentSwap(
+            creationData.from,
+            creationData.to,
+            assetReceive(),
+            assetSend(),
+            sendAmount(),
+            gasAbstraction,
+            dex,
+            bridge,
+            deferredInvoiceDestination(),
+        );
+
+        await setSwapStorage({
+            ...commitmentSwap,
+            getGasToken: getGasToken(),
+        });
+        navigate("/swap/" + commitmentSwap.id);
+    };
+
     const buttonClick = async () => {
         setLoading(true);
         try {
+            if (canCreateCommitmentSwap()) {
+                await createLocalCommitmentSwap();
+                return;
+            }
+
             if (validWayToFetchInvoice()) {
                 if (!(await fetchInvoice())) {
                     return;
@@ -912,7 +1055,7 @@ const CreateButton = () => {
             disabled={
                 !online() ||
                 pairsLoading() ||
-                !(valid() || validWayToFetchInvoice()) ||
+                !canCreateSwap() ||
                 buttonDisable() ||
                 loading() ||
                 quoteLoading() ||
@@ -920,8 +1063,8 @@ const CreateButton = () => {
                     getGasToken() === undefined) ||
                 (onchainAddress() === "" &&
                     invoice() === "" &&
-                    bolt12Offer() === undefined &&
-                    lnurl() === "")
+                    deferredInvoiceDestination() === undefined &&
+                    !canCreateCommitmentSwap())
             }
             onClick={buttonClick}>
             {(pairsLoading() ||

--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -132,7 +132,7 @@ const buildDexDetail = (
     position: SwapPosition | undefined,
     sendAmount: BigNumber,
     receiveAmount: BigNumber,
-    amountChanged: Side,
+    sourceAmount?: BigNumber,
 ): DexDetail | undefined => {
     if (position === undefined) {
         return undefined;
@@ -147,13 +147,13 @@ const buildDexDetail = (
                 : Number(sendAmount),
     };
 
-    if (position !== SwapPosition.Pre || amountChanged !== Side.Send) {
+    if (position !== SwapPosition.Pre || sourceAmount === undefined) {
         return dex;
     }
 
     return {
         ...dex,
-        sourceAmount: toDexAmount(sendAmount, hops[0].from).toString(),
+        sourceAmount: toDexAmount(sourceAmount, hops[0].from).toString(),
     };
 };
 
@@ -588,7 +588,6 @@ const CreateButton = () => {
                               creationData.hopsPosition,
                               creationData.sendAmount,
                               creationData.receiveAmount,
-                              amountChanged(),
                           )
                         : undefined;
                 bridge =
@@ -961,7 +960,7 @@ const CreateButton = () => {
             SwapPosition.Pre,
             sendAmount(),
             BigNumber(0),
-            Side.Send,
+            sendAmount(),
         );
         const bridge = buildBridgeDetail(
             assetSend(),

--- a/src/components/InvoiceInput.tsx
+++ b/src/components/InvoiceInput.tsx
@@ -19,7 +19,13 @@ import {
 } from "../utils/invoice";
 import { validateInvoice } from "../utils/validation";
 
-const InvoiceInput = () => {
+type InvoiceInputProps = {
+    class?: string;
+    disabled?: boolean;
+    placeholder?: string;
+};
+
+const InvoiceInput = (props: InvoiceInputProps = {}) => {
     let inputRef!: HTMLInputElement;
     let validationRequest = 0;
 
@@ -30,6 +36,7 @@ const InvoiceInput = () => {
         minerFee,
         invoice,
         amountValid,
+        resetAmounts,
         setAmountChanged,
         setInvoice,
         setInvoiceValid,
@@ -56,14 +63,38 @@ const InvoiceInput = () => {
         setLnurl("");
     };
 
-    const validate = async (input: HTMLInputElement) => {
-        const requestId = ++validationRequest;
-        const getCurrentInputValue = () => input.value.trim();
-        const inputValue = getCurrentInputValue();
-        const isStale = () =>
-            requestId !== validationRequest ||
-            getCurrentInputValue() !== inputValue;
+    const canSwitchToAsset = (asset: string | null): asset is string =>
+        asset !== LN &&
+        asset !== null &&
+        (!bitcoinOnly() || isBitcoinOnlyAsset(asset));
 
+    const validateInput = (input: HTMLInputElement) => {
+        const inputValue = input.value.trim();
+        const address = extractAddress(inputValue);
+        const invoiceValue = extractInvoice(inputValue) ?? "";
+        const actualAsset =
+            probeUserInput(LN, invoiceValue) ?? probeUserInput(LN, address);
+
+        if (!canSwitchToAsset(actualAsset)) {
+            resetAmounts();
+        }
+
+        void validate(input);
+    };
+
+    const validate = async (
+        input: HTMLInputElement,
+        inputValue = input.value.trim(),
+    ) => {
+        const requestId = ++validationRequest;
+        const isStale = () =>
+            requestId !== validationRequest || invoice().trim() !== inputValue;
+
+        const address = extractAddress(inputValue);
+        const invoiceValue = extractInvoice(inputValue) ?? "";
+        const actualAsset =
+            probeUserInput(LN, invoiceValue) ?? probeUserInput(LN, address);
+        const switchesToAsset = canSwitchToAsset(actualAsset);
         setInvoice(inputValue);
 
         try {
@@ -75,12 +106,6 @@ const InvoiceInput = () => {
                 resetInvoiceState();
                 return;
             }
-
-            const address = extractAddress(inputValue);
-            const invoiceValue = extractInvoice(inputValue) ?? "";
-
-            const actualAsset =
-                probeUserInput(LN, invoiceValue) ?? probeUserInput(LN, address);
 
             const bip21Amount = extractBip21Amount(inputValue);
             if (bip21Amount) {
@@ -102,11 +127,7 @@ const InvoiceInput = () => {
             if (isStale()) {
                 return;
             }
-            if (
-                actualAsset !== LN &&
-                actualAsset !== null &&
-                (!bitcoinOnly() || isBitcoinOnlyAsset(actualAsset))
-            ) {
+            if (switchesToAsset) {
                 const fromAsset =
                     pair().fromAsset === actualAsset ? LN : pair().fromAsset;
                 setPair(
@@ -120,8 +141,9 @@ const InvoiceInput = () => {
             }
 
             if (isLnurl(invoiceValue)) {
-                setLnurl(invoiceValue);
+                resetInvoiceState();
                 setInvoice(invoiceValue);
+                setLnurl(invoiceValue);
             } else {
                 setBolt12Loading(true);
                 let isBolt12: boolean;
@@ -137,8 +159,9 @@ const InvoiceInput = () => {
                 }
 
                 if (isBolt12) {
-                    setBolt12Offer(invoiceValue);
+                    resetInvoiceState();
                     setInvoice(invoiceValue);
+                    setBolt12Offer(invoiceValue);
                 } else {
                     const sats = validateInvoice(invoiceValue);
                     setAmountChanged(Side.Receive);
@@ -180,28 +203,37 @@ const InvoiceInput = () => {
     };
 
     createEffect(
-        on([amountValid, invoice, pair, minerFee], async () => {
-            if (
-                pair().swapToCreate?.type === SwapType.Submarine ||
-                pair().toAsset === LN
-            ) {
-                await validate(inputRef);
-            }
-        }),
+        on(
+            [amountValid, invoice, pair, minerFee, () => props.disabled],
+            async () => {
+                if (props.disabled) {
+                    return;
+                }
+
+                if (
+                    pair().swapToCreate?.type === SwapType.Submarine ||
+                    pair().toAsset === LN
+                ) {
+                    await validate(inputRef, invoice().trim());
+                }
+            },
+        ),
     );
 
     return (
         <input
             required
             ref={inputRef}
-            onInput={(e) => validate(e.currentTarget)}
+            onInput={(e) => validateInput(e.currentTarget)}
             type="text"
+            class={props.class}
             id="invoice"
             data-testid="invoice"
             name="invoice"
             value={invoice()}
             autocomplete="off"
-            placeholder={t("create_and_paste")}
+            disabled={props.disabled}
+            placeholder={props.placeholder ?? t("create_and_paste")}
         />
     );
 };

--- a/src/components/LockupEvm.tsx
+++ b/src/components/LockupEvm.tsx
@@ -3,6 +3,7 @@ import {
     type QuoteData,
     encodeDexQuote,
     getCommitmentLockupDetails,
+    quoteDexAmountIn,
     quoteDexAmountOut,
 } from "boltz-swaps/client";
 import { prefix0x, satsToAssetAmount } from "boltz-swaps/evm";
@@ -16,7 +17,10 @@ import {
     etherSwapAbi,
     routerAbi,
 } from "boltz-swaps/generated/evm-abis";
-import { calculateAmountWithSlippage } from "boltz-swaps/helper";
+import {
+    calculateAmountOutMin,
+    calculateAmountWithSlippage,
+} from "boltz-swaps/helper";
 import { AssetKind } from "boltz-swaps/types";
 import { randomBytes } from "crypto";
 import log from "loglevel";
@@ -48,6 +52,7 @@ import {
 import { useModifySwap } from "../hooks/useModifySwap";
 import type { EncodedHop } from "../utils/Pair";
 import { formatAssetAmountForLog } from "../utils/denomination";
+import { getNativeEvmLockupSpendableBalance } from "../utils/evmLockup";
 import { sendPopulatedTransaction } from "../utils/evmTransaction";
 import type { HardwareSigner } from "../utils/hardware/HardwareSigner";
 import { estimateFeesPerGas } from "../utils/provider";
@@ -56,6 +61,7 @@ import {
     type BridgeDetail,
     GasAbstractionType,
     type SomeSwap,
+    isCommitmentSwap,
 } from "../utils/swapCreator";
 import { patchEncryptedSwapMetadata } from "../utils/swapMetadata";
 import ApproveErc20 from "./ApproveErc20";
@@ -65,8 +71,6 @@ import InsufficientBalance from "./InsufficientBalance";
 import LoadingSpinner from "./LoadingSpinner";
 import OptimizedRoute from "./OptimizedRoute";
 import SendToBridge from "./SendToBridge";
-
-const lockupGasUsage = 46_000n;
 
 const permitWitnessTransferFromTypes = {
     PermitWitnessTransferFrom: [
@@ -94,6 +98,7 @@ const getHopExecutionQuote = async (
     hop: EncodedHop,
     lockupAmount: bigint,
     slippage: number,
+    hopInputAmount?: bigint,
 ): Promise<{
     targetLockupAmount: bigint;
     quote: QuoteData;
@@ -102,6 +107,34 @@ const getHopExecutionQuote = async (
     if (hop.dexDetails === undefined) {
         throw new Error("missing DEX details for lockup hop");
     }
+
+    if (hopInputAmount !== undefined) {
+        const quotes = await quoteDexAmountIn(
+            hop.dexDetails.chain,
+            hop.dexDetails.tokenIn,
+            hop.dexDetails.tokenOut,
+            hopInputAmount,
+        );
+
+        if (!Array.isArray(quotes) || quotes.length === 0) {
+            log.error("No DEX exact-input quotes returned for lockup hop", {
+                dexDetails: hop.dexDetails,
+                hopInputAmount: hopInputAmount.toString(),
+            });
+            throw new Error("could not get DEX quote for lockup hop");
+        }
+
+        const quote = quotes[0];
+        return {
+            quote,
+            amountIn: hopInputAmount,
+            targetLockupAmount: calculateAmountOutMin(
+                BigInt(quote.quote),
+                slippage,
+            ),
+        };
+    }
+
     const targetLockupAmount = calculateAmountWithSlippage(
         lockupAmount,
         slippage / 2,
@@ -115,7 +148,7 @@ const getHopExecutionQuote = async (
     );
 
     if (!Array.isArray(quotes) || quotes.length === 0) {
-        log.error("No DEX quotes returned for lockup hop", {
+        log.error("No DEX exact-output quotes returned for lockup hop", {
             dexDetails: hop.dexDetails,
             targetLockupAmount: formatAssetAmountForLog(
                 targetLockupAmount,
@@ -252,6 +285,7 @@ const lockupWithHops = async (
     getSwap: (id: string) => Promise<SomeSwap | null>,
     modifySwap: ReturnType<typeof useModifySwap>,
     rescueFile: RescueFile | null,
+    hopInputAmount?: bigint,
 ): Promise<string> => {
     const transactionSigner = getSignerForGasAbstraction(
         gasAbstraction,
@@ -273,7 +307,12 @@ const lockupWithHops = async (
         }
 
         const { targetLockupAmount, quote, amountIn } =
-            await getHopExecutionQuote(hop, lockupAmount, slippage);
+            await getHopExecutionQuote(
+                hop,
+                lockupAmount,
+                slippage,
+                hopInputAmount,
+            );
         log.info("Got DEX quote for lockup hop", {
             amountIn: formatAssetAmountForLog(amountIn, hop.from),
             targetLockupAmount: formatAssetAmountForLog(
@@ -317,6 +356,7 @@ const lockupWithHops = async (
 
         const tokenAddress = getAddress(getTokenAddress(asset));
         const commitmentLockupDetails = await getCommitmentLockupDetails(asset);
+        const timeoutBlockHeight = Number(commitmentLockupDetails.timelock);
         const commitmentPreimageHash = "00".repeat(32);
 
         const permit2Signature = await connectedSigner.signTypedData({
@@ -343,7 +383,7 @@ const lockupWithHops = async (
                         commitmentLockupDetails.claimAddress,
                     ),
                     refundAddress: refundAddress,
-                    timelock: BigInt(commitmentLockupDetails.timelock),
+                    timelock: BigInt(timeoutBlockHeight),
                     callsHash,
                 },
             },
@@ -359,7 +399,7 @@ const lockupWithHops = async (
                     tokenAddress,
                     getAddress(commitmentLockupDetails.claimAddress),
                     refundAddress,
-                    BigInt(commitmentLockupDetails.timelock),
+                    BigInt(timeoutBlockHeight),
                     calls,
                     {
                         permitted: {
@@ -395,6 +435,9 @@ const lockupWithHops = async (
             s.commitmentLockupTxHash = transactionHash;
             s.commitmentSignatureSubmitted = false;
             s.signer = ownerAddress;
+            if (isCommitmentSwap(s)) {
+                s.timeoutBlockHeight = timeoutBlockHeight;
+            }
         });
         if (currentSwap === null) {
             throw new Error(`missing swap ${swapId} for lockup persistence`);
@@ -409,8 +452,7 @@ const lockupWithHops = async (
         return transactionHash;
     };
 
-    let commitmentTxHash: string | undefined = (await getSwap(swapId))
-        ?.commitmentLockupTxHash;
+    let commitmentTxHash = (await getSwap(swapId))?.commitmentLockupTxHash;
     if (commitmentTxHash === undefined) {
         commitmentTxHash = await lockup();
     } else {
@@ -438,6 +480,7 @@ const LockupTransaction = (props: {
     approvalValue?: () => bigint;
     approvalTarget?: Address;
     hops?: EncodedHop[];
+    hopInputAmount?: bigint;
 }) => {
     const { t, slippage, getSwap, rescueFile } = useGlobalContext();
     const {
@@ -500,6 +543,7 @@ const LockupTransaction = (props: {
                             getSwap,
                             modifySwap,
                             rescueFile(),
+                            props.hopInputAmount,
                         );
                     } else if (
                         getKindForAsset(props.asset) === AssetKind.EVMNative
@@ -561,8 +605,12 @@ const LockupTransaction = (props: {
                         }
                     }
 
+                    const persistLockupTx =
+                        props.hops === undefined || props.hops.length === 0;
                     const updated = await modifySwap(props.swapId, (s) => {
-                        s.lockupTx = transactionHash;
+                        if (persistLockupTx) {
+                            s.lockupTx = transactionHash;
+                        }
                         s.signer = connectedSigner.address;
 
                         if (
@@ -604,12 +652,17 @@ const LockupEvm = (props: {
     claimAddress: Address;
     timeoutBlockHeight: number;
     hops?: EncodedHop[];
+    hopInputAmount?: string;
     bridge?: BridgeDetail;
 }) => {
     const { slippage } = useGlobalContext();
     const { getErc20Swap, signer } = useWeb3Signer();
 
     const value = () => satsToAssetAmount(props.amount, props.asset);
+    const hopInputValue = () =>
+        props.hopInputAmount === undefined
+            ? undefined
+            : BigInt(props.hopInputAmount);
 
     const hasHopsBefore = () =>
         props.hops !== undefined && props.hops.length > 0;
@@ -640,6 +693,11 @@ const LockupEvm = (props: {
     createEffect(() => {
         void (async () => {
             if (props.bridge !== undefined) {
+                if (props.bridge.sourceAmount !== undefined) {
+                    setBridgeValue(BigInt(props.bridge.sourceAmount));
+                    return;
+                }
+
                 if (!hasHopsBefore() || props.hops === undefined) {
                     throw new Error(
                         `bridge swap ${props.swapId} is missing a lockup-side DEX hop`,
@@ -681,9 +739,12 @@ const LockupEvm = (props: {
                         activeSigner.address,
                         permit2Address,
                     ]),
-                    getHopExecutionQuote(hop, value(), slippage()).then(
-                        ({ amountIn }) => amountIn,
-                    ),
+                    getHopExecutionQuote(
+                        hop,
+                        value(),
+                        slippage(),
+                        hopInputValue(),
+                    ).then(({ amountIn }) => amountIn),
                 ]);
 
                 log.info("Hop input token balance", {
@@ -722,7 +783,10 @@ const LockupEvm = (props: {
                     if (gasPrice === null) {
                         throw new Error("missing gas price");
                     }
-                    const spendable = balance - gasPrice * lockupGasUsage;
+                    const spendable = getNativeEvmLockupSpendableBalance(
+                        balance,
+                        gasPrice,
+                    );
                     log.info("EVM signer spendable balance", {
                         asset: props.asset,
                         spendableBalance: formatAssetAmountForLog(
@@ -832,6 +896,7 @@ const LockupEvm = (props: {
                             }
                             approvalTarget={approvalTarget()}
                             hops={hasHopsBefore() ? props.hops : undefined}
+                            hopInputAmount={hopInputValue()}
                         />
                     </Show>
                 </Show>

--- a/src/components/RefundButton.tsx
+++ b/src/components/RefundButton.tsx
@@ -75,6 +75,7 @@ import { RefundType, refund } from "../utils/rescue";
 import {
     type BridgeDetail,
     type ChainSwap,
+    type CommitmentSwap,
     type DexDetail,
     GasAbstractionType,
     type SubmarineSwap,
@@ -764,7 +765,10 @@ export const RefundEvm = (props: {
                                 await getEvmRefundCooperativeSignature({
                                     isCommitmentLockup,
                                     asset: props.asset,
-                                    swapId: props.swapId,
+                                    swapId:
+                                        props.swapType === SwapType.Commitment
+                                            ? undefined
+                                            : props.swapId,
                                     swapType: props.swapType,
                                     commitmentTxHash:
                                         props.lockupTxHash ??
@@ -1090,7 +1094,7 @@ export const RefundBtc = (props: {
 };
 
 const RefundButton = (props: {
-    swap: Accessor<SubmarineSwap | ChainSwap>;
+    swap: Accessor<SubmarineSwap | ChainSwap | CommitmentSwap>;
     setRefundTxId?: Setter<string>;
     buttonOverride?: string;
     deriveKeyFn?: deriveKeyFn;
@@ -1134,7 +1138,12 @@ const RefundButton = (props: {
                     bridge={props.swap().bridge}
                 />
             }>
-            <RefundBtc {...props} setRefundTxId={setRefundTxId} />
+            <RefundBtc
+                swap={props.swap as Accessor<SubmarineSwap | ChainSwap>}
+                buttonOverride={props.buttonOverride}
+                deriveKeyFn={props.deriveKeyFn}
+                setRefundTxId={setRefundTxId}
+            />
         </Show>
     );
 };

--- a/src/components/SendToBridge.tsx
+++ b/src/components/SendToBridge.tsx
@@ -165,6 +165,11 @@ const EvmSendCandidateRecovery = (props: {
     );
 };
 
+type BridgeSendResult = {
+    tx: BridgeTransaction;
+    sourceAmount: bigint;
+};
+
 const SendToBridge = (props: {
     bridge: BridgeDetail;
     swapId: string;
@@ -312,28 +317,36 @@ const SendToBridge = (props: {
         const bridgeRoute = props.bridge;
         const quotedBridgeInstance =
             await bridgeDriver().getQuotedContract(bridgeRoute);
+
+        // we don't want to refetch a quote if we previously committed to
+        // a fixed source amount, e.g. for sweeping the wallet.
+        let sourceAmount = BigInt(bridgeRoute.sourceAmount ?? 0);
+
         // `props.amount` is the amount Boltz needs to arrive on the destination
         // chain (it was computed by the pair/DEX step on the far side). Bridges
         // that charge fees in the bridged asset (CCTP) must burn more than
         // that so the arrival matches. OFT typically returns `amount`
         // unchanged when there's no token-side fee.
-        const tokenAmount = await bridgeDriver().quoteAmountInForAmountOut(
-            bridgeRoute,
-            props.amount,
-            { cctpReceiveMode: cctpReceiveMode() },
-        );
+        if (sourceAmount === 0n) {
+            sourceAmount = await bridgeDriver().quoteAmountInForAmountOut(
+                bridgeRoute,
+                props.amount,
+                { cctpReceiveMode: cctpReceiveMode() },
+            );
+        }
+
         const { sendParam, msgFee } = await bridgeDriver().quoteSend(
             quotedBridgeInstance,
             bridgeRoute,
             recipient,
-            tokenAmount,
+            sourceAmount,
             { cctpReceiveMode: cctpReceiveMode() },
         );
 
         return {
             bridgeRoute,
             recipient,
-            tokenAmount,
+            sourceAmount,
             sendParam,
             msgFee,
         };
@@ -346,11 +359,9 @@ const SendToBridge = (props: {
         nativeBalance: bigint,
         requiredNativeBalance: bigint,
         {
-            trackRequiredTokenBalance = true,
             needsApproval = false,
             approvalTarget,
         }: {
-            trackRequiredTokenBalance?: boolean;
             needsApproval?: boolean;
             approvalTarget?: string;
         } = {},
@@ -382,9 +393,7 @@ const SendToBridge = (props: {
         });
 
         setSignerBalance(balance);
-        setRequiredTokenBalance(
-            trackRequiredTokenBalance ? requiredTokenAmount : undefined,
-        );
+        setRequiredTokenBalance(requiredTokenAmount);
         setHasEnoughMsgFee(hasEnoughMsgFee);
         setNeedsApproval(needsApproval);
         setApprovalTarget(approvalTarget);
@@ -396,7 +405,7 @@ const SendToBridge = (props: {
             props.bridge.sourceAsset,
             connectedSigner,
         );
-        const { bridgeRoute, tokenAmount, sendParam, msgFee } =
+        const { bridgeRoute, sourceAmount, sendParam, msgFee } =
             await quoteBridgeSendState(recipient);
         const directSendTarget =
             await bridgeDriver().getDirectSendTarget(bridgeRoute);
@@ -417,7 +426,7 @@ const SendToBridge = (props: {
 
         const requiredTokenAmount = bridgeDriver().getDirectRequiredTokenAmount(
             directSendTarget,
-            tokenAmount,
+            sourceAmount,
             msgFee,
         );
         const requiredNativeBalance =
@@ -460,7 +469,7 @@ const SendToBridge = (props: {
         return {
             directSendTarget,
             recipient,
-            tokenAmount,
+            sourceAmount,
             sendParam,
             msgFee,
             hasEnoughTokenBalance,
@@ -471,7 +480,7 @@ const SendToBridge = (props: {
     };
 
     const refreshSolanaBridgeSendState = async (walletAddress: string) => {
-        const { bridgeRoute, tokenAmount, msgFee } =
+        const { bridgeRoute, sourceAmount, msgFee } =
             await quoteBridgeSendState(getBridgeRecipient());
         const [balance, nativeBalance] = await Promise.all([
             bridgeDriver().getSourceTokenBalance(bridgeRoute, walletAddress),
@@ -482,21 +491,21 @@ const SendToBridge = (props: {
                 bridgeRoute,
                 msgFee,
             );
-        const hasEnoughTokenBalance = balance >= tokenAmount;
+        const hasEnoughTokenBalance = balance >= sourceAmount;
         const hasEnoughNativeBalanceForMsgFee =
             nativeBalance >= requiredNativeBalance;
 
         syncBridgeSendBalanceState(
             "Solana bridge",
             balance,
-            tokenAmount,
+            sourceAmount,
             nativeBalance,
             requiredNativeBalance,
-            { trackRequiredTokenBalance: false },
         );
 
         return {
             balance,
+            sourceAmount,
             hasEnoughTokenBalance,
             hasEnoughNativeBalanceForMsgFee,
         };
@@ -504,7 +513,8 @@ const SendToBridge = (props: {
 
     const refreshTronBridgeSendState = async (walletAddress: string) => {
         const recipient = getBridgeRecipient();
-        const { bridgeRoute, msgFee } = await quoteBridgeSendState(recipient);
+        const { bridgeRoute, sourceAmount, msgFee } =
+            await quoteBridgeSendState(recipient);
         const bridgeInstance = await bridgeDriver().createContract(bridgeRoute);
         const [balance, nativeBalance] = await Promise.all([
             bridgeDriver().getSourceTokenBalance(bridgeRoute, walletAddress),
@@ -515,7 +525,7 @@ const SendToBridge = (props: {
                 bridgeRoute,
                 msgFee,
             );
-        const hasEnoughTokenBalance = balance >= props.amount;
+        const hasEnoughTokenBalance = balance >= sourceAmount;
         const hasEnoughNativeBalanceForMsgFee =
             nativeBalance >= requiredNativeBalance;
         // Tron bridge sends are OFT-only (CCTP has no Tron transport).
@@ -533,17 +543,16 @@ const SendToBridge = (props: {
                 walletAddress,
                 spenderAddress,
             );
-            needsUpdatedApproval = allowance < props.amount;
+            needsUpdatedApproval = allowance < sourceAmount;
         }
 
         syncBridgeSendBalanceState(
             "Tron bridge",
             balance,
-            props.amount,
+            sourceAmount,
             nativeBalance,
             requiredNativeBalance,
             {
-                trackRequiredTokenBalance: false,
                 needsApproval: needsUpdatedApproval,
                 approvalTarget: spenderAddress,
             },
@@ -551,6 +560,7 @@ const SendToBridge = (props: {
 
         return {
             balance,
+            sourceAmount,
             hasEnoughTokenBalance,
             hasEnoughNativeBalanceForMsgFee,
             needsUpdatedApproval,
@@ -610,7 +620,7 @@ const SendToBridge = (props: {
         }
     };
 
-    const sendBridgeFromSolana = async () => {
+    const sendBridgeFromSolana = async (): Promise<BridgeSendResult> => {
         const wallet = connectedWallet();
         if (
             wallet?.transport !== NetworkTransport.Solana ||
@@ -640,25 +650,12 @@ const SendToBridge = (props: {
             `Sending bridge ${props.bridge.destinationAsset} to ${recipient}`,
         );
 
-        const quotedBridgeInstance = await bridgeDriver().getQuotedContract(
-            props.bridge,
-        );
-        const tokenAmount = await bridgeDriver().quoteAmountInForAmountOut(
-            props.bridge,
-            props.amount,
-            { cctpReceiveMode: cctpReceiveMode() },
-        );
         const bridgeInstance = await bridgeDriver().createContract(
             props.bridge,
             WalletConnectProvider.getSolanaProvider(),
         );
-        const { sendParam, msgFee } = await bridgeDriver().quoteSend(
-            quotedBridgeInstance,
-            props.bridge,
-            recipient,
-            tokenAmount,
-            { cctpReceiveMode: cctpReceiveMode() },
-        );
+        const { sourceAmount, sendParam, msgFee } =
+            await quoteBridgeSendState(recipient);
 
         log.debug("Quoted bridge send", {
             swapId: props.swapId,
@@ -666,7 +663,7 @@ const SendToBridge = (props: {
             destinationAsset: props.bridge.destinationAsset,
             recipient,
             amount: formatAssetAmountForLog(
-                tokenAmount,
+                sourceAmount,
                 props.bridge.sourceAsset,
             ),
             nativeFee: formatNativeAmountForLog(
@@ -676,15 +673,16 @@ const SendToBridge = (props: {
             lzTokenFee: msgFee[1].toString(),
         });
 
-        return await sendTransport({
+        const tx = await sendTransport({
             contract: bridgeInstance,
             sendParam,
             msgFee,
             refundAddress: wallet.address,
         });
+        return { tx, sourceAmount };
     };
 
-    const sendBridgeFromTron = async () => {
+    const sendBridgeFromTron = async (): Promise<BridgeSendResult> => {
         const wallet = connectedWallet();
         if (
             wallet?.transport !== NetworkTransport.Tron ||
@@ -726,7 +724,7 @@ const SendToBridge = (props: {
             props.bridge,
             WalletConnectProvider.getTronProvider(),
         );
-        const { tokenAmount, sendParam, msgFee } =
+        const { sourceAmount, sendParam, msgFee } =
             await quoteBridgeSendState(recipient);
 
         log.debug("Quoted bridge send", {
@@ -735,7 +733,7 @@ const SendToBridge = (props: {
             destinationAsset: props.bridge.destinationAsset,
             recipient,
             amount: formatAssetAmountForLog(
-                tokenAmount,
+                sourceAmount,
                 props.bridge.sourceAsset,
             ),
             nativeFee: formatNativeAmountForLog(
@@ -745,15 +743,16 @@ const SendToBridge = (props: {
             lzTokenFee: msgFee[1].toString(),
         });
 
-        return await sendTransport({
+        const tx = await sendTransport({
             contract: bridgeInstance,
             sendParam,
             msgFee,
             refundAddress: wallet.address,
         });
+        return { tx, sourceAmount };
     };
 
-    const sendBridgeFromEvm = async () => {
+    const sendBridgeFromEvm = async (): Promise<BridgeSendResult> => {
         const connectedSigner = signer();
         if (connectedSigner === undefined) {
             throw new Error("connected signer is required for bridge send");
@@ -762,7 +761,7 @@ const SendToBridge = (props: {
         const {
             directSendTarget,
             recipient,
-            tokenAmount,
+            sourceAmount,
             sendParam,
             msgFee,
             signerAddress,
@@ -797,7 +796,7 @@ const SendToBridge = (props: {
             destinationAsset: props.bridge.destinationAsset,
             recipient,
             amount: formatAssetAmountForLog(
-                tokenAmount,
+                sourceAmount,
                 props.bridge.sourceAsset,
             ),
             nativeFee: formatNativeAmountForLog(
@@ -847,16 +846,19 @@ const SendToBridge = (props: {
                     destinationAsset: props.bridge.destinationAsset,
                     error,
                 });
-                return await sendDirect();
+                return { tx: await sendDirect(), sourceAmount };
             }
 
-            return await sendPreparedEvmBridgeTransaction(
-                connectedSigner,
-                prepared,
-            );
+            return {
+                tx: await sendPreparedEvmBridgeTransaction(
+                    connectedSigner,
+                    prepared,
+                ),
+                sourceAmount,
+            };
         }
 
-        return await sendDirect();
+        return { tx: await sendDirect(), sourceAmount };
     };
 
     const getEvmCandidateFromBlock = (latestBlock: bigint) =>
@@ -1087,10 +1089,12 @@ const SendToBridge = (props: {
                                         onClick={async () => {
                                             setBridgeSendActive(true);
                                             try {
-                                                const tx = await sendBridge();
+                                                const result =
+                                                    await sendBridge();
                                                 await persistBridgeSend(
-                                                    tx.hash,
-                                                    tx.details,
+                                                    result.tx.hash,
+                                                    result.tx.details,
+                                                    result.sourceAmount,
                                                 );
                                             } finally {
                                                 setBridgeSendActive(false);

--- a/src/components/SwapChecker.tsx
+++ b/src/components/SwapChecker.tsx
@@ -108,15 +108,25 @@ export const SwapChecker = () => {
     };
 
     onMount(async () => {
-        const swapsToCheck = (await getSwaps()).filter(
-            (s) =>
-                s.status === undefined ||
-                !swapStatusFinal.includes(s.status) ||
-                ((s.status === swapStatusSuccess.InvoiceSettled ||
-                    (s.type === SwapType.Chain &&
-                        s.status === swapStatusSuccess.TransactionClaimed)) &&
-                    s.claimTx === undefined),
-        );
+        const swapsToCheck = (await getSwaps()).filter((swap) => {
+            if (swap.type === SwapType.Commitment) {
+                return false;
+            }
+
+            if (
+                swap.status === undefined ||
+                !swapStatusFinal.includes(swap.status)
+            ) {
+                return true;
+            }
+
+            return (
+                swap.claimTx === undefined &&
+                (swap.status === swapStatusSuccess.InvoiceSettled ||
+                    (swap.type === SwapType.Chain &&
+                        swap.status === swapStatusSuccess.TransactionClaimed))
+            );
+        });
 
         for (const s of swapsToCheck) {
             subscribeSwap(s.id);
@@ -130,6 +140,9 @@ export const SwapChecker = () => {
     createEffect(() => {
         const activeSwap = swap();
         if (activeSwap === undefined || activeSwap === null) {
+            return;
+        }
+        if (activeSwap.type === SwapType.Commitment) {
             return;
         }
         subscribeSwap(activeSwap.id);

--- a/src/components/SwapExecutionWorker.tsx
+++ b/src/components/SwapExecutionWorker.tsx
@@ -27,6 +27,7 @@ import {
     postCommitmentSignatureForTransaction,
 } from "boltz-swaps/evm/commitment";
 import { createRouterContract } from "boltz-swaps/evm/contracts";
+import { getLockupEvent } from "boltz-swaps/evm/transaction";
 import {
     erc20Abi,
     erc20SwapAbi,
@@ -123,10 +124,21 @@ const getCommitmentChainAsset = (swap: SomeSwap) =>
         ? swap.bridge.destinationAsset
         : swap.assetSend;
 
-const getPreBridgeCommitmentClaimAddress = (swap: SomeSwap) =>
-    swap.type === SwapType.Chain
-        ? (swap as ChainSwap).lockupDetails.claimAddress
-        : swap.claimAddress;
+const getPreBridgeClaimAddress = (
+    swap: SomeSwap,
+    commitmentClaimAddress: string | undefined,
+) => {
+    switch (swap.type) {
+        case SwapType.Chain:
+            return swap.lockupDetails.claimAddress;
+
+        case SwapType.Commitment:
+            return commitmentClaimAddress;
+
+        default:
+            return swap.claimAddress;
+    }
+};
 
 const getSwapPreimageHash = (swap: SomeSwap): string => {
     switch (swap.type) {
@@ -175,6 +187,7 @@ export const needsCommitmentPost = (
 ): swap is SomeSwap & { commitmentLockupTxHash: string } =>
     swap !== undefined &&
     swap !== null &&
+    swap.type !== SwapType.Commitment &&
     swap.commitmentLockupTxHash !== undefined &&
     !swap.commitmentSignatureSubmitted &&
     swap.commitmentRejection === undefined &&
@@ -198,6 +211,7 @@ type PreBridgeCommitmentLockupRecoveryResult =
     | {
           status: PreBridgeCommitmentLockupRecoveryStatus.Recovered;
           transactionHash: Hex;
+          timeoutBlockHeight: number;
       }
     | {
           status: PreBridgeCommitmentLockupRecoveryStatus.Ambiguous;
@@ -240,11 +254,15 @@ export const SwapExecutionWorker = () => {
         swapId: string,
         commitmentLockupTxHash: string,
         source: CommitmentLockupTransactionSource,
+        timeoutBlockHeight?: number,
     ) => {
         const latestSwap = await modifySwap(swapId, (s) => {
             s.commitmentLockupTxHash = commitmentLockupTxHash;
             s.commitmentLockupCallId = undefined;
             s.commitmentSignatureSubmitted = false;
+            if (s.type === SwapType.Commitment) {
+                s.timeoutBlockHeight = timeoutBlockHeight;
+            }
         });
         if (latestSwap === null) {
             return false;
@@ -255,10 +273,33 @@ export const SwapExecutionWorker = () => {
             `Swap execution persisted ${source} commitment lockup transaction`,
             getSwapExecutionLogContext(latestSwap.id, {
                 commitmentLockupTxHash,
+                timeoutBlockHeight,
             }),
         );
         queueRelevantTasks(latestSwap);
         return true;
+    };
+
+    const getCommitmentLockupTimeoutBlockHeight = async (
+        asset: string,
+        commitmentLockupTxHash: string,
+    ) => {
+        const provider = createAssetProvider(asset);
+        const receipt = await provider.getTransactionReceipt({
+            hash: commitmentLockupTxHash as Hash,
+        });
+        if (receipt === null) {
+            throw new Error(
+                `commitment lockup receipt not found: ${commitmentLockupTxHash}`,
+            );
+        }
+
+        const event = getLockupEvent(
+            erc20SwapAbi,
+            receipt,
+            getErc20Swap(asset).address,
+        );
+        return Number(event.timelock);
     };
 
     const persistPreBridgeDexQuoteBlock = async ({
@@ -427,6 +468,7 @@ export const SwapExecutionWorker = () => {
         gasAbstractionSigner: {
             address: string;
         },
+        claimAddress: string,
     ): Promise<PreBridgeCommitmentLockupRecoveryResult> => {
         const commitmentAsset = currentSwap.assetSend;
         const erc20Swap = getErc20Swap(commitmentAsset);
@@ -437,19 +479,6 @@ export const SwapExecutionWorker = () => {
             fromBlock: BigInt(receivedEvent.blockNumber),
             toBlock: "latest",
         });
-        const claimAddress = getPreBridgeCommitmentClaimAddress(currentSwap);
-        if (typeof claimAddress !== "string") {
-            log.warn(
-                "Swap execution cannot recover pre-bridge commitment lockup without claim address",
-                getSwapExecutionLogContext(currentSwap.id, {
-                    commitmentAsset,
-                    fromBlock: receivedEvent.blockNumber,
-                }),
-            );
-            return {
-                status: PreBridgeCommitmentLockupRecoveryStatus.NotFound,
-            };
-        }
         const tokenAddress = getTokenAddress(commitmentAsset);
         const matchingLockups = lockupLogs.flatMap((event) => {
             const {
@@ -457,6 +486,7 @@ export const SwapExecutionWorker = () => {
                 tokenAddress: lockupTokenAddress,
                 claimAddress: lockupClaimAddress,
                 refundAddress,
+                timelock,
             } = event.args;
             const matches =
                 typeof event.transactionHash === "string" &&
@@ -464,6 +494,7 @@ export const SwapExecutionWorker = () => {
                 lockupTokenAddress !== undefined &&
                 lockupClaimAddress !== undefined &&
                 refundAddress !== undefined &&
+                timelock !== undefined &&
                 isEmptyPreimageHash(preimageHash) &&
                 isAddressEqual(lockupTokenAddress, getAddress(tokenAddress)) &&
                 isAddressEqual(lockupClaimAddress, getAddress(claimAddress)) &&
@@ -480,6 +511,7 @@ export const SwapExecutionWorker = () => {
                 {
                     transactionHash: event.transactionHash,
                     logIndex: event.logIndex ?? 0,
+                    timeoutBlockHeight: Number(timelock),
                 },
             ];
         });
@@ -498,6 +530,7 @@ export const SwapExecutionWorker = () => {
             return {
                 status: PreBridgeCommitmentLockupRecoveryStatus.Recovered,
                 transactionHash: recovered.transactionHash,
+                timeoutBlockHeight: recovered.timeoutBlockHeight,
             };
         }
 
@@ -977,10 +1010,16 @@ export const SwapExecutionWorker = () => {
                 await waitForPreparedCallTransactionHash(
                     currentSwap.commitmentLockupCallId,
                 );
+            const timeoutBlockHeight =
+                await getCommitmentLockupTimeoutBlockHeight(
+                    currentSwap.assetSend,
+                    commitmentLockupTxHash,
+                );
             await persistCommitmentLockupTransaction(
                 currentSwap.id,
                 commitmentLockupTxHash,
                 CommitmentLockupTransactionSource.Resumed,
+                timeoutBlockHeight,
             );
             return;
         }
@@ -1147,6 +1186,14 @@ export const SwapExecutionWorker = () => {
         const commitmentLockupDetails = await getCommitmentLockupDetails(
             latestSwap.assetSend,
         );
+        const timeoutBlockHeight = Number(commitmentLockupDetails.timelock);
+        const preBridgeClaimAddress = getPreBridgeClaimAddress(
+            latestSwap,
+            commitmentLockupDetails.claimAddress,
+        );
+        if (preBridgeClaimAddress === undefined) {
+            throw new Error("missing pre-bridge commitment claim address");
+        }
         const hop = latestSwap.dex.hops[0];
         if (hop.dexDetails === undefined) {
             throw new Error("missing DEX details for pre-bridge hop");
@@ -1158,6 +1205,7 @@ export const SwapExecutionWorker = () => {
             latestSwap,
             receivedEvent,
             gasAbstractionSigner,
+            preBridgeClaimAddress,
         );
         switch (recoveryResult.status) {
             case PreBridgeCommitmentLockupRecoveryStatus.Ambiguous:
@@ -1168,35 +1216,51 @@ export const SwapExecutionWorker = () => {
                     latestSwap.id,
                     recoveryResult.transactionHash,
                     CommitmentLockupTransactionSource.Recovered,
+                    recoveryResult.timeoutBlockHeight,
                 );
                 return;
 
             case PreBridgeCommitmentLockupRecoveryStatus.NotFound:
                 break;
         }
-        const receivedAmount = receivedEvent.amountReceivedLD;
-        const expectedAmount = satsToAssetAmount(
-            latestSwap.sendAmount,
-            latestSwap.assetSend,
-        );
-        const { quote, shouldLock } = await fetchPreBridgeDexQuote({
-            swap: latestSwap,
-            swapId: latestSwap.id,
-            guid,
-            hop: hop.dexDetails,
-            receivedAmount,
-            expectedAmount,
-            receivedAsset: latestSwap.bridge.destinationAsset,
-            requiredAsset: latestSwap.assetSend,
-        });
 
-        if (!shouldLock) {
-            await persistPreBridgeDexQuoteBlock({
-                latestSwap,
+        const receivedAmount = receivedEvent.amountReceivedLD;
+        let quote: ClaimQuote;
+        if (latestSwap.type === SwapType.Commitment) {
+            quote = await fetchDexQuote(hop.dexDetails, receivedAmount);
+            log.debug(
+                "Swap execution fetched pre-bridge DEX quote",
+                getSwapExecutionLogContext(latestSwap.id, {
+                    guid,
+                    amountReceived: receivedAmount.toString(),
+                    quotedAmountOut: quote.trade.amountOut.toString(),
+                }),
+            );
+        } else {
+            const expectedAmount = satsToAssetAmount(
+                latestSwap.sendAmount,
+                latestSwap.assetSend,
+            );
+            const quoteResult = await fetchPreBridgeDexQuote({
+                swap: latestSwap,
+                swapId: latestSwap.id,
+                guid,
+                hop: hop.dexDetails,
                 receivedAmount,
-                receiveCall: manualCctpReceive?.receiveCall,
+                expectedAmount,
+                receivedAsset: latestSwap.bridge.destinationAsset,
+                requiredAsset: latestSwap.assetSend,
             });
-            return;
+            quote = quoteResult.quote;
+
+            if (!quoteResult.shouldLock) {
+                await persistPreBridgeDexQuoteBlock({
+                    latestSwap,
+                    receivedAmount,
+                    receiveCall: manualCctpReceive?.receiveCall,
+                });
+                return;
+            }
         }
 
         await clearPreBridgeRecovery(latestSwap);
@@ -1243,11 +1307,6 @@ export const SwapExecutionWorker = () => {
                 ),
             }),
         );
-        const preBridgeClaimAddress =
-            getPreBridgeCommitmentClaimAddress(latestSwap);
-        if (preBridgeClaimAddress === undefined) {
-            throw new Error("missing pre-bridge commitment claim address");
-        }
         const tx = {
             to: router.address,
             data: encodeFunctionData({
@@ -1258,7 +1317,7 @@ export const SwapExecutionWorker = () => {
                     getAddress(getTokenAddress(latestSwap.assetSend)),
                     getAddress(preBridgeClaimAddress),
                     getAddress(gasAbstractionSigner.address),
-                    BigInt(commitmentLockupDetails.timelock),
+                    BigInt(timeoutBlockHeight),
                     encoded.calls.map((call) => ({
                         target: getAddress(call.to),
                         value: BigInt(call.value),
@@ -1295,6 +1354,7 @@ export const SwapExecutionWorker = () => {
                 latestSwap,
                 receivedEvent,
                 gasAbstractionSigner,
+                preBridgeClaimAddress,
             );
             switch (recoveryResult.status) {
                 case PreBridgeCommitmentLockupRecoveryStatus.Ambiguous:
@@ -1305,6 +1365,7 @@ export const SwapExecutionWorker = () => {
                         latestSwap.id,
                         recoveryResult.transactionHash,
                         CommitmentLockupTransactionSource.Recovered,
+                        recoveryResult.timeoutBlockHeight,
                     );
                     return;
 
@@ -1319,6 +1380,7 @@ export const SwapExecutionWorker = () => {
             latestSwap.id,
             latestSwap.commitmentLockupTxHash,
             CommitmentLockupTransactionSource.Broadcast,
+            timeoutBlockHeight,
         );
     };
 

--- a/src/components/SwapLimits.tsx
+++ b/src/components/SwapLimits.tsx
@@ -5,16 +5,17 @@ type SwapLimitProps = {
     testId: string;
     amount: number;
     loading: boolean;
+    enabled?: boolean;
     onClick: (amount: number) => void;
 };
 
 type SwapLimitsProps = {
-    minimum: number;
     maximum: number;
-    minLabel: string;
     maxLabel: string;
     loading: boolean;
+    maximumEnabled?: boolean;
     onSelectAmount: (amount: number) => void;
+    onSelectMaximum?: () => void;
 };
 
 const SwapLimit = (props: SwapLimitProps) => (
@@ -24,7 +25,7 @@ const SwapLimit = (props: SwapLimitProps) => (
         data-testid={props.testId}
         aria-busy={props.loading}
         aria-label={props.label}
-        disabled={props.loading || props.amount <= 0}
+        disabled={props.loading || !(props.enabled ?? props.amount > 0)}
         onClick={() => props.onClick(props.amount)}>
         <Show
             when={!props.loading}
@@ -35,21 +36,22 @@ const SwapLimit = (props: SwapLimitProps) => (
 );
 
 const SwapLimits = (props: SwapLimitsProps) => (
-    <Show when={props.loading || props.minimum > 0 || props.maximum > 0}>
+    <Show when={props.loading || (props.maximumEnabled ?? props.maximum > 0)}>
         <div class="amount-limits">
-            <SwapLimit
-                label={props.minLabel}
-                testId="limit-min-button"
-                amount={props.minimum}
-                loading={props.loading}
-                onClick={props.onSelectAmount}
-            />
             <SwapLimit
                 label={props.maxLabel}
                 testId="limit-max-button"
                 amount={props.maximum}
                 loading={props.loading}
-                onClick={props.onSelectAmount}
+                enabled={props.maximumEnabled ?? props.maximum > 0}
+                onClick={() => {
+                    if (props.onSelectMaximum !== undefined) {
+                        props.onSelectMaximum();
+                        return;
+                    }
+
+                    props.onSelectAmount(props.maximum);
+                }}
             />
         </div>
     </Show>

--- a/src/context/Create.tsx
+++ b/src/context/Create.tsx
@@ -298,6 +298,7 @@ export type CreateContextType = {
     setSendAmountFormatted: Setter<string>;
     receiveAmountFormatted: Accessor<string>;
     setReceiveAmountFormatted: Setter<string>;
+    resetAmounts: () => void;
     amountChanged: Accessor<Side>;
     setAmountChanged: Setter<Side>;
     minimum: Accessor<number>;
@@ -462,6 +463,13 @@ const CreateProvider = (props: { children: JSX.Element }) => {
     const [sendAmountFormatted, setSendAmountFormatted] = createSignal("0");
     const [receiveAmountFormatted, setReceiveAmountFormatted] =
         createSignal("0");
+    const resetAmounts = () => {
+        setSendAmount(BigNumber(0));
+        setReceiveAmount(BigNumber(0));
+        setSendAmountFormatted("");
+        setReceiveAmountFormatted("");
+        setAmountValid(false);
+    };
 
     const [amountChanged, setAmountChanged] = createSignal(Side.Send);
     const [minimum, setMinimum] = createSignal<number>(0);
@@ -524,6 +532,7 @@ const CreateProvider = (props: { children: JSX.Element }) => {
                 setSendAmountFormatted,
                 receiveAmountFormatted,
                 setReceiveAmountFormatted,
+                resetAmounts,
                 amountChanged,
                 setAmountChanged,
                 minimum,

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -26,7 +26,7 @@ const dict = {
         privacy: "Privacy",
         blockexplorer: "Open {{ typeLabel }}",
         blockexplorer_lockup_address: "lockup address",
-        blockexplorer_lockup_tx: "lockup transaction",
+        blockexplorer_lockup_tx: "Lockup Transaction",
         blockexplorer_claim_tx: "claim transaction",
         blockexplorer_refund_tx: "refund transaction",
         check_bridge_status: "Check bridge status",
@@ -51,7 +51,6 @@ const dict = {
             "Only continue if you are sure your wallet did not submit the transaction. Continuing can make you send funds twice.",
         continue: "Continue",
         receive: "Receive",
-        min: "Min",
         max: "Max",
         minimum_amount: "Minimum amount is {{ amount }} {{ denomination }}",
         maximum_amount: "Maximum amount is {{ amount }} {{ denomination }}",
@@ -64,8 +63,14 @@ const dict = {
             "Network fee was updated based on network situation, please confirm new amounts and continue with swap.",
         amount_limits_changed:
             "Swap limits changed. Please confirm new amounts and continue with swap.",
+        commitment_invoice_heading:
+            "Enter a Lightning Invoice for {{ amount }} {{ denomination }}",
+        commitment_invoice_deferred: "Invoice to be entered after funding",
+        clear_amount: "Clear",
         create_and_paste:
             "Paste a Lightning invoice, BOLT12 or LNURL to receive funds",
+        invoice_cleared_amount_changed:
+            "Invoice cleared because the amount changed.",
         congrats: "Congratulations!",
         successfully_swapped:
             "You successfully received {{ amount }} {{ denomination }}!",
@@ -594,7 +599,6 @@ const dict = {
             "Fahre nur fort, wenn du sicher bist, dass dein Wallet die Transaktion nicht übermittelt hat. Wenn du fortfährst, könntest du Geld zweimal senden.",
         continue: "Weiter",
         receive: "Empfange",
-        min: "Min",
         max: "Max",
         minimum_amount: "Mindestbetrag ist {{ amount }} {{ denomination }}",
         maximum_amount: "Höchstbetrag ist {{ amount }} {{ denomination }}",
@@ -607,8 +611,15 @@ const dict = {
             "Die Netzwerkgebühr wurde aufgrund der Netzwerksituation aktualisiert. Bitte bestätige die neuen Beträge und fahren mit dem Swap fort.",
         amount_limits_changed:
             "Swap-Limits haben sich geändert. Bitte bestätige die neuen Beträge und fahre mit dem Swap fort.",
+        commitment_invoice_heading:
+            "Lightning-Rechnung über {{ amount }} {{ denomination }} eingeben",
+        commitment_invoice_deferred:
+            "Rechnung wird nach der Zahlung eingegeben",
+        clear_amount: "Löschen",
         create_and_paste:
             "Füge eine Lightning-Rechnung, BOLT12 oder LNURL des Empfängers ein",
+        invoice_cleared_amount_changed:
+            "Rechnung gelöscht, weil sich der Betrag geändert hat.",
         congrats: "Herzlichen Glückwunsch!",
         successfully_swapped:
             "Du hast erfolgreich {{ amount }} {{ denomination }} empfangen!",
@@ -1154,7 +1165,6 @@ const dict = {
             "Continúa solo si tienes la certeza de que tu billetera no envió la transacción. Continuar puede hacer que envíes fondos dos veces.",
         continue: "Continuar",
         receive: "Recibir",
-        min: "Mín",
         max: "Máx",
         minimum_amount: "La cantidad mínima es {{ amount }} {{ denomination }}",
         maximum_amount: "La cantidad máxima es {{ amount }} {{ denomination }}",
@@ -1167,8 +1177,15 @@ const dict = {
             "La comisión de red se actualizó según la situación de la red. Por favor, confirma los nuevos importes y continúa con el intercambio.",
         amount_limits_changed:
             "Los límites del intercambio han cambiado. Por favor, confirma los nuevos importes y continúa con el intercambio.",
+        commitment_invoice_heading:
+            "Introduce una factura Lightning por {{ amount }} {{ denomination }}",
+        commitment_invoice_deferred:
+            "La factura se introducirá después de financiar",
+        clear_amount: "Borrar",
         create_and_paste:
             "Pega una factura Lightning, una dirección BOLT12 o una LNURL para recibir los fondos",
+        invoice_cleared_amount_changed:
+            "La factura se borró porque cambió el importe.",
         congrats: "¡Felicitaciones!",
         successfully_swapped:
             "Has recibido con éxito {{ amount }} {{ denomination }}!",
@@ -1711,7 +1728,6 @@ const dict = {
             "Continue apenas se tiver certeza de que sua carteira não enviou a transação. Continuar pode fazer com que você envie fundos duas vezes.",
         continue: "Continuar",
         receive: "Receber",
-        min: "Mín",
         max: "Máx",
         minimum_amount: "O valor mínimo é {{ amount }} {{ denomination }}",
         maximum_amount: "O valor máximo é {{ amount }} {{ denomination }}",
@@ -1724,8 +1740,15 @@ const dict = {
             "A taxa da rede foi atualizada conforme a situação atual, por favor confirme os novos valores e continue a troca.",
         amount_limits_changed:
             "Os limites da troca mudaram. Por favor confirme os novos valores e continue a troca.",
+        commitment_invoice_heading:
+            "Insira um invoice Lightning de {{ amount }} {{ denomination }}",
+        commitment_invoice_deferred:
+            "Invoice será inserido após o envio dos fundos",
+        clear_amount: "Limpar",
         create_and_paste:
             "Cole um invoice Lightning, um endereço BOLT12 ou um LNURL para receber os fundos",
+        invoice_cleared_amount_changed:
+            "O invoice foi removido porque o valor mudou.",
         congrats: "Parabéns!",
         successfully_swapped:
             "{{ amount }} {{ denomination }} recebidos com sucesso!",
@@ -2261,7 +2284,6 @@ const dict = {
             "仅当您确定钱包没有提交该交易时才继续。继续可能会导致您重复发送资金。",
         continue: "继续",
         receive: "接收",
-        min: "最小",
         max: "最大",
         minimum_amount: "最小金额为{{ amount }}{{ denomination }}",
         maximum_amount: "最大金额为{{ amount }}{{ denomination }}",
@@ -2272,7 +2294,12 @@ const dict = {
         new_swap: "新的交换",
         feecheck: "根据网络情况更新了网络费用，请确认新的金额并继续进行交换。",
         amount_limits_changed: "兑换限额已变更，请确认新的金额并继续进行兑换。",
+        commitment_invoice_heading:
+            "输入 {{ amount }} {{ denomination }} 的闪电发票",
+        commitment_invoice_deferred: "资金发送后输入发票",
+        clear_amount: "清除",
         create_and_paste: "粘贴闪电发票、BOLT12 地址或 LNURL 以接收资金",
+        invoice_cleared_amount_changed: "金额已更改，发票已清除。",
         congrats: "恭喜！",
         successfully_swapped: "您成功收到{{ amount }}{{ denomination }}！",
         bridge_transfer_pending:
@@ -2760,7 +2787,6 @@ const dict = {
             "ウォレットがトランザクションを送信していないことが確実な場合のみ続行してください。続行すると、資金を二重に送信する可能性があります。",
         continue: "続ける",
         receive: "受取",
-        min: "最小",
         max: "最大",
         minimum_amount: "最小金額は{{ amount }} {{ denomination }}です",
         maximum_amount: "最大金額は{{ amount }} {{ denomination }}です",
@@ -2773,8 +2799,14 @@ const dict = {
             "ネットワーク手数料はネットワーク状況に基づいて更新されました。新しい金額を確認し、スワップを続行してください",
         amount_limits_changed:
             "スワップの上限／下限が変更されました。新しい金額を確認し、スワップを続行してください。",
+        commitment_invoice_heading:
+            "{{ amount }} {{ denomination }} のライトニングインボイスを入力してください",
+        commitment_invoice_deferred: "送金後にインボイスを入力",
+        clear_amount: "クリア",
         create_and_paste:
             "資金を受け取るために、ライトニングインボイス、BOLT12、またはLNURLを貼り付けてください",
+        invoice_cleared_amount_changed:
+            "金額が変更されたためインボイスをクリアしました。",
         congrats: "おめでとうございます！",
         successfully_swapped: "スワップが正常に完了しました",
         bridge_transfer_pending:

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -1,7 +1,6 @@
 import { useSearchParams } from "@solidjs/router";
 import { BigNumber } from "bignumber.js";
 import { getRpcUrls } from "boltz-swaps/config";
-import { decodeInvoice } from "boltz-swaps/invoice";
 import { AssetKind, NetworkTransport } from "boltz-swaps/types";
 import log from "loglevel";
 import {
@@ -46,6 +45,8 @@ import { useGlobalContext } from "../context/Global";
 import { useWeb3Signer } from "../context/Web3";
 import Pair, { RequiredInput } from "../utils/Pair";
 import { getAssetNativeBalance } from "../utils/chains/balance";
+import { canCommitSubmarineSendAmount } from "../utils/commitmentSwap";
+import { getConnectedMaximum } from "../utils/connectedMaximum";
 import {
     calculateDigits,
     convertAmount,
@@ -55,7 +56,7 @@ import {
     getValidationRegex,
 } from "../utils/denomination";
 import { isMobile } from "../utils/helper";
-import { isLnurl } from "../utils/invoice";
+import { isDeferredInvoiceDestination } from "../utils/invoice";
 import { gasTopUpSupported, getGasTopUpNativeAmount } from "../utils/quoter";
 import ErrorWasm from "./ErrorWasm";
 
@@ -94,6 +95,7 @@ const Create = () => {
         setInvoice,
         invoiceValid,
         setInvoiceValid,
+        setInvoiceError,
         addressValid,
         sendAmount,
         setSendAmount,
@@ -103,11 +105,13 @@ const Create = () => {
         setSendAmountFormatted,
         receiveAmountFormatted,
         setReceiveAmountFormatted,
+        resetAmounts,
         amountChanged,
         setAmountChanged,
         minimum,
         maximum,
         limitsLoading,
+        amountValid,
         setAmountValid,
         boltzFee,
         minerFee,
@@ -116,7 +120,7 @@ const Create = () => {
         setQuoteLoading,
         destinationLocked,
     } = useCreateContext();
-    const { connectedWallet } = useWeb3Signer();
+    const { connectedWallet, signer } = useWeb3Signer();
 
     let quoteDebounceTimeout: number | undefined;
     let quoteRequestId = 0;
@@ -145,10 +149,25 @@ const Create = () => {
     const sendAmountQuoteLoading = createMemo(
         () => quoteLoading() && amountChanged() === Side.Receive,
     );
+    const [maxAmountLoading, setMaxAmountLoading] = createSignal(false);
     const limitActionsLoading = createMemo(
-        () => limitsLoading() || quoteLoading(),
+        () => limitsLoading() || quoteLoading() || maxAmountLoading(),
     );
-
+    const requiresInvoiceInput = createMemo(
+        () =>
+            pair().requiredInput === RequiredInput.Invoice ||
+            (pair().requiredInput === RequiredInput.Unknown &&
+                pair().toAsset === LN),
+    );
+    const canDeferInvoiceInput = createMemo(
+        () =>
+            requiresInvoiceInput() &&
+            canCommitSubmarineSendAmount(pair(), amountChanged()) &&
+            amountValid(),
+    );
+    const invoiceInputDisabled = createMemo(
+        () => canDeferInvoiceInput() && invoice() === "",
+    );
     const gasTopUpTrigger = createMemo(() => {
         const rpcUrls = getRpcUrls(pair().toAsset);
         const gasTopUpEnabled = gasTopUp();
@@ -326,25 +345,19 @@ const Create = () => {
         return amount === "";
     };
 
-    const resetAmounts = () => {
-        setReceiveAmount(BigNumber(0));
-        setSendAmount(BigNumber(0));
-    };
-
     const clearStaleInvoice = () => {
-        if (invoice() === "" || isLnurl(invoice())) {
+        const currentInvoice = invoice();
+        if (
+            currentInvoice === "" ||
+            isDeferredInvoiceDestination(currentInvoice)
+        ) {
             return;
         }
-        try {
-            const invoiceSats = decodeInvoice(invoice()).satoshis;
-            if (invoiceSats === 0) {
-                return;
-            }
-            setInvoice("");
-            setInvoiceValid(false);
-        } catch {
-            // not a valid invoice, nothing to clear
-        }
+
+        setInvoice("");
+        setInvoiceValid(false);
+        setInvoiceError(undefined);
+        notify("success", t("invoice_cleared_amount_changed"));
     };
 
     const changeReceiveAmount = (evt: InputEvent) => {
@@ -517,7 +530,11 @@ const Create = () => {
             return;
         }
 
-        if (amount > 0 && receiveAmount().isZero()) {
+        if (
+            amount > 0 &&
+            receiveAmount().isZero() &&
+            !canCommitSubmarineSendAmount(pair(), amountChanged())
+        ) {
             setCustomValidity(t("error_zero_quote"), false);
             setAmountValid(false);
             return;
@@ -566,6 +583,52 @@ const Create = () => {
             validateAmount();
             sendAmountRef?.focus();
         });
+    };
+
+    const setMaxAmount = async () => {
+        const selectedPair = pair();
+        let connectedMaximum: BigNumber | undefined;
+
+        setMaxAmountLoading(true);
+        try {
+            connectedMaximum = await getConnectedMaximum({
+                fromAsset: selectedPair.fromAsset,
+                connectedWallet: connectedWallet(),
+                signer: signer(),
+            });
+        } catch (error) {
+            log.warn("failed to resolve connected wallet max amount", {
+                asset: selectedPair.fromAsset,
+                error,
+            });
+        } finally {
+            setMaxAmountLoading(false);
+        }
+
+        if (pair() !== selectedPair) {
+            return;
+        }
+
+        const limit = maximum();
+        const selectedAmount =
+            connectedMaximum === undefined ||
+            !connectedMaximum.isGreaterThan(0) ||
+            (limit > 0 && connectedMaximum.isGreaterThan(limit))
+                ? limit
+                : connectedMaximum.toNumber();
+        setAmount(selectedAmount);
+    };
+
+    const clearCommittedAmounts = () => {
+        if (!invoiceInputDisabled()) {
+            return;
+        }
+
+        ++quoteRequestId;
+        clearQuoteDebounce();
+        setQuoteLoading(false);
+        resetAmounts();
+        setAmountChanged(Side.Send);
     };
 
     onMount(() => {
@@ -761,12 +824,15 @@ const Create = () => {
                                 </span>
                                 <Show when={!destinationLocked()}>
                                     <SwapLimits
-                                        minimum={minimum()}
                                         maximum={maximum()}
-                                        minLabel={t("min")}
                                         maxLabel={t("max")}
                                         loading={limitActionsLoading()}
+                                        maximumEnabled={
+                                            maximum() > 0 ||
+                                            pair().canZeroAmount
+                                        }
                                         onSelectAmount={setAmount}
+                                        onSelectMaximum={setMaxAmount}
                                     />
                                 </Show>
                                 <Show when={sendAmountQuoteLoading()}>
@@ -799,6 +865,7 @@ const Create = () => {
                                     autocomplete="off"
                                     disabled={
                                         sendAmountQuoteLoading() ||
+                                        maxAmountLoading() ||
                                         destinationLocked()
                                     }
                                     classList={{
@@ -864,6 +931,7 @@ const Create = () => {
                                     autocomplete="off"
                                     disabled={
                                         receiveAmountQuoteLoading() ||
+                                        maxAmountLoading() ||
                                         destinationLocked()
                                     }
                                     classList={{
@@ -901,24 +969,37 @@ const Create = () => {
                         <hr class="spacer" />
                     </Show>
                 </Show>
-                <Show
-                    when={
-                        pair().requiredInput === RequiredInput.Invoice ||
-                        (pair().requiredInput === RequiredInput.Unknown &&
-                            pair().toAsset === LN)
-                    }>
-                    <Show when={webln()}>
+                <Show when={requiresInvoiceInput() && !destinationLocked()}>
+                    <Show when={webln() && !invoiceInputDisabled()}>
                         <WeblnButton />
                         <hr class="spacer" />
                     </Show>
-                    <Show when={!destinationLocked()}>
-                        <InvoiceInput />
-                        <hr class="spacer" />
+                    <Show
+                        when={invoiceInputDisabled()}
+                        fallback={<InvoiceInput />}>
+                        <div
+                            class="committed-invoice-row"
+                            data-testid="committed-invoice-row">
+                            <InvoiceInput
+                                class="committed-invoice-input"
+                                disabled={invoiceInputDisabled()}
+                                placeholder={t("commitment_invoice_deferred")}
+                            />
+                            <button
+                                type="button"
+                                class="btn-small invoice-slot-action"
+                                data-testid="committed-invoice-clear"
+                                onClick={clearCommittedAmounts}>
+                                {t("clear_amount")}
+                            </button>
+                        </div>
                     </Show>
+                    <hr class="spacer" />
                 </Show>
                 <Show
                     when={
                         isMobile() &&
+                        !invoiceInputDisabled() &&
                         !destinationLocked() &&
                         (pair().toAsset === LN ||
                             config.assets?.[pair().toAsset]?.type ===

--- a/src/pages/Pay.tsx
+++ b/src/pages/Pay.tsx
@@ -43,6 +43,7 @@ import {
 } from "../consts/SwapStatus";
 import { useGlobalContext } from "../context/Global";
 import { usePayContext } from "../context/Pay";
+import CommitmentCreated from "../status/CommitmentCreated";
 import CommitmentRejected from "../status/CommitmentRejected";
 import InvoiceExpired from "../status/InvoiceExpired";
 import InvoiceFailedToPay from "../status/InvoiceFailedToPay";
@@ -75,6 +76,7 @@ import {
     type SomeSwap,
     type SubmarineSwap,
     getPostBridgeDetail,
+    isCommitmentSwap,
 } from "../utils/swapCreator";
 import { getUrlParam } from "../utils/urlParams";
 
@@ -168,6 +170,7 @@ const Pay = () => {
         return (
             currentSwap !== null &&
             currentSwap.type !== SwapType.Reverse &&
+            !isCommitmentSwap(currentSwap) &&
             !rescueFileBackupDone()
         );
     });
@@ -203,24 +206,31 @@ const Pay = () => {
 
             return {
                 backupDone: rescueFileBackupDone(),
-                id: currentSwap.id,
+                swap: currentSwap,
                 timedOutRefundable: timedOutRefundable(),
-                type: currentSwap.type,
             };
         },
-        async (currentSwap) => {
+        async ({ backupDone, swap: currentSwap, timedOutRefundable }) => {
             if (
                 currentSwap.type !== SwapType.Reverse &&
-                !currentSwap.backupDone
+                !isCommitmentSwap(currentSwap) &&
+                !backupDone
             ) {
                 return;
             }
 
-            if (currentSwap.timedOutRefundable) {
+            if (timedOutRefundable) {
                 log.info(
                     `Refundable swap ${currentSwap.id} timed out, uncooperative refund is possible`,
                 );
                 setSwapStatus(swapStatusFailed.SwapWaitingForRefund);
+                return;
+            }
+
+            if (isCommitmentSwap(currentSwap)) {
+                setSwapStatus(
+                    currentSwap.status ?? swapStatusPending.SwapCreated,
+                );
                 return;
             }
 
@@ -237,6 +247,9 @@ const Pay = () => {
         const currentSwap = swap();
 
         if (currentSwap === null || backupVerificationRequired()) {
+            return;
+        }
+        if (isCommitmentSwap(currentSwap)) {
             return;
         }
         const swapValue = currentSwap;
@@ -437,15 +450,17 @@ const Pay = () => {
         />
     );
 
-    // Post-bridge swaps need a "check status" link to follow the transfer to the
-    // destination chain; their status components render it themselves. Other
-    // swaps just get the plain transaction link, the default button below.
-    const shouldShowPostBridgeExplorer = createMemo(
-        () =>
+    const shouldHideDefaultExplorer = createMemo(() => {
+        const currentSwap = swap();
+        return (
+            (currentSwap !== null &&
+                isCommitmentSwap(currentSwap) &&
+                currentSwap.commitmentLockupTxHash !== undefined) ||
             transactionClaimedPostBridge() ||
-            swap()?.bridge?.recovery?.status ===
-                PreBridgeRecoveryStatus.Recovered,
-    );
+            currentSwap?.bridge?.recovery?.status ===
+                PreBridgeRecoveryStatus.Recovered
+        );
+    });
 
     return (
         <Show
@@ -470,11 +485,13 @@ const Pay = () => {
                 <div data-status={status()} class="frame">
                     <span class="frame-header">
                         <h2>
-                            {t("pay_invoice", {
-                                id: privacyMode()
-                                    ? hiddenInformation
-                                    : params.id!,
-                            })}
+                            {swap() !== null && isCommitmentSwap(swap()!)
+                                ? t("swap")
+                                : t("pay_invoice", {
+                                      id: privacyMode()
+                                          ? hiddenInformation
+                                          : params.id!,
+                                  })}
                             <Show when={swap()}>
                                 <SwapIcons swap={swap()!} />
                             </Show>
@@ -502,59 +519,71 @@ const Pay = () => {
                                         <hr />
                                     </>
                                 }>
-                                <div class="swap-status">
-                                    {t("status")}:
-                                    <span class="btn-small">{status()}</span>
-                                    <Show
-                                        when={
-                                            getDestinationAddress(swap()) &&
-                                            (swapStatus() ===
-                                                swapStatusPending.SwapCreated ||
-                                                swapStatus() ===
-                                                    swapStatusPending.InvoiceSet)
-                                        }>
-                                        <span class="vertical-line" />
-                                        <Tooltip
-                                            pxDistance={20}
-                                            label={{
-                                                key: "destination_address",
-                                                variables: {
-                                                    address: cropString(
-                                                        getDestinationAddress(
-                                                            swap(),
+                                <Show
+                                    when={
+                                        swap() !== null &&
+                                        !isCommitmentSwap(swap()!)
+                                    }>
+                                    <div class="swap-status">
+                                        {t("status")}:
+                                        <span class="btn-small">
+                                            {status()}
+                                        </span>
+                                        <Show
+                                            when={
+                                                getDestinationAddress(swap()) &&
+                                                (swapStatus() ===
+                                                    swapStatusPending.SwapCreated ||
+                                                    swapStatus() ===
+                                                        swapStatusPending.InvoiceSet)
+                                            }>
+                                            <span class="vertical-line" />
+                                            <Tooltip
+                                                pxDistance={20}
+                                                label={{
+                                                    key: "destination_address",
+                                                    variables: {
+                                                        address: cropString(
+                                                            getDestinationAddress(
+                                                                swap(),
+                                                            ),
+                                                            14,
+                                                            8,
                                                         ),
-                                                        14,
-                                                        8,
-                                                    ),
-                                                },
-                                            }}
-                                            direction={[
-                                                "top",
-                                                isMobile() ? "left" : "right",
-                                            ]}>
-                                            <button
-                                                id="copy-destination"
-                                                onClick={() =>
-                                                    copyBoxText(
-                                                        getDestinationAddress(
-                                                            swap(),
-                                                        ),
-                                                    )
-                                                }>
-                                                <Show
-                                                    when={copyDestinationActive()}
-                                                    fallback={
-                                                        <BiRegularCopy
+                                                    },
+                                                }}
+                                                direction={[
+                                                    "top",
+                                                    isMobile()
+                                                        ? "left"
+                                                        : "right",
+                                                ]}>
+                                                <button
+                                                    id="copy-destination"
+                                                    onClick={() =>
+                                                        copyBoxText(
+                                                            getDestinationAddress(
+                                                                swap(),
+                                                            ),
+                                                        )
+                                                    }>
+                                                    <Show
+                                                        when={copyDestinationActive()}
+                                                        fallback={
+                                                            <BiRegularCopy
+                                                                size={14}
+                                                            />
+                                                        }>
+                                                        <IoCheckmark
                                                             size={14}
                                                         />
-                                                    }>
-                                                    <IoCheckmark size={14} />
-                                                </Show>
-                                                {t("destination")}
-                                            </button>
-                                        </Tooltip>
-                                    </Show>
-                                </div>
+                                                    </Show>
+                                                    {t("destination")}
+                                                </button>
+                                            </Tooltip>
+                                        </Show>
+                                    </div>
+                                </Show>
                                 <hr />
                             </Show>
                             <Show
@@ -612,6 +641,13 @@ const Pay = () => {
                                             undefined
                                         }>
                                         <PreBridgeDexQuoteBlocked />
+                                    </Match>
+                                    <Match
+                                        when={
+                                            swap() !== null &&
+                                            isCommitmentSwap(swap()!)
+                                        }>
+                                        <CommitmentCreated />
                                     </Match>
                                     <Match when={isTransactionClaimedStatus()}>
                                         <TransactionClaimed
@@ -709,7 +745,7 @@ const Pay = () => {
                                         <SwapCreated />
                                     </Match>
                                 </Switch>
-                                <Show when={!shouldShowPostBridgeExplorer()}>
+                                <Show when={!shouldHideDefaultExplorer()}>
                                     {blockExplorerLink()}
                                 </Show>
                             </Show>

--- a/src/status/CommitmentCreated.tsx
+++ b/src/status/CommitmentCreated.tsx
@@ -1,0 +1,689 @@
+import { useNavigate } from "@solidjs/router";
+import { BigNumber } from "bignumber.js";
+import { createAssetProvider } from "boltz-swaps/evm";
+import { emptyPreimageHash } from "boltz-swaps/evm/commitment";
+import { getLockupEvent } from "boltz-swaps/evm/transaction";
+import { erc20SwapAbi } from "boltz-swaps/generated/evm-abis";
+import { SwapPosition } from "boltz-swaps/types";
+import log from "loglevel";
+import { BsGlobe } from "solid-icons/bs";
+import {
+    type Accessor,
+    Show,
+    createEffect,
+    createMemo,
+    createResource,
+    createSignal,
+    untrack,
+} from "solid-js";
+import {
+    type Hash,
+    type PublicClient,
+    type TransactionReceipt,
+    zeroAddress,
+} from "viem";
+
+import CopyButton from "../components/CopyButton";
+import ExternalLink from "../components/ExternalLink";
+import LoadingSpinner from "../components/LoadingSpinner";
+import LockupEvm from "../components/LockupEvm";
+import RefundButton from "../components/RefundButton";
+import { Denomination } from "../consts/Enums";
+import type { ButtonLabelParams } from "../consts/Types";
+import { useGlobalContext } from "../context/Global";
+import { usePayContext } from "../context/Pay";
+import { useWeb3Signer } from "../context/Web3";
+import Pair from "../utils/Pair";
+import {
+    baseAssetAmountToInternal,
+    formatAmount,
+    formatDenomination,
+} from "../utils/denomination";
+import { formatError } from "../utils/errors";
+import { blockExplorerLink } from "../utils/explorerLink";
+import {
+    extractInvoice,
+    fetchDeferredInvoice,
+    invoiceAmountLabel,
+    isDeferredInvoiceDestination,
+} from "../utils/invoice";
+import {
+    type CommitmentSwap,
+    createSubmarine,
+    getPreBridgeDetail,
+} from "../utils/swapCreator";
+import { validateInvoice, validateResponse } from "../utils/validation";
+
+export type CommitmentAmounts = {
+    pairHash: string;
+    sendAmount: BigNumber;
+    receiveAmount: BigNumber;
+};
+
+type InvoiceData = {
+    invoice: string;
+    originalDestination?: string;
+    sats: number;
+};
+
+const receiptWaitTimeout = 120_000;
+const receiptRetryDelay = 3_000;
+const receiptWaitAttempts = 3;
+
+const wait = (ms: number) =>
+    new Promise((resolve) => window.setTimeout(resolve, ms));
+
+const getInvoiceSats = (amounts: CommitmentAmounts) =>
+    Math.floor(amounts.receiveAmount.toNumber());
+
+export const waitForCommitmentLockupReceipt = async (
+    provider: PublicClient,
+    hash: Hash,
+    waitTimeout = receiptWaitTimeout,
+    retryDelay = receiptRetryDelay,
+    attempts = receiptWaitAttempts,
+): Promise<TransactionReceipt> => {
+    let lastError: unknown = new Error("commitment lockup receipt not found");
+
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        try {
+            const receipt = await provider.waitForTransactionReceipt({
+                hash,
+                confirmations: 1,
+                timeout: waitTimeout,
+            });
+            if (receipt !== null) {
+                return receipt;
+            }
+            lastError = new Error("commitment lockup receipt not found");
+        } catch (error) {
+            lastError = error;
+            log.warn("Waiting for commitment lockup receipt failed", error);
+        }
+
+        if (attempt < attempts) {
+            await wait(retryDelay);
+        }
+    }
+
+    throw lastError;
+};
+
+export const validateCommitmentInvoiceInput = (
+    value: string,
+    amounts: CommitmentAmounts,
+): InvoiceData => {
+    const invoiceInput = extractInvoice(value) ?? "";
+    if (isDeferredInvoiceDestination(invoiceInput)) {
+        return {
+            invoice: invoiceInput,
+            originalDestination: invoiceInput,
+            sats: getInvoiceSats(amounts),
+        };
+    }
+
+    return validateCommitmentInvoice(value, amounts);
+};
+
+export const validateCommitmentInvoice = (
+    value: string,
+    amounts: CommitmentAmounts,
+): InvoiceData => {
+    const invoice = extractInvoice(value) ?? "";
+    const sats = validateInvoice(invoice);
+    if (sats !== getInvoiceSats(amounts)) {
+        throw new Error("invalid_invoice");
+    }
+
+    return { invoice, sats };
+};
+
+const resolveInvoice = async (
+    validation: InvoiceData,
+    amounts: CommitmentAmounts,
+): Promise<InvoiceData> => {
+    if (validation.originalDestination === undefined) {
+        return validation;
+    }
+
+    return {
+        ...validateCommitmentInvoice(
+            await fetchDeferredInvoice(validation.invoice, validation.sats),
+            amounts,
+        ),
+        originalDestination: validation.originalDestination,
+    };
+};
+
+const getInvoiceAmountString = (
+    amounts: CommitmentAmounts,
+    asset: string,
+    separator: string,
+) =>
+    formatAmount(
+        BigNumber(getInvoiceSats(amounts)),
+        Denomination.Sat,
+        separator,
+        asset,
+    );
+
+const CommitmentInvoiceHeader = (props: {
+    amounts: CommitmentAmounts;
+    copyAmount: () => string;
+    invoiceAsset: string;
+    lockupAsset: string;
+    lockupTxHash: string;
+}) => {
+    const { separator, t } = useGlobalContext();
+
+    return (
+        <div class="commitment-invoice-header">
+            <h2
+                id="commitment-invoice-label"
+                class="commitment-invoice-heading">
+                {t("commitment_invoice_heading", {
+                    amount: getInvoiceAmountString(
+                        props.amounts,
+                        props.invoiceAsset,
+                        separator(),
+                    ),
+                    denomination: formatDenomination(
+                        Denomination.Sat,
+                        props.invoiceAsset,
+                    ),
+                })}
+            </h2>
+            <div class="commitment-invoice-meta">
+                <CopyButton
+                    label="copy_amount"
+                    btnClass="commitment-copy-amount"
+                    data={props.copyAmount}
+                />
+                <span class="commitment-invoice-meta-separator" />
+                <CommitmentLockupTransaction
+                    asset={props.lockupAsset}
+                    txHash={props.lockupTxHash}
+                />
+            </div>
+        </div>
+    );
+};
+
+const CommitmentLockupTransaction = (props: {
+    asset: string;
+    txHash: string;
+}) => {
+    const { t } = useGlobalContext();
+    const explorerHref = () =>
+        blockExplorerLink(props.asset, true, props.txHash);
+
+    return (
+        <Show when={explorerHref()}>
+            {(href) => (
+                <ExternalLink
+                    class="commitment-lockup-transaction"
+                    href={href()}
+                    aria-label={t("blockexplorer", {
+                        typeLabel: t("blockexplorer_lockup_tx"),
+                    })}>
+                    <BsGlobe size={14} />
+                    <span>{t("blockexplorer_lockup_tx")}</span>
+                </ExternalLink>
+            )}
+        </Show>
+    );
+};
+
+export const calculateCommittedSubmarineAmounts = async (
+    directPair: Pair,
+    lockupAmount: BigNumber,
+): Promise<CommitmentAmounts> => {
+    const receiveAmount = await directPair.calculateReceiveAmount(
+        lockupAmount,
+        directPair.minerFees,
+    );
+    const invoiceSats = Math.floor(receiveAmount.toNumber());
+    const sendAmount = await directPair.calculateSendAmount(
+        BigNumber(invoiceSats),
+        directPair.minerFees,
+    );
+    const creationData = await directPair.creationData(
+        sendAmount,
+        directPair.minerFees,
+    );
+    if (creationData === undefined) {
+        throw new Error("missing committed swap creation data");
+    }
+
+    return {
+        pairHash: creationData.pairHash,
+        sendAmount,
+        receiveAmount,
+    };
+};
+
+const CommitmentCreated = () => {
+    let invoiceInput!: HTMLInputElement;
+    const navigate = useNavigate();
+
+    const {
+        deleteSwap,
+        deriveKey,
+        fetchPairs,
+        newKey,
+        notify,
+        pairs,
+        regularPairs,
+        separator,
+        setSwapStorage,
+        t,
+    } = useGlobalContext();
+    const { swap } = usePayContext();
+    const { getEtherSwap, getErc20Swap } = useWeb3Signer();
+    const commitment = createMemo(() => swap() as CommitmentSwap);
+    const [invoice, setInvoice] = createSignal(
+        untrack(() => commitment().originalDestination ?? ""),
+    );
+    const [invoiceError, setInvoiceError] = createSignal<
+        ButtonLabelParams | undefined
+    >();
+    const [loading, setLoading] = createSignal(false);
+    const [loadError, setLoadError] = createSignal<string | undefined>();
+    const hasInvoice = () => invoice().trim().length > 0;
+    const invoiceErrorText = () => {
+        const error = invoiceError();
+        return error === undefined ? undefined : t(error.key, error.params);
+    };
+
+    const lockupDex = () => {
+        const dex = commitment().dex;
+        if (
+            dex?.position !== SwapPosition.Pre ||
+            dex.hops.length === 0 ||
+            dex.sourceAmount === undefined
+        ) {
+            throw new Error(
+                `commitment swap ${commitment().id} is missing a lockup-side DEX route`,
+            );
+        }
+
+        return dex;
+    };
+    const lockupHops = () => lockupDex().hops;
+    const lockupHopInputAmount = () => lockupDex().sourceAmount;
+
+    createEffect(() => {
+        if (
+            commitment().commitmentLockupTxHash === undefined ||
+            pairs() !== undefined
+        ) {
+            return;
+        }
+
+        setLoadError(undefined);
+        void fetchPairs().catch((error) => {
+            const message = formatError(error);
+            log.error("Fetching pairs for committed swap failed", error);
+            setLoadError(message);
+            notify("error", message);
+        });
+    });
+
+    const committedAmountsSource = createMemo(
+        () => {
+            const current = commitment();
+            const currentPairs = pairs();
+            if (
+                current.commitmentLockupTxHash === undefined ||
+                currentPairs === undefined
+            ) {
+                return undefined;
+            }
+
+            return {
+                assetSend: current.assetSend,
+                commitmentLockupTxHash: current.commitmentLockupTxHash,
+                initialReceiveAsset: current.initialReceiveAsset,
+                pairs: currentPairs,
+                regularPairs: regularPairs(),
+            };
+        },
+        undefined,
+        {
+            equals: (previous, next) =>
+                previous?.assetSend === next?.assetSend &&
+                previous?.commitmentLockupTxHash ===
+                    next?.commitmentLockupTxHash &&
+                previous?.initialReceiveAsset === next?.initialReceiveAsset &&
+                previous?.pairs === next?.pairs &&
+                previous?.regularPairs === next?.regularPairs,
+        },
+    );
+
+    const [committedAmounts] = createResource(
+        committedAmountsSource,
+        async ({
+            assetSend,
+            commitmentLockupTxHash,
+            initialReceiveAsset,
+            pairs: currentPairs,
+            regularPairs,
+        }): Promise<CommitmentAmounts> => {
+            const provider = createAssetProvider(assetSend);
+            const receipt = await waitForCommitmentLockupReceipt(
+                provider,
+                commitmentLockupTxHash as Hash,
+            );
+
+            const contract = getErc20Swap(assetSend);
+            const event = getLockupEvent(
+                erc20SwapAbi,
+                receipt,
+                contract.address,
+            );
+            const lockupAmount = baseAssetAmountToInternal(
+                assetSend,
+                event.amount,
+            );
+            const directPair = new Pair(
+                currentPairs,
+                assetSend,
+                initialReceiveAsset,
+                regularPairs,
+            );
+            return calculateCommittedSubmarineAmounts(directPair, lockupAmount);
+        },
+    );
+
+    const committedAmountsError = () =>
+        loadError() ??
+        (committedAmounts.error === undefined
+            ? undefined
+            : formatError(committedAmounts.error));
+
+    const validationErrorLabel = (
+        error: unknown,
+    ): ButtonLabelParams | undefined => {
+        if (!(error instanceof Error)) {
+            return undefined;
+        }
+
+        const amountLabel = invoiceAmountLabel(error, {
+            denomination: Denomination.Sat,
+            separator: separator(),
+            asset: commitment().initialReceiveAsset,
+        });
+        if (amountLabel !== undefined) {
+            return amountLabel;
+        }
+
+        switch (error.message) {
+            case "invalid_invoice":
+            case "invalid_0_amount":
+                return { key: error.message };
+
+            default:
+                return undefined;
+        }
+    };
+
+    const setInvoiceInputError = (error: ButtonLabelParams | undefined) => {
+        setInvoiceError(error);
+        const message = error === undefined ? "" : t(error.key, error.params);
+        invoiceInput.setCustomValidity(message);
+        invoiceInput.classList.toggle("invalid", error !== undefined);
+    };
+
+    const validateCurrentInvoice = () => {
+        const amounts = committedAmounts();
+        if (amounts === undefined) {
+            return undefined;
+        }
+
+        const value = invoice().trim();
+        setInvoice(value);
+        if (value.length === 0) {
+            setInvoiceInputError(undefined);
+            return undefined;
+        }
+
+        try {
+            const validatedInvoice = validateCommitmentInvoiceInput(
+                value,
+                amounts,
+            );
+
+            setInvoice(validatedInvoice.invoice);
+            setInvoiceInputError(undefined);
+            return validatedInvoice;
+        } catch (error) {
+            setInvoiceInputError(
+                validationErrorLabel(error) ?? { key: "invalid_invoice" },
+            );
+            return undefined;
+        }
+    };
+
+    const completeSwap = async () => {
+        const validatedInvoice = validateCurrentInvoice();
+        if (validatedInvoice === undefined) {
+            return;
+        }
+
+        const current = commitment();
+        const amounts = committedAmounts();
+        if (
+            current.commitmentLockupTxHash === undefined ||
+            amounts === undefined
+        ) {
+            return;
+        }
+
+        setLoading(true);
+        try {
+            const resolvedInvoice = await resolveInvoice(
+                validatedInvoice,
+                amounts,
+            );
+            const submarine = await createSubmarine(
+                current.assetSend,
+                current.assetReceive,
+                amounts.sendAmount,
+                BigNumber(resolvedInvoice.sats),
+                resolvedInvoice.invoice,
+                amounts.pairHash,
+                current.gasAbstraction,
+                newKey,
+                resolvedInvoice.originalDestination,
+            );
+            await validateResponse(
+                submarine,
+                deriveKey,
+                getEtherSwap,
+                getErc20Swap,
+            );
+
+            await setSwapStorage({
+                ...submarine,
+                getGasToken: current.getGasToken,
+                commitmentLockupTxHash: current.commitmentLockupTxHash,
+                commitmentSignatureSubmitted: false,
+                signer: current.signer,
+                dex: current.dex,
+                bridge: current.bridge,
+            });
+            await deleteSwap(current.id);
+            navigate(`/swap/${submarine.id}`);
+        } catch (error) {
+            const errorLabel = validationErrorLabel(error);
+            if (errorLabel !== undefined) {
+                setInvoiceInputError(errorLabel);
+                return;
+            }
+
+            const message = formatError(error);
+            if (message.includes("invalid pair hash")) {
+                try {
+                    setLoadError(undefined);
+                    await fetchPairs();
+                    notify("error", t("feecheck"));
+                } catch (refreshError) {
+                    const refreshMessage = formatError(refreshError);
+                    log.error(
+                        "Refreshing pairs for committed swap failed",
+                        refreshError,
+                    );
+                    notify("error", refreshMessage);
+                }
+                return;
+            }
+
+            log.error("Creating committed submarine swap failed", error);
+            notify("error", message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    let autoCompletionAttempt: string | undefined;
+    createEffect(() => {
+        const current = commitment();
+        const amounts = committedAmounts();
+        if (
+            current.commitmentLockupTxHash === undefined ||
+            amounts === undefined ||
+            loading() ||
+            !isDeferredInvoiceDestination(current.originalDestination)
+        ) {
+            return;
+        }
+
+        const originalDestination =
+            extractInvoice(current.originalDestination) ?? "";
+        const currentInvoice = extractInvoice(invoice()) ?? "";
+        if (currentInvoice !== originalDestination) {
+            return;
+        }
+
+        const attempt = `${current.id}:${originalDestination}:${getInvoiceSats(
+            amounts,
+        )}`;
+        if (autoCompletionAttempt === attempt) {
+            return;
+        }
+
+        autoCompletionAttempt = attempt;
+        void completeSwap();
+    });
+
+    return (
+        <Show
+            when={commitment().commitmentLockupTxHash !== undefined}
+            fallback={
+                <LockupEvm
+                    swapId={commitment().id}
+                    gasAbstraction={commitment().gasAbstraction.lockup}
+                    // Exact-input commitment lockups derive the output amount
+                    // from the fixed hop input; the final lockup amount is
+                    // read from the on-chain event after broadcast.
+                    amount={0}
+                    preimageHash={emptyPreimageHash.slice(2)}
+                    claimAddress={zeroAddress}
+                    timeoutBlockHeight={0}
+                    asset={commitment().assetSend}
+                    hops={lockupHops()}
+                    hopInputAmount={lockupHopInputAmount()}
+                    bridge={getPreBridgeDetail(commitment().bridge)}
+                />
+            }>
+            <>
+                <Show
+                    when={committedAmountsError()}
+                    fallback={
+                        <Show
+                            when={committedAmounts()}
+                            fallback={<LoadingSpinner />}>
+                            {(amounts) => (
+                                <>
+                                    <CommitmentInvoiceHeader
+                                        amounts={amounts()}
+                                        invoiceAsset={
+                                            commitment().initialReceiveAsset
+                                        }
+                                        lockupAsset={commitment().assetSend}
+                                        copyAmount={() =>
+                                            getInvoiceAmountString(
+                                                amounts(),
+                                                commitment()
+                                                    .initialReceiveAsset,
+                                                separator(),
+                                            )
+                                        }
+                                        lockupTxHash={
+                                            commitment().commitmentLockupTxHash!
+                                        }
+                                    />
+                                    <input
+                                        required
+                                        class="commitment-invoice-input"
+                                        ref={invoiceInput}
+                                        type="text"
+                                        id="invoice"
+                                        data-testid="invoice"
+                                        aria-invalid={
+                                            invoiceError() !== undefined ||
+                                            undefined
+                                        }
+                                        aria-labelledby="commitment-invoice-label"
+                                        name="invoice"
+                                        value={invoice()}
+                                        autocomplete="off"
+                                        placeholder={t("create_and_paste")}
+                                        onInput={(event) => {
+                                            setInvoice(
+                                                event.currentTarget.value,
+                                            );
+                                            validateCurrentInvoice();
+                                        }}
+                                    />
+                                    <button
+                                        class="btn commitment-invoice-submit"
+                                        data-testid="commitment-invoice-submit"
+                                        disabled={
+                                            loading() ||
+                                            invoiceError() !== undefined ||
+                                            !hasInvoice()
+                                        }
+                                        onClick={completeSwap}>
+                                        {loading() ? (
+                                            <LoadingSpinner class="inner-spinner" />
+                                        ) : invoiceErrorText() !== undefined &&
+                                          hasInvoice() ? (
+                                            invoiceErrorText()
+                                        ) : (
+                                            t("continue")
+                                        )}
+                                    </button>
+                                </>
+                            )}
+                        </Show>
+                    }>
+                    {(error) => (
+                        <>
+                            <h2>{t("error")}</h2>
+                            <p>{error()}</p>
+                        </>
+                    )}
+                </Show>
+                <hr class="commitment-action-separator" />
+                <div class="commitment-refund-action">
+                    <RefundButton
+                        swap={commitment as Accessor<CommitmentSwap>}
+                    />
+                </div>
+            </>
+        </Show>
+    );
+};
+
+export default CommitmentCreated;

--- a/src/status/InvoiceSet.tsx
+++ b/src/status/InvoiceSet.tsx
@@ -47,6 +47,11 @@ const InvoiceSet = () => {
                         ? submarine.dex.hops
                         : undefined
                 }
+                hopInputAmount={
+                    submarine.dex?.position === SwapPosition.Pre
+                        ? submarine.dex.sourceAmount
+                        : undefined
+                }
                 bridge={getPreBridgeDetail(submarine.bridge)}
             />
         </Show>

--- a/src/status/SwapCreated.tsx
+++ b/src/status/SwapCreated.tsx
@@ -58,6 +58,11 @@ const SwapCreated = () => {
                             ? chain.dex.hops
                             : undefined
                     }
+                    hopInputAmount={
+                        chain.dex?.position === SwapPosition.Pre
+                            ? chain.dex.sourceAmount
+                            : undefined
+                    }
                     bridge={getPreBridgeDetail(chain.bridge)}
                 />
             </Show>

--- a/src/status/TransactionClaimed.tsx
+++ b/src/status/TransactionClaimed.tsx
@@ -22,6 +22,8 @@ import { useModifySwap } from "../hooks/useModifySwap";
 import { formatAmount, formatDenomination } from "../utils/denomination";
 import { formatError } from "../utils/errors";
 import {
+    type ChainSwap,
+    type ReverseSwap,
     type SubmarineSwap,
     getFinalAssetReceive,
     getPostBridgeDetail,
@@ -89,17 +91,19 @@ const TransactionClaimed = (props: { bridgeStatusLink?: JSX.Element }) => {
         );
     });
 
-    const receiveAmount = () =>
-        formatAmount(
+    const receiveAmount = () => {
+        const current = swap() as ChainSwap | ReverseSwap | SubmarineSwap;
+        return formatAmount(
             BigNumber(
-                (swap()!.dex?.position === SwapPosition.Post
-                    ? swap()!.dex?.quoteAmount
-                    : swap()!.receiveAmount) ?? 0,
+                (current.dex?.position === SwapPosition.Post
+                    ? current.dex.quoteAmount
+                    : current.receiveAmount) ?? 0,
             ),
             denomination(),
             separator(),
-            getFinalAssetReceive(swap()!),
+            getFinalAssetReceive(current),
         );
+    };
 
     const receiveDenomination = () =>
         formatDenomination(denomination(), getFinalAssetReceive(swap()!));

--- a/src/status/TransactionConfirmed.tsx
+++ b/src/status/TransactionConfirmed.tsx
@@ -912,7 +912,7 @@ export const AutoClaimHops = (props: {
                 <div class="quote">
                     <Amount
                         label={"sent"}
-                        amount={swap()!.sendAmount}
+                        amount={props.amount}
                         asset={props.assetSend}
                     />
                     <ImArrowDown size={15} style={{ opacity: 0.5 }} />
@@ -1047,7 +1047,7 @@ const ClaimEvm = (props: {
 
         const { transactionHash, receiveAmount } = result;
 
-        await modifySwap(props.swapId, (s) => {
+        await modifySwap<ChainSwap | ReverseSwap>(props.swapId, (s) => {
             s.claimTx = transactionHash;
             s.receiveAmount = Number(
                 normalizePersistedReceiveAmount(

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -314,6 +314,116 @@ hr.spacer {
     text-align: right;
     overflow-wrap: break-word;
 }
+
+.commitment-invoice-header {
+    text-align: center;
+    margin: 16px 0 14px;
+}
+
+.commitment-invoice-heading {
+    margin: 0 0 10px;
+    font-size: 1.08rem;
+    line-height: 1.35;
+    color: var(--color-text);
+    font-weight: 600;
+}
+
+.commitment-invoice-meta {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.35rem 0.55rem;
+    color: var(--color-white-50);
+    font-size: 0.82rem;
+    line-height: 1.4;
+    margin: 0 auto;
+}
+
+.commitment-lockup-transaction {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0;
+    background: transparent;
+    color: var(--color-white-60);
+    border: none;
+    cursor: pointer;
+    font-weight: 500;
+    text-decoration: none;
+
+    svg {
+        height: 14px;
+        width: 14px;
+    }
+}
+
+@media (hover: hover) {
+    .commitment-lockup-transaction:hover {
+        background-color: transparent;
+        color: var(--color-text);
+    }
+}
+
+.commitment-copy-amount {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0;
+    background: transparent;
+    color: var(--color-white-60);
+    border: none;
+    cursor: pointer;
+    font-weight: 500;
+
+    svg {
+        height: 14px;
+        width: 14px;
+    }
+}
+
+@media (hover: hover) {
+    .commitment-copy-amount:hover {
+        background-color: transparent;
+        color: var(--color-text);
+    }
+}
+
+.commitment-copy-amount.btn-active {
+    background-color: transparent;
+    color: var(--color-text);
+}
+
+.commitment-invoice-meta-separator {
+    width: 1px;
+    height: 13px;
+    background-color: var(--color-white-15);
+}
+
+.commitment-invoice-input {
+    margin-top: 14px;
+}
+
+.btn.commitment-invoice-submit {
+    margin-top: 10px;
+    min-height: 38px;
+    padding-block: 8px;
+}
+
+.commitment-action-separator {
+    margin: 12px 0 10px;
+    border-color: var(--color-white-15);
+}
+
+.commitment-refund-action {
+    margin-top: 0;
+    text-align: center;
+}
+
+.commitment-refund-action .btn {
+    margin-top: 0;
+}
+
 .fees-dyn,
 .icons > div {
     position: relative;
@@ -443,12 +553,14 @@ hr.spacer {
     }
 }
 
-.btn-explorer {
+.btn-explorer,
+.commitment-refund-action .btn {
     background: var(--color-tertiary);
     color: var(--color-text);
 }
 @media (hover: hover) {
-    .btn-explorer:hover {
+    .btn-explorer:hover,
+    .commitment-refund-action .btn:not(:disabled):hover {
         background: var(--color-secondary-100);
         color: var(--color-tertiary);
     }
@@ -559,6 +671,67 @@ input.invalid,
 textarea.invalid {
     outline: none;
     border-color: var(--color-error-500);
+}
+.committed-invoice-row {
+    position: relative;
+}
+.committed-invoice-input:disabled {
+    opacity: 1;
+    background: color-mix(
+        in srgb,
+        var(--color-secondary-800) 76%,
+        var(--color-medium-gray)
+    );
+    border-color: var(--color-white-10);
+    color: var(--color-white-30);
+    cursor: not-allowed;
+    -webkit-text-fill-color: var(--color-white-30);
+}
+.committed-invoice-input:disabled::placeholder {
+    color: var(--color-white-30);
+}
+.committed-invoice-row .invoice-slot-action {
+    position: absolute;
+    top: 50%;
+    right: 10px;
+    transform: translateY(-50%);
+    padding: 0 7px;
+    border-color: var(--color-white-05);
+    background: var(--color-white-05);
+    color: var(--color-white-50);
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+.invoice-slot-action {
+    flex: 0 0 auto;
+    border: 1px solid var(--color-white-15);
+    background: var(--color-secondary-700);
+    color: var(--color-text);
+    font-weight: 600;
+}
+@media (hover: hover) {
+    .invoice-slot-action:hover {
+        background: var(--color-secondary-100);
+        color: var(--color-secondary-700);
+    }
+}
+.invoice-slot-action:focus-visible,
+.invoice-slot-action:active {
+    background: var(--color-secondary-100);
+    color: var(--color-secondary-700);
+}
+.committed-invoice-row .invoice-slot-action:focus-visible,
+.committed-invoice-row .invoice-slot-action:active {
+    border-color: var(--color-white-10);
+    background: var(--color-white-10);
+    color: var(--color-white-80);
+}
+@media (hover: hover) {
+    .committed-invoice-row .invoice-slot-action:hover {
+        border-color: var(--color-white-10);
+        background: var(--color-white-10);
+        color: var(--color-white-80);
+    }
 }
 .fees-dyn label {
     display: block;
@@ -1480,6 +1653,7 @@ textarea.invalid {
     display: flex;
     flex-direction: column;
     align-items: center;
+    width: 100%;
     gap: 0.3rem;
 }
 
@@ -1487,7 +1661,7 @@ textarea.invalid {
     display: flex;
     justify-content: center;
     align-items: center;
-    width: 20rem;
+    width: min(20rem, 100%);
     padding: 10px 12px;
     margin: 0;
     text-align: center;

--- a/src/utils/Pair.ts
+++ b/src/utils/Pair.ts
@@ -63,11 +63,19 @@ const isRoutedAsset = (asset: string) =>
     getRouteViaAsset(asset) !== undefined ||
     config.assets?.[asset]?.bridge !== undefined;
 
-/** Convert an internal amount to EVM base units for the DEX API. */
-const toDexAmount = (amount: number, asset: string): bigint =>
-    isRoutedAsset(asset)
+const toIntegerAmount = (amount: number | BigNumber) =>
+    typeof amount === "number"
         ? BigInt(Math.round(amount))
-        : satsToAssetAmount(amount, asset);
+        : BigInt(amount.toFixed(0));
+
+/** Convert an internal amount to EVM base units for the DEX API. */
+export const toDexAmount = (
+    amount: number | BigNumber,
+    asset: string,
+): bigint =>
+    isRoutedAsset(asset)
+        ? toIntegerAmount(amount)
+        : satsToAssetAmount(toIntegerAmount(amount), asset);
 
 /** Convert an EVM base unit amount from the DEX API back to internal representation. */
 const fromDexAmount = (amount: bigint, asset: string): BigNumber =>
@@ -88,7 +96,7 @@ export const enum BridgeMessagingFeeDisplayMode {
 }
 
 type Hop = {
-    type: SwapType;
+    type: Exclude<SwapType, SwapType.Commitment>;
     from: string;
     to: string;
     pair?:
@@ -462,7 +470,7 @@ export default class Pair {
         }
 
         if (firstHop.type !== SwapType.Chain) {
-            blockers.push(`first hop type is ${firstHop.type}`);
+            blockers.push("first hop is not a chain swap");
         }
 
         if (isEvmAsset(firstHop.from)) {
@@ -567,6 +575,10 @@ export default class Pair {
         }
 
         return undefined;
+    }
+
+    public get hasPreBoltzDex() {
+        return this.dexHopBeforeBoltz !== undefined;
     }
 
     private get postBridgeDexHop(): Hop | undefined {

--- a/src/utils/commitmentSwap.ts
+++ b/src/utils/commitmentSwap.ts
@@ -1,0 +1,22 @@
+import { bridgeRegistry } from "boltz-swaps/bridge";
+import { AssetKind, SwapType } from "boltz-swaps/types";
+
+import { getKindForAsset } from "../consts/Assets";
+import { Side } from "../consts/Enums";
+import type Pair from "./Pair";
+
+export const canCommitSubmarineSendAmount = (
+    pair: Pair,
+    amountChanged: Side,
+) => {
+    const commitmentAsset =
+        bridgeRegistry.getPreRoute(pair.fromAsset)?.destinationAsset ??
+        pair.fromAsset;
+
+    return (
+        pair.swapToCreate?.type === SwapType.Submarine &&
+        amountChanged === Side.Send &&
+        pair.hasPreBoltzDex &&
+        getKindForAsset(commitmentAsset) === AssetKind.ERC20
+    );
+};

--- a/src/utils/connectedMaximum.ts
+++ b/src/utils/connectedMaximum.ts
@@ -1,0 +1,80 @@
+import type { BigNumber } from "bignumber.js";
+import { bridgeRegistry } from "boltz-swaps/bridge";
+import { createAssetProvider } from "boltz-swaps/evm";
+import { createTokenContract } from "boltz-swaps/evm/contracts";
+import { AssetKind } from "boltz-swaps/types";
+
+import { getKindForAsset } from "../consts/Assets";
+import type { ConnectedWallet, Signer } from "../context/Web3";
+import { getAssetNativeBalance } from "./chains/balance";
+import { baseAssetAmountToInternal } from "./denomination";
+import { getNativeEvmLockupSpendableBalance } from "./evmLockup";
+import { estimateFeesPerGas } from "./provider";
+
+const getNativeGasPrice = async (asset: string) => {
+    const provider = createAssetProvider(asset);
+    const { gasPrice } = await estimateFeesPerGas(provider);
+    if (gasPrice === null) {
+        throw new Error("missing gas price");
+    }
+    return gasPrice;
+};
+
+export const getConnectedMaximum = async ({
+    fromAsset,
+    connectedWallet,
+    signer,
+}: {
+    fromAsset: string;
+    connectedWallet?: ConnectedWallet;
+    signer?: Signer;
+}): Promise<BigNumber | undefined> => {
+    const preBridgeRoute = bridgeRegistry.getPreRoute(fromAsset);
+    if (preBridgeRoute !== undefined) {
+        const driver = bridgeRegistry.requireDriverForRoute(preBridgeRoute);
+        if (
+            connectedWallet?.transport !==
+                driver.getTransport(preBridgeRoute.sourceAsset) ||
+            connectedWallet.address === undefined
+        ) {
+            return undefined;
+        }
+
+        return baseAssetAmountToInternal(
+            preBridgeRoute.sourceAsset,
+            await driver.getSourceTokenBalance(
+                preBridgeRoute,
+                connectedWallet.address,
+            ),
+        );
+    }
+
+    if (signer === undefined) {
+        return undefined;
+    }
+
+    switch (getKindForAsset(fromAsset)) {
+        case AssetKind.EVMNative: {
+            const [balance, gasPrice] = await Promise.all([
+                getAssetNativeBalance(fromAsset, signer.address),
+                getNativeGasPrice(fromAsset),
+            ]);
+            return baseAssetAmountToInternal(
+                fromAsset,
+                getNativeEvmLockupSpendableBalance(balance, gasPrice),
+            );
+        }
+
+        case AssetKind.ERC20: {
+            const balance = await createTokenContract(
+                fromAsset,
+                signer,
+            ).read.balanceOf([signer.address]);
+
+            return baseAssetAmountToInternal(fromAsset, balance);
+        }
+
+        default:
+            return undefined;
+    }
+};

--- a/src/utils/denomination.ts
+++ b/src/utils/denomination.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from "bignumber.js";
+import { assetAmountToSats } from "boltz-swaps/evm";
 import { AssetKind } from "boltz-swaps/types";
 
 import { config } from "../config";
@@ -132,6 +133,11 @@ export const convertAmount = (
         return amount;
     }
 };
+
+export const baseAssetAmountToInternal = (asset: string, amount: bigint) =>
+    getDecimals(asset).isErc20
+        ? BigNumber(amount.toString())
+        : BigNumber(assetAmountToSats(amount, asset).toString());
 
 export const calculateDigits = (
     maximum: number,

--- a/src/utils/evmLockup.ts
+++ b/src/utils/evmLockup.ts
@@ -1,0 +1,9 @@
+export const lockupGasUsage = 46_000n;
+
+export const getNativeEvmLockupSpendableBalance = (
+    balance: bigint,
+    gasPrice: bigint,
+) => {
+    const reserve = gasPrice * lockupGasUsage;
+    return balance > reserve ? balance - reserve : 0n;
+};

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -109,7 +109,7 @@ export const getPair = <
 ): T | undefined => {
     if (pairs === undefined) return undefined;
 
-    if (swapType === SwapType.Dex) {
+    if (swapType === SwapType.Dex || swapType === SwapType.Commitment) {
         return undefined;
     }
     const pairSwapType = pairs[swapType];
@@ -226,6 +226,10 @@ export const getDestinationAddress = (
     swap: SomeSwap | null | undefined,
 ): string => {
     if (swap === null || swap === undefined) {
+        return "";
+    }
+
+    if (swap.type === SwapType.Commitment) {
         return "";
     }
 

--- a/src/utils/invoice.ts
+++ b/src/utils/invoice.ts
@@ -1,6 +1,13 @@
 import { BigNumber } from "bignumber.js";
+import { isLnurlAmountError } from "boltz-swaps/errors";
+import { isBolt12Offer } from "boltz-swaps/invoice";
+import { isLnurl } from "boltz-swaps/lnurl";
+import { resolveInvoice } from "boltz-swaps/resolveInvoice";
 
 import { BTC, LBTC, LN } from "../consts/Assets";
+import { type Denomination, InvoiceValidation } from "../consts/Enums";
+import type { ButtonLabelParams } from "../consts/Types";
+import { formatAmount, formatDenomination } from "./denomination";
 
 export { isInvoice } from "boltz-swaps/invoice";
 export { isLnurl } from "boltz-swaps/lnurl";
@@ -11,6 +18,80 @@ export const liquidPrefix = "liquidnetwork:";
 export const liquidTestnetPrefix = "liquidtestnet:";
 
 export const maxExpiryHours = 24;
+
+export const isInvoiceValidationError = (error: unknown): error is Error =>
+    isLnurlAmountError(error) ||
+    (error instanceof Error &&
+        (Object.values(InvoiceValidation) as string[]).includes(error.message));
+
+export const invoiceAmountLabel = (
+    error: Error,
+    options: {
+        denomination: Denomination;
+        separator: string;
+        asset: string;
+    },
+): ButtonLabelParams | undefined => {
+    if (isLnurlAmountError(error)) {
+        return {
+            key: `${error.kind}_amount_destination`,
+            params: {
+                amount: formatAmount(
+                    BigNumber(error.limitSat),
+                    options.denomination,
+                    options.separator,
+                    options.asset,
+                ),
+                denomination: formatDenomination(
+                    options.denomination,
+                    options.asset,
+                ),
+            },
+        };
+    }
+
+    if (!isInvoiceValidationError(error)) {
+        return undefined;
+    }
+
+    let key: ButtonLabelParams["key"];
+    switch (error.message) {
+        case InvoiceValidation.MinAmount:
+            key = "min_amount_destination";
+            break;
+        case InvoiceValidation.MaxAmount:
+            key = "max_amount_destination";
+            break;
+        default: {
+            const unhandled: never = error.message as never;
+            return unhandled;
+        }
+    }
+
+    return {
+        key,
+        params: {
+            amount: formatAmount(
+                BigNumber(error.cause as BigNumber.Value),
+                options.denomination,
+                options.separator,
+                options.asset,
+            ),
+            denomination: formatDenomination(
+                options.denomination,
+                options.asset,
+            ),
+        },
+    };
+};
+
+export const fetchDeferredInvoice = async (
+    destination: string,
+    amountSat: number,
+): Promise<string> => {
+    const { invoice } = await resolveInvoice(destination, amountSat);
+    return invoice;
+};
 
 export const isBip21 = (data: string) => {
     if (typeof data !== "string") {
@@ -43,7 +124,7 @@ export const extractInvoice = (data: string) => {
         return null;
     }
 
-    data = data.toLowerCase();
+    data = data.trim().toLowerCase();
     if (data.startsWith(invoicePrefix)) {
         const url = new URL(data);
         return url.pathname;
@@ -99,4 +180,18 @@ export const getAssetByBip21Prefix = (prefix: string) => {
         default:
             return "";
     }
+};
+
+export const isDeferredInvoiceDestination = (
+    value: string | undefined,
+): value is string => {
+    if (value === undefined) {
+        return false;
+    }
+
+    const invoiceInput = extractInvoice(value.trim()) ?? "";
+    return (
+        invoiceInput !== "" &&
+        (isLnurl(invoiceInput) || isBolt12Offer(invoiceInput))
+    );
 };

--- a/src/utils/rescue.ts
+++ b/src/utils/rescue.ts
@@ -47,6 +47,7 @@ import { getFeeEstimationsFailover } from "./fees";
 import { parseBlindingKey, parsePrivateKey } from "./helper";
 import {
     type ChainSwap,
+    type CommitmentSwap,
     type ReverseSwap,
     type SomeSwap,
     type SubmarineSwap,
@@ -127,15 +128,22 @@ export const hasSwapTimedOut = (swap: SomeSwap, currentBlockHeight: number) => {
         return false;
     }
 
-    const swapTimeoutBlockHeight: Record<SwapType, () => number> = {
+    const swapTimeoutBlockHeight: Partial<
+        Record<SwapType, () => number | undefined>
+    > = {
         [SwapType.Chain]: () =>
             (swap as ChainSwap).lockupDetails.timeoutBlockHeight,
         [SwapType.Reverse]: () => (swap as ReverseSwap).timeoutBlockHeight,
         [SwapType.Submarine]: () => (swap as SubmarineSwap).timeoutBlockHeight,
-        [SwapType.Dex]: () => Number.MAX_SAFE_INTEGER, // TODO: fix that
+        [SwapType.Commitment]: () =>
+            (swap as CommitmentSwap).timeoutBlockHeight,
     };
 
-    return currentBlockHeight >= swapTimeoutBlockHeight[swap.type]();
+    const timeoutBlockHeight = swapTimeoutBlockHeight[swap.type]?.();
+    return (
+        timeoutBlockHeight !== undefined &&
+        currentBlockHeight >= timeoutBlockHeight
+    );
 };
 
 const refundTaproot = (

--- a/src/utils/swapCreator.ts
+++ b/src/utils/swapCreator.ts
@@ -41,6 +41,9 @@ export type DexDetail = {
     // For post-swap hops: expected output amount from the DEX.
     // For pre-swap hops: expected input amount to the DEX.
     quoteAmount: number | string;
+
+    // For pre-swap hops, exact source amount to spend in the DEX.
+    sourceAmount?: string;
 };
 
 export enum PreBridgeRecoveryStatus {
@@ -62,6 +65,7 @@ export type PreBridgeRecovery = {
 export type BridgeDetail = BridgeRoute & {
     kind: BridgeKind;
     position: SwapPosition;
+    sourceAmount?: string;
     txHash?: string;
     details?: BridgeDetails;
     pendingSend?: PendingBridgeSend;
@@ -91,14 +95,12 @@ export const createUniformGasAbstraction = (
 export const noGasAbstraction = (): GasAbstraction =>
     createUniformGasAbstraction(GasAbstractionType.None);
 
-export type SwapBase = {
+export type SwapBaseData = {
     type: SwapType;
     status?: string;
     assetSend: string;
     assetReceive: string;
     getGasToken?: boolean;
-    sendAmount: number;
-    receiveAmount: number;
     version: number;
     date: number;
 
@@ -128,6 +130,11 @@ export type SwapBase = {
 
     // Bridge routes for bridging before lockup or after claim.
     bridge?: BridgeDetail;
+};
+
+export type SwapBase = SwapBaseData & {
+    sendAmount: number;
+    receiveAmount: number;
 };
 
 export type SubmarineSwap = SwapBase &
@@ -166,17 +173,32 @@ export type ChainSwap = SwapBase &
         refundPrivateKey?: string;
     };
 
-export type SomeSwap = SubmarineSwap | ReverseSwap | ChainSwap;
+export type CommitmentSwap = SwapBaseData & {
+    type: SwapType.Commitment;
+    id: string;
+    initialReceiveAsset: string;
+    sourceAsset: string;
+    sourceAmount: string;
+    timeoutBlockHeight?: number;
+};
 
-export const getLockupGasAbstraction = (swap: SwapBase): GasAbstractionType =>
-    swap.gasAbstraction.lockup;
+export type SomeSwap = SubmarineSwap | ReverseSwap | ChainSwap | CommitmentSwap;
 
-export const getClaimGasAbstraction = (swap: SwapBase): GasAbstractionType =>
-    swap.gasAbstraction.claim;
+export const isCommitmentSwap = (swap: SwapBaseData): swap is CommitmentSwap =>
+    swap.type === SwapType.Commitment;
 
-export const getRelevantAssetForSwap = (swap: SwapBase) => {
+export const getLockupGasAbstraction = (
+    swap: SwapBaseData,
+): GasAbstractionType => swap.gasAbstraction.lockup;
+
+export const getClaimGasAbstraction = (
+    swap: SwapBaseData,
+): GasAbstractionType => swap.gasAbstraction.claim;
+
+export const getRelevantAssetForSwap = (swap: SwapBaseData) => {
     switch (swap.type) {
         case SwapType.Submarine:
+        case SwapType.Commitment:
             return swap.assetSend;
 
         default:
@@ -192,13 +214,19 @@ export const getSwapAddress = (swap: SomeSwap): string => {
             return swap.lockupAddress;
         case SwapType.Chain:
             return swap.lockupDetails.lockupAddress;
+        case SwapType.Commitment:
+            return "";
     }
 };
 
 export const getFinalAssetSend = (
-    swap: SwapBase,
+    swap: SwapBaseData,
     coalesceLn: boolean = false,
 ): string => {
+    if (isCommitmentSwap(swap)) {
+        return swap.sourceAsset;
+    }
+
     if (swap.bridge?.position === SwapPosition.Pre) {
         return swap.bridge.sourceAsset;
     }
@@ -215,9 +243,13 @@ export const getFinalAssetSend = (
 };
 
 export const getFinalAssetReceive = (
-    swap: SwapBase,
+    swap: SwapBaseData,
     coalesceLn: boolean = false,
 ): string => {
+    if (isCommitmentSwap(swap)) {
+        return swap.initialReceiveAsset;
+    }
+
     if (swap.bridge?.position === SwapPosition.Post) {
         return swap.bridge.destinationAsset;
     }
@@ -258,6 +290,39 @@ const generatePreimage = ({
     rescueFile: RescueFile;
 }) => {
     return derivePreimageFromRescueKey(rescueFile, keyIndex, asset);
+};
+
+export const createLocalSwapId = () =>
+    Array.from(crypto.getRandomValues(new Uint8Array(8)), (byte) =>
+        byte.toString(16).padStart(2, "0"),
+    ).join("");
+
+export const createCommitmentSwap = (
+    assetSend: string,
+    assetReceive: string,
+    initialReceiveAsset: string,
+    sourceAsset: string,
+    sourceAmount: BigNumber,
+    gasAbstraction: GasAbstraction,
+    dex?: DexDetail,
+    bridge?: BridgeDetail,
+    originalDestination?: string,
+): CommitmentSwap => {
+    return {
+        id: createLocalSwapId(),
+        type: SwapType.Commitment,
+        gasAbstraction,
+        assetSend,
+        assetReceive,
+        date: new Date().getTime(),
+        version: OutputType.Taproot,
+        initialReceiveAsset,
+        sourceAsset,
+        sourceAmount: sourceAmount.toFixed(0),
+        dex,
+        bridge,
+        originalDestination,
+    };
 };
 
 export const createSubmarine = async (

--- a/src/utils/swapMetadata.ts
+++ b/src/utils/swapMetadata.ts
@@ -130,8 +130,15 @@ const parseObject =
         return result as T;
     };
 
+const swapHopTypes = {
+    Submarine: SwapType.Submarine,
+    Reverse: SwapType.Reverse,
+    Chain: SwapType.Chain,
+    Dex: SwapType.Dex,
+} as const;
+
 const parseHopMetadata = parseObject<EncodedHop>({
-    type: parseEnum(SwapType),
+    type: parseEnum(swapHopTypes),
     from: parseString,
     to: parseString,
     dexDetails: parseOptional(

--- a/tests/components/CreateButton.spec.tsx
+++ b/tests/components/CreateButton.spec.tsx
@@ -1,21 +1,25 @@
-import { render, screen, waitFor } from "@solidjs/testing-library";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { BigNumber } from "bignumber.js";
 import type { Pairs } from "boltz-swaps/client";
 import type * as InvoiceModule from "boltz-swaps/invoice";
+import { SwapPosition, SwapType } from "boltz-swaps/types";
 
 import CreateButton, {
     getClaimAddress,
 } from "../../src/components/CreateButton";
 import type * as ConfigModule from "../../src/config";
+import type * as MainnetConfigModule from "../../src/configs/mainnet";
 import {
     BTC,
     LBTC,
     LN,
     RBTC,
     TBTC,
+    USDC,
     USDT0,
     WBTC,
 } from "../../src/consts/Assets";
+import { Side } from "../../src/consts/Enums";
 import { useCreateContext } from "../../src/context/Create";
 import { useGlobalContext } from "../../src/context/Global";
 import i18n from "../../src/i18n/i18n";
@@ -48,6 +52,9 @@ vi.mock("boltz-swaps/invoice", async (importActual) => {
 vi.mock("../../src/config", async () => {
     const actual =
         await vi.importActual<typeof ConfigModule>("../../src/config");
+    const { config: mainnetConfig } = await vi.importActual<
+        typeof MainnetConfigModule
+    >("../../src/configs/mainnet");
 
     return {
         ...actual,
@@ -55,6 +62,9 @@ vi.mock("../../src/config", async () => {
             ...actual.config,
             assets: {
                 ...actual.config.assets!,
+                USDC:
+                    actual.config.assets!.USDC ??
+                    structuredClone(mainnetConfig.assets!.USDC),
                 "USDT0-POL": {
                     ...actual.config.assets!.USDT0,
                     canSend: true,
@@ -132,6 +142,7 @@ vi.mock("../../src/config", async () => {
 
 const invoice =
     "lnbcrt600u1p5ynhmgpp5l8j7lnaql4mqeukvcqmhr8zp9vh3rngfgmla6km2fh9vf8pt678sdqqcqzzsxqrpwusp56gha98s9xk2f4eeyhs7dcsx4j4rt79llks72nf6l6hc9cna6vfgs9qxpqysgqqnt8lqcrujmuuv3ajvrlu5z7ydvvge4efv39hj28etf8v72vpcl597evz5e0tvq04tv3z089wxtugee4xh5hvu6309ymrfddrlzfhzgqumsrpk";
+const bolt12Offer = "lno1mockoffer";
 
 const usdt0Pairs: Pairs = {
     submarine: {
@@ -167,7 +178,77 @@ const setPairAssetsWithPairs = (
     signals.setPair(new Pair(pairs, fromAsset, toAsset, pairs));
 };
 
+const renderCreateButton = () =>
+    render(
+        () => (
+            <>
+                <TestComponent />
+                <CreateButton />
+            </>
+        ),
+        { wrapper: contextWrapper },
+    );
+
+const mockPreDexCommitmentCreation = () => {
+    signals.pair().creationData = vi.fn().mockResolvedValue({
+        type: SwapType.Submarine,
+        from: TBTC,
+        to: BTC,
+        sendAmount: BigNumber(80_000),
+        receiveAmount: BigNumber(79_000),
+        pairHash: "tbtc-ln-pair-hash",
+        hops: [
+            {
+                type: SwapType.Dex,
+                from: USDC,
+                to: TBTC,
+            },
+        ],
+        hopsPosition: SwapPosition.Pre,
+    });
+};
+
+const setupPreDexCommitmentButton = async (destination = "") => {
+    renderCreateButton();
+
+    await globalSignals.clearSwaps();
+    globalSignals.setOnline(true);
+    signals.setSendAmount(BigNumber(100_000));
+    signals.setReceiveAmount(BigNumber(99_000));
+    signals.setAmountChanged(Side.Send);
+    signals.setAmountValid(true);
+    signals.setInvoice(destination);
+    signals.setBolt12Offer(destination || undefined);
+    signals.setInvoiceValid(false);
+    setPairAssetsWithPairs(usdt0Pairs, USDC, LN);
+    mockPreDexCommitmentCreation();
+
+    const btn = (await screen.findByTestId(
+        "create-swap-button",
+    )) as HTMLButtonElement;
+
+    await waitFor(() => {
+        expect(signals.valid()).toBe(false);
+        expect(btn.disabled).toBe(false);
+    });
+
+    return btn;
+};
+
 describe("CreateButton", () => {
+    beforeEach(() => {
+        window.history.pushState({}, "", "/");
+        Object.defineProperty(window.navigator, "locks", {
+            configurable: true,
+            value: {
+                request: vi.fn(
+                    async (_name: string, callback: () => Promise<unknown>) =>
+                        await callback(),
+                ),
+            },
+        });
+    });
+
     afterEach(() => {
         vi.restoreAllMocks();
     });
@@ -661,6 +742,92 @@ describe("CreateButton", () => {
         )) as HTMLButtonElement;
         expect(btn).not.toBeUndefined();
         expect(btn.disabled).toBeTruthy();
+    });
+
+    test("should require an invoice when an ERC20 asset resolves to a direct submarine route", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <CreateButton />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        await globalSignals.clearSwaps();
+        globalSignals.setOnline(true);
+        signals.setSendAmount(BigNumber(100_000));
+        signals.setReceiveAmount(BigNumber(99_000));
+        signals.setAmountChanged(Side.Send);
+        signals.setAmountValid(true);
+        signals.setInvoice("");
+        signals.setInvoiceValid(false);
+        setPairAssetsWithPairs(
+            {
+                submarine: {
+                    ...usdt0Pairs.submarine,
+                    [USDC]: {
+                        [BTC]: usdt0Pairs.submarine.TBTC.BTC,
+                    },
+                },
+                reverse: {},
+                chain: {},
+            },
+            USDC,
+            LN,
+        );
+
+        const btn = (await screen.findByTestId(
+            "create-swap-button",
+        )) as HTMLButtonElement;
+
+        await waitFor(() => {
+            expect(signals.valid()).toBe(false);
+            expect(btn.disabled).toBe(true);
+        });
+        await expect(globalSignals.getSwaps()).resolves.toEqual([]);
+    });
+
+    test("should create a local commitment swap for send-side pre-dex submarine without invoice", async () => {
+        const btn = await setupPreDexCommitmentButton();
+        fireEvent.click(btn);
+
+        await waitFor(async () => {
+            const [swap] = await globalSignals.getSwaps();
+            expect(swap).toMatchObject({
+                type: SwapType.Commitment,
+                assetSend: TBTC,
+                assetReceive: BTC,
+                initialReceiveAsset: LN,
+                sourceAsset: USDC,
+                sourceAmount: "100000",
+                dex: {
+                    position: SwapPosition.Pre,
+                    quoteAmount: 100000,
+                    sourceAmount: "100000",
+                    hops: [
+                        {
+                            from: USDC,
+                            to: TBTC,
+                        },
+                    ],
+                },
+            });
+        });
+    });
+
+    test("should defer invoice fetching for send-side pre-dex commitments", async () => {
+        const btn = await setupPreDexCommitmentButton(bolt12Offer);
+        fireEvent.click(btn);
+
+        await waitFor(async () => {
+            const [swap] = await globalSignals.getSwaps();
+            expect(swap).toMatchObject({
+                type: SwapType.Commitment,
+                originalDestination: bolt12Offer,
+            });
+        });
     });
 
     test("should be disabled on empty address", async () => {

--- a/tests/components/InvoiceInput.spec.tsx
+++ b/tests/components/InvoiceInput.spec.tsx
@@ -4,6 +4,7 @@ import { vi } from "vitest";
 
 import InvoiceInput from "../../src/components/InvoiceInput";
 import { BTC, LBTC, LN } from "../../src/consts/Assets";
+import { Side } from "../../src/consts/Enums";
 import Pair from "../../src/utils/Pair";
 import { extractInvoice, invoicePrefix } from "../../src/utils/invoice";
 import {
@@ -31,17 +32,19 @@ vi.mock("boltz-swaps/invoice", async () => {
 
 vi.mock("../../src/utils/validation", async () => {
     const actual = await vi.importActual("../../src/utils/validation");
+    const validateInvoice = vi.fn((inputValue: string) => {
+        if (inputValue.startsWith("lnzeroamt")) {
+            throw new Error("invalid_0_amount");
+        }
+        if (inputValue.startsWith("ln")) {
+            return 1000;
+        }
+        throw new Error("invalid_invoice");
+    });
+
     return {
         ...actual,
-        validateInvoice: vi.fn((inputValue: string) => {
-            if (inputValue.startsWith("lnzeroamt")) {
-                throw new Error("invalid_0_amount");
-            }
-            if (inputValue.startsWith("ln")) {
-                return 1000;
-            }
-            throw new Error("invalid_invoice");
-        }),
+        validateInvoice,
     };
 });
 
@@ -145,6 +148,75 @@ describe("InvoiceInput", () => {
         signals.setSendAmount(signals.sendAmount().plus(1));
 
         expect(input.value).toEqual(lnurl);
+    });
+
+    test("should keep BOLT12 offers when the send amount changes", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <InvoiceInput />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+        setPairAssets(BTC, LN);
+
+        const input = (await screen.findByTestId(
+            "invoice",
+        )) as HTMLInputElement;
+        const offer =
+            "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qqtzzqcxyaupvt8xstdrl8vlun9ch2t28a94hq80agu6usv02rxvetfm3c";
+
+        fireEvent.input(input, {
+            target: { value: offer },
+        });
+
+        await waitFor(() => {
+            expect(signals.bolt12Offer()).toEqual(offer);
+        });
+
+        signals.setAmountChanged(Side.Send);
+        signals.setSendAmount(BigNumber(10_000));
+        signals.setReceiveAmount(BigNumber(9_900));
+        signals.setAmountValid(true);
+
+        await waitFor(() => {
+            expect(signals.invoice()).toEqual(offer);
+            expect(input.value).toEqual(offer);
+        });
+    });
+
+    test("should clear amounts when changing to a BOLT12 offer", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <InvoiceInput />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+        setPairAssets(BTC, LN);
+
+        signals.setSendAmount(BigNumber(10_000));
+        signals.setReceiveAmount(BigNumber(9_900));
+
+        const input = (await screen.findByTestId(
+            "invoice",
+        )) as HTMLInputElement;
+        const offer =
+            "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qqtzzqcxyaupvt8xstdrl8vlun9ch2t28a94hq80agu6usv02rxvetfm3c";
+
+        fireEvent.input(input, {
+            target: { value: offer },
+        });
+
+        await waitFor(() => {
+            expect(signals.bolt12Offer()).toEqual(offer);
+            expect(signals.sendAmount().isZero()).toEqual(true);
+            expect(signals.receiveAmount().isZero()).toEqual(true);
+        });
     });
 
     test.each`

--- a/tests/components/SwapLimits.spec.tsx
+++ b/tests/components/SwapLimits.spec.tsx
@@ -10,9 +10,7 @@ const renderLimits = (
     const onSelectAmount = vi.fn();
     const result = render(() => (
         <SwapLimits
-            minimum={1_000}
             maximum={2_000_000}
-            minLabel="Min"
             maxLabel="Max"
             loading={false}
             onSelectAmount={onSelectAmount}
@@ -23,15 +21,15 @@ const renderLimits = (
 };
 
 describe("SwapLimits", () => {
-    it("renders min and max buttons with their labels", () => {
+    it("renders the max button with its label", () => {
         renderLimits();
 
-        expect(screen.getByTestId("limit-min-button")).toHaveTextContent("Min");
+        expect(screen.queryByTestId("limit-min-button")).toBeNull();
         expect(screen.getByTestId("limit-max-button")).toHaveTextContent("Max");
     });
 
-    it("does not render when not loading and both limits are zero", () => {
-        const { container } = renderLimits({ minimum: 0, maximum: 0 });
+    it("does not render when not loading and the maximum is zero", () => {
+        const { container } = renderLimits({ maximum: 0 });
 
         expect(container.querySelector(".amount-limits")).toBeNull();
         expect(screen.queryByTestId("limit-min-button")).toBeNull();
@@ -39,19 +37,10 @@ describe("SwapLimits", () => {
     });
 
     it("renders while loading even when limits are zero", () => {
-        renderLimits({ minimum: 0, maximum: 0, loading: true });
+        renderLimits({ maximum: 0, loading: true });
 
-        expect(screen.getByTestId("limit-min-button")).toBeInTheDocument();
+        expect(screen.queryByTestId("limit-min-button")).toBeNull();
         expect(screen.getByTestId("limit-max-button")).toBeInTheDocument();
-    });
-
-    it("calls onSelectAmount with the minimum when min is clicked", () => {
-        const { onSelectAmount } = renderLimits({ minimum: 1_234 });
-
-        fireEvent.click(screen.getByTestId("limit-min-button"));
-
-        expect(onSelectAmount).toHaveBeenCalledTimes(1);
-        expect(onSelectAmount).toHaveBeenCalledWith(1_234);
     });
 
     it("calls onSelectAmount with the maximum when max is clicked", () => {
@@ -63,47 +52,37 @@ describe("SwapLimits", () => {
         expect(onSelectAmount).toHaveBeenCalledWith(9_999);
     });
 
-    it("disables both buttons and shows skeletons while loading", () => {
-        const { container, onSelectAmount } = renderLimits({ loading: true });
+    it("can enable the max button independently from the displayed maximum", () => {
+        const onSelectMaximum = vi.fn();
+        const { onSelectAmount } = renderLimits({
+            maximum: 0,
+            maximumEnabled: true,
+            onSelectMaximum,
+        });
 
-        const minBtn = screen.getByTestId("limit-min-button");
-        const maxBtn = screen.getByTestId("limit-max-button");
+        fireEvent.click(screen.getByTestId("limit-max-button"));
 
-        expect(minBtn).toBeDisabled();
-        expect(maxBtn).toBeDisabled();
-        expect(minBtn).toHaveAttribute("aria-busy", "true");
-        expect(maxBtn).toHaveAttribute("aria-busy", "true");
-        expect(container.querySelectorAll(".skeleton")).toHaveLength(2);
-        expect(minBtn).not.toHaveTextContent("Min");
-        expect(maxBtn).not.toHaveTextContent("Max");
-
-        fireEvent.click(minBtn);
-        fireEvent.click(maxBtn);
+        expect(onSelectMaximum).toHaveBeenCalledTimes(1);
         expect(onSelectAmount).not.toHaveBeenCalled();
     });
 
-    it("disables only the side whose limit is non-positive", () => {
-        const { onSelectAmount } = renderLimits({ minimum: 0, maximum: 500 });
+    it("disables the max button and shows a skeleton while loading", () => {
+        const { container, onSelectAmount } = renderLimits({ loading: true });
 
-        const minBtn = screen.getByTestId("limit-min-button");
         const maxBtn = screen.getByTestId("limit-max-button");
 
-        expect(minBtn).toBeDisabled();
-        expect(maxBtn).toBeEnabled();
-
-        fireEvent.click(minBtn);
-        expect(onSelectAmount).not.toHaveBeenCalled();
+        expect(maxBtn).toBeDisabled();
+        expect(maxBtn).toHaveAttribute("aria-busy", "true");
+        expect(container.querySelectorAll(".skeleton")).toHaveLength(1);
+        expect(maxBtn).not.toHaveTextContent("Max");
 
         fireEvent.click(maxBtn);
-        expect(onSelectAmount).toHaveBeenCalledWith(500);
+        expect(onSelectAmount).not.toHaveBeenCalled();
     });
 
     it("uses the labels as accessible names", () => {
-        renderLimits({ minLabel: "Minimum", maxLabel: "Maximum" });
+        renderLimits({ maxLabel: "Maximum" });
 
-        expect(
-            screen.getByRole("button", { name: "Minimum" }),
-        ).toBeInTheDocument();
         expect(
             screen.getByRole("button", { name: "Maximum" }),
         ).toBeInTheDocument();

--- a/tests/components/SwapList.spec.tsx
+++ b/tests/components/SwapList.spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { SwapType } from "boltz-swaps/types";
 
 import SwapList, { type Swap } from "../../src/components/SwapList";
 import { BTC, LN } from "../../src/consts/Assets";
@@ -76,6 +77,24 @@ describe("SwapList", () => {
 
         const item = screen.getByTestId(`swaplist-item-${swap.id}`);
         expect(item.tagName).toEqual("A");
+        expect(item.getAttribute("href")).toEqual(`/swap/${swap.id}`);
+    });
+
+    it("should keep local commitment links pointed at the full swap id", () => {
+        const swap = {
+            id: "12345678-1234-1234-1234-123456789abc",
+            type: SwapType.Commitment,
+            date: new Date().getTime(),
+            assetSend: BTC,
+            assetReceive: LN,
+        } as SomeSwap;
+
+        render(
+            () => <SwapList swapsSignal={() => [swap]} action={() => "view"} />,
+            { wrapper: contextWrapper },
+        );
+
+        const item = screen.getByTestId(`swaplist-item-${swap.id}`);
         expect(item.getAttribute("href")).toEqual(`/swap/${swap.id}`);
     });
 

--- a/tests/pages/Create.spec.tsx
+++ b/tests/pages/Create.spec.tsx
@@ -7,17 +7,26 @@ import {
     within,
 } from "@solidjs/testing-library";
 import { BigNumber } from "bignumber.js";
-import { SwapType } from "boltz-swaps/types";
+import { type BridgeDriver, bridgeRegistry } from "boltz-swaps/bridge";
+import type { Pairs } from "boltz-swaps/client";
+import {
+    BridgeKind,
+    NetworkTransport,
+    SwapPosition,
+    SwapType,
+} from "boltz-swaps/types";
 import { Show, createSignal, onMount } from "solid-js";
 
 import { config as runtimeConfig } from "../../src/config";
 import { config as mainnetConfig } from "../../src/configs/mainnet";
-import { BTC, LBTC, LN, RBTC } from "../../src/consts/Assets";
+import { BTC, LBTC, LN, RBTC, TBTC, USDT0 } from "../../src/consts/Assets";
 import { Denomination, Side } from "../../src/consts/Enums";
+import * as web3Context from "../../src/context/Web3";
 import i18n from "../../src/i18n/i18n";
 import Create from "../../src/pages/Create";
 import Pair from "../../src/utils/Pair";
 import { calculateReceiveAmount } from "../../src/utils/calculate";
+import * as connectedMaximum from "../../src/utils/connectedMaximum";
 import type * as HelperModule from "../../src/utils/helper";
 import { isMobile } from "../../src/utils/helper";
 import {
@@ -34,6 +43,7 @@ beforeAll(() => {
     runtimeConfig.assets = {
         ...runtimeConfig.assets,
         "USDT0-SOL": structuredClone(mainnetConfig.assets!["USDT0-SOL"]),
+        "USDT0-POL": structuredClone(mainnetConfig.assets!["USDT0-POL"]),
     };
 });
 
@@ -59,8 +69,225 @@ const setPairAssets = (fromAsset: string, toAsset: string) => {
     signals.setPair(new Pair(signals.pair().pairs, fromAsset, toAsset));
 };
 
+const invoice =
+    "lnbcrt600u1p5ynhmgpp5l8j7lnaql4mqeukvcqmhr8zp9vh3rngfgmla6km2fh9vf8pt678sdqqcqzzsxqrpwusp56gha98s9xk2f4eeyhs7dcsx4j4rt79llks72nf6l6hc9cna6vfgs9qxpqysgqqnt8lqcrujmuuv3ajvrlu5z7ydvvge4efv39hj28etf8v72vpcl597evz5e0tvq04tv3z089wxtugee4xh5hvu6309ymrfddrlzfhzgqumsrpk";
+const bolt12Offer =
+    "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qqtzzqcxyaupvt8xstdrl8vlun9ch2t28a94hq80agu6usv02rxvetfm3c";
+
 const flushQuoteDebounce = async () => {
     await vi.runOnlyPendingTimersAsync();
+};
+
+const testEvmAddress = "0x1000000000000000000000000000000000000000";
+const commitmentSourceAsset = "USDT0-POL";
+const commitmentRoute = {
+    sourceAsset: commitmentSourceAsset,
+    destinationAsset: USDT0,
+};
+const commitmentRouteDetail = {
+    ...commitmentRoute,
+    kind: BridgeKind.Oft,
+    position: SwapPosition.Pre,
+};
+const commitmentSubmarinePairs: Pairs = {
+    submarine: {
+        [TBTC]: {
+            [BTC]: {
+                hash: "tbtc-ln-pair-hash",
+                rate: 1,
+                limits: {
+                    maximal: 1_000_000,
+                    minimal: 1,
+                    maximalZeroConf: 0,
+                },
+                fees: {
+                    percentage: 0,
+                    minerFees: 0,
+                },
+            },
+        },
+    },
+    reverse: {},
+    chain: {},
+};
+
+const renderCreate = () =>
+    render(
+        () => (
+            <>
+                <TestComponent />
+                <Create />
+            </>
+        ),
+        {
+            wrapper: contextWrapper,
+        },
+    );
+
+const mockWalletConnectEvm = () =>
+    vi.spyOn(web3Context, "useWeb3Signer").mockReturnValue({
+        signer: () => undefined,
+        connectedWallet: () => ({
+            address: testEvmAddress,
+            rdns: "wallet-connect",
+            transport: NetworkTransport.Evm,
+        }),
+        providers: () => ({}),
+        getEtherSwap: vi.fn(),
+        getErc20Swap: vi.fn(),
+        getGasAbstractionSigner: vi.fn(),
+    } as unknown as ReturnType<typeof web3Context.useWeb3Signer>);
+
+const createCommitmentPair = () => {
+    const currentPair = new Pair(
+        commitmentSubmarinePairs,
+        commitmentSourceAsset,
+        LN,
+        commitmentSubmarinePairs,
+    );
+    currentPair.getMinimum = vi.fn().mockResolvedValue(1);
+    currentPair.getMaximum = vi.fn().mockResolvedValue(1_000_000);
+    currentPair.calculateReceiveAmount = vi
+        .fn()
+        .mockResolvedValue(BigNumber(0));
+    currentPair.creationData = vi.fn().mockResolvedValue({
+        type: SwapType.Submarine,
+        from: TBTC,
+        to: BTC,
+        sendAmount: BigNumber(740_000),
+        receiveAmount: BigNumber(99_000),
+        pairHash: "tbtc-ln-pair-hash",
+        hops: [
+            {
+                type: SwapType.Dex,
+                from: USDT0,
+                to: TBTC,
+            },
+        ],
+        hopsPosition: SwapPosition.Pre,
+    });
+
+    return currentPair;
+};
+
+const mockPreBridgeDriver = (driver: Partial<BridgeDriver>) => ({
+    getPreRoute: vi
+        .spyOn(bridgeRegistry, "getPreRoute")
+        .mockImplementation((asset) =>
+            asset === commitmentSourceAsset ? commitmentRoute : undefined,
+        ),
+    requireDriverForRoute: vi
+        .spyOn(bridgeRegistry, "requireDriverForRoute")
+        .mockReturnValue(driver as BridgeDriver),
+    getDriverForAsset: vi
+        .spyOn(bridgeRegistry, "getDriverForAsset")
+        .mockImplementation((asset) =>
+            asset === commitmentSourceAsset
+                ? (driver as BridgeDriver)
+                : undefined,
+        ),
+});
+
+const createPreBridgeDriver = (
+    getSourceTokenBalance: BridgeDriver["getSourceTokenBalance"],
+): Partial<BridgeDriver> => ({
+    getTransport: () => NetworkTransport.Evm,
+    getSourceTokenBalance,
+    getPreRoute: () => commitmentRoute,
+    getRoutePosition: () => commitmentRouteDetail,
+    getMessagingFeeToken: () => "POL",
+    getTransferFeeAsset: () => commitmentRoute.sourceAsset,
+});
+
+const mockCommitmentWalletAndBridge = (
+    getSourceTokenBalance: BridgeDriver["getSourceTokenBalance"],
+) => {
+    const useWeb3Signer = mockWalletConnectEvm();
+    const bridgeMocks = mockPreBridgeDriver(
+        createPreBridgeDriver(getSourceTokenBalance),
+    );
+
+    return () => {
+        useWeb3Signer.mockRestore();
+        bridgeMocks.getPreRoute.mockRestore();
+        bridgeMocks.requireDriverForRoute.mockRestore();
+        bridgeMocks.getDriverForAsset.mockRestore();
+        window.history.pushState({}, "", "/");
+    };
+};
+
+const selectMaximumCommitmentSwap = async ({
+    createSwap = true,
+}: { createSwap?: boolean } = {}) => {
+    window.history.pushState({}, "", "/");
+    localStorage.removeItem("assetSend");
+    localStorage.removeItem("assetReceive");
+    const currentPair = createCommitmentPair();
+    renderCreate();
+    await globalSignals.clearSwaps();
+    globalSignals.setOnline(true);
+    globalSignals.setPairs(commitmentSubmarinePairs);
+    globalSignals.setRegularPairs(commitmentSubmarinePairs);
+    signals.setPair(currentPair);
+    signals.setInvoice("");
+    signals.setLnurl("");
+    signals.setBolt12Offer(undefined);
+    signals.setInvoiceValid(false);
+    signals.setInvoiceError(undefined);
+
+    await waitFor(() => {
+        expect(signals.maximum()).toBe(1_000_000);
+    });
+
+    fireEvent.click(await screen.findByTestId("limit-max-button"));
+
+    await waitFor(() => {
+        expect(signals.sendAmount().toNumber()).toBe(1_000_000);
+        expect(signals.amountValid()).toBe(true);
+        expect(signals.receiveAmount().isZero()).toBe(true);
+    });
+
+    let createButton!: HTMLButtonElement;
+    await waitFor(() => {
+        createButton = screen.getByTestId(
+            "create-swap-button",
+        ) as HTMLButtonElement;
+        expect(signals.valid()).toBe(false);
+        expect(createButton.disabled).toBe(false);
+    });
+
+    if (createSwap) {
+        fireEvent.click(createButton);
+    }
+
+    return createButton;
+};
+
+const assertCommitmentSwapCreated = async () => {
+    await waitFor(async () => {
+        const [swap] = await globalSignals.getSwaps();
+        expect(swap).toMatchObject({
+            type: SwapType.Commitment,
+            assetSend: TBTC,
+            assetReceive: BTC,
+            initialReceiveAsset: LN,
+            sourceAsset: commitmentSourceAsset,
+            sourceAmount: "1000000",
+            bridge: {
+                sourceAsset: commitmentSourceAsset,
+                destinationAsset: USDT0,
+                position: SwapPosition.Pre,
+                sourceAmount: "1000000",
+            },
+            dex: {
+                position: SwapPosition.Pre,
+                sourceAmount: "1000000",
+                quoteAmount: 1000000,
+            },
+        });
+        expect(swap).not.toHaveProperty("sendAmount");
+        expect(swap).not.toHaveProperty("receiveAmount");
+    });
 };
 
 describe("Create", () => {
@@ -744,11 +971,7 @@ describe("Create", () => {
         });
     });
 
-    test.each`
-        extrema
-        ${"min"}
-        ${"max"}
-    `("should set $extrema amount on click", async ({ extrema }) => {
+    test("should set max amount on click", async () => {
         render(
             () => (
                 <>
@@ -763,23 +986,114 @@ describe("Create", () => {
 
         globalSignals.setPairs(pairs);
 
-        const amount =
-            extrema === "min" ? signals.minimum() : signals.maximum();
+        await waitFor(() => {
+            expect(signals.maximum()).toBeGreaterThan(0);
+        });
+        const amount = signals.maximum();
 
-        fireEvent.click(await screen.findByTestId(`limit-${extrema}-button`));
+        fireEvent.click(await screen.findByTestId("limit-max-button"));
 
-        expect(signals.sendAmount()).toEqual(BigNumber(amount));
-        expect(signals.receiveAmount()).toEqual(
-            calculateReceiveAmount(
-                BigNumber(amount),
-                signals.boltzFee(),
-                signals.minerFee(),
-                SwapType.Reverse,
-            ),
-        );
+        await waitFor(() => {
+            expect(signals.sendAmount()).toEqual(BigNumber(amount));
+            expect(signals.receiveAmount()).toEqual(
+                calculateReceiveAmount(
+                    BigNumber(amount),
+                    signals.boltzFee(),
+                    signals.minerFee(),
+                    SwapType.Reverse,
+                ),
+            );
+        });
     });
 
-    test("should update the loading target immediately when selecting a limit", async () => {
+    test("should use the swap maximum when connected wallet maximum is zero", async () => {
+        const getConnectedMaximum = vi
+            .spyOn(connectedMaximum, "getConnectedMaximum")
+            .mockResolvedValue(BigNumber(0));
+
+        try {
+            render(
+                () => (
+                    <>
+                        <TestComponent />
+                        <Create />
+                    </>
+                ),
+                {
+                    wrapper: contextWrapper,
+                },
+            );
+
+            globalSignals.setPairs(pairs);
+
+            await waitFor(() => {
+                expect(signals.maximum()).toBeGreaterThan(0);
+            });
+            const amount = signals.maximum();
+
+            fireEvent.click(await screen.findByTestId("limit-max-button"));
+
+            await waitFor(() => {
+                expect(signals.sendAmount()).toEqual(BigNumber(amount));
+            });
+            expect(getConnectedMaximum).toHaveBeenCalled();
+        } finally {
+            getConnectedMaximum.mockRestore();
+        }
+    });
+
+    test("should disable amount inputs while resolving connected wallet maximum", async () => {
+        let resolveMaximum!: (amount: BigNumber) => void;
+        const getConnectedMaximum = vi
+            .spyOn(connectedMaximum, "getConnectedMaximum")
+            .mockReturnValue(
+                new Promise<BigNumber>((resolve) => {
+                    resolveMaximum = resolve;
+                }),
+            );
+
+        try {
+            render(
+                () => (
+                    <>
+                        <TestComponent />
+                        <Create />
+                    </>
+                ),
+                {
+                    wrapper: contextWrapper,
+                },
+            );
+
+            globalSignals.setPairs(pairs);
+
+            await waitFor(() => {
+                expect(signals.maximum()).toBeGreaterThan(0);
+            });
+
+            fireEvent.click(await screen.findByTestId("limit-max-button"));
+
+            const sendAmountInput = screen.getByTestId(
+                "sendAmount",
+            ) as HTMLInputElement;
+            const receiveAmountInput = screen.getByTestId(
+                "receiveAmount",
+            ) as HTMLInputElement;
+            await waitFor(() => {
+                expect(sendAmountInput.disabled).toBe(true);
+                expect(receiveAmountInput.disabled).toBe(true);
+            });
+
+            resolveMaximum(BigNumber(0));
+            await waitFor(() => {
+                expect(sendAmountInput.disabled).toBe(false);
+            });
+        } finally {
+            getConnectedMaximum.mockRestore();
+        }
+    });
+
+    test("should update the loading target when selecting max", async () => {
         vi.useFakeTimers();
 
         try {
@@ -818,7 +1132,8 @@ describe("Create", () => {
             const sendAmountInput = (await screen.findByTestId(
                 "sendAmount",
             )) as HTMLInputElement;
-            fireEvent.click(screen.getByTestId("limit-min-button"));
+            fireEvent.click(screen.getByTestId("limit-max-button"));
+            await Promise.resolve();
 
             expect(signals.amountChanged()).toEqual(Side.Send);
             expect(sendAmountInput.disabled).toEqual(false);
@@ -1024,6 +1339,196 @@ describe("Create", () => {
         });
     });
 
+    test("should explain when changing the amount clears a fixed invoice", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Create />
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+        globalSignals.setOnline(true);
+        globalSignals.setPairs(pairs);
+        setPairAssets(BTC, LN);
+        await waitFor(() => {
+            expect(signals.minimum()).toBeGreaterThan(0);
+        });
+
+        signals.setInvoice(invoice);
+        signals.setInvoiceValid(true);
+
+        fireEvent.input(await screen.findByTestId("sendAmount"), {
+            target: { value: `${signals.minimum()}` },
+        });
+
+        await waitFor(() => {
+            expect(signals.invoice()).toBe("");
+            expect(globalSignals.notification()).toBe(
+                i18n.en.invoice_cleared_amount_changed,
+            );
+            expect(globalSignals.notificationType()).toBe("success");
+        });
+    });
+
+    test("should clear a fixed invoice while validation is pending", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Create />
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+        globalSignals.setOnline(true);
+        globalSignals.setPairs(pairs);
+        setPairAssets(BTC, LN);
+        await waitFor(() => {
+            expect(signals.minimum()).toBeGreaterThan(0);
+        });
+
+        signals.setInvoice(invoice);
+        signals.setInvoiceValid(false);
+
+        fireEvent.input(await screen.findByTestId("sendAmount"), {
+            target: { value: `${signals.minimum()}` },
+        });
+
+        await waitFor(() => {
+            expect(signals.invoice()).toBe("");
+            expect(globalSignals.notification()).toBe(
+                i18n.en.invoice_cleared_amount_changed,
+            );
+            expect(globalSignals.notificationType()).toBe("success");
+        });
+    });
+
+    test("should keep a deferred destination editable after selecting max for a commitment swap", async () => {
+        const restoreMocks = mockCommitmentWalletAndBridge(
+            vi
+                .fn<BridgeDriver["getSourceTokenBalance"]>()
+                .mockResolvedValue(1_000_000n),
+        );
+
+        try {
+            window.history.pushState({}, "", "/");
+            const currentPair = createCommitmentPair();
+            renderCreate();
+            await globalSignals.clearSwaps();
+            globalSignals.setOnline(true);
+            globalSignals.setPairs(commitmentSubmarinePairs);
+            globalSignals.setRegularPairs(commitmentSubmarinePairs);
+            signals.setPair(currentPair);
+
+            await waitFor(() => {
+                expect(signals.maximum()).toBe(1_000_000);
+            });
+
+            signals.setInvoice(bolt12Offer);
+            signals.setBolt12Offer(bolt12Offer);
+            signals.setInvoiceValid(false);
+            signals.setInvoiceError(undefined);
+
+            fireEvent.click(await screen.findByTestId("limit-max-button"));
+
+            await waitFor(() => {
+                const invoiceInput = screen.getByTestId(
+                    "invoice",
+                ) as HTMLInputElement;
+                expect(signals.sendAmount().toNumber()).toBe(1_000_000);
+                expect(invoiceInput).toHaveValue(bolt12Offer);
+                expect(invoiceInput).not.toBeDisabled();
+                expect(
+                    screen.queryByTestId("committed-invoice-row"),
+                ).toBeNull();
+            });
+        } finally {
+            restoreMocks();
+        }
+    });
+
+    test("should create a pre-bridge commitment swap without an invoice after selecting max", async () => {
+        const restoreMocks = mockCommitmentWalletAndBridge(
+            vi
+                .fn<BridgeDriver["getSourceTokenBalance"]>()
+                .mockResolvedValue(1_000_000n),
+        );
+
+        try {
+            await selectMaximumCommitmentSwap();
+            await assertCommitmentSwapCreated();
+        } finally {
+            restoreMocks();
+        }
+    });
+
+    test("should clear committed amounts from the disabled invoice row", async () => {
+        const restoreMocks = mockCommitmentWalletAndBridge(
+            vi
+                .fn<BridgeDriver["getSourceTokenBalance"]>()
+                .mockResolvedValue(1_000_000n),
+        );
+
+        try {
+            await selectMaximumCommitmentSwap({ createSwap: false });
+
+            const invoiceInput = screen.getByTestId(
+                "invoice",
+            ) as HTMLInputElement;
+            expect(invoiceInput).toBeDisabled();
+            expect(invoiceInput.placeholder).toBe(
+                i18n.en.commitment_invoice_deferred,
+            );
+            expect(
+                screen.getByTestId("committed-invoice-row"),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByTestId("committed-invoice-clear"),
+            ).toHaveTextContent(i18n.en.clear_amount);
+
+            fireEvent.click(screen.getByTestId("committed-invoice-clear"));
+
+            await waitFor(() => {
+                expect(signals.sendAmount().isZero()).toBe(true);
+                expect(signals.receiveAmount().isZero()).toBe(true);
+                expect(
+                    screen.queryByTestId("committed-invoice-row"),
+                ).toBeNull();
+                expect(
+                    screen.getByTestId("invoice") as HTMLInputElement,
+                ).not.toBeDisabled();
+            });
+        } finally {
+            restoreMocks();
+        }
+    });
+
+    test("should keep the max commitment flow when a pre-bridge balance lookup fails", async () => {
+        const restoreMocks = mockCommitmentWalletAndBridge(
+            vi
+                .fn<BridgeDriver["getSourceTokenBalance"]>()
+                .mockRejectedValue(new Error("balance unavailable")),
+        );
+
+        try {
+            const createButton = await selectMaximumCommitmentSwap({
+                createSwap: false,
+            });
+
+            expect(signals.sendAmount().toNumber()).toBe(signals.maximum());
+            expect(createButton.disabled).toBe(false);
+            await expect(globalSignals.getSwaps()).resolves.toEqual([]);
+        } finally {
+            restoreMocks();
+        }
+    });
+
     test("should show invalid address error when amount is empty and an invalid address is entered", async () => {
         render(
             () => (
@@ -1094,16 +1599,14 @@ describe("Create", () => {
             expect(signals.minimum()).toBeGreaterThan(0);
         });
 
-        const createButton = (await screen.findByTestId(
-            "create-swap-button",
-        )) as HTMLButtonElement;
         const invoiceInput = (await screen.findByTestId(
             "invoice",
         )) as HTMLInputElement;
+        const createButton = (await screen.findByTestId(
+            "create-swap-button",
+        )) as HTMLButtonElement;
 
-        await waitFor(() => {
-            expect(createButton.textContent).toMatch(/^Minimum amount is /);
-        });
+        expect(createButton.textContent).toMatch(/^Minimum amount is /);
 
         fireEvent.input(invoiceInput, {
             target: { value: "totally invalid invoice" },
@@ -1121,6 +1624,7 @@ describe("Create", () => {
         await waitFor(() => {
             expect(createButton.disabled).toEqual(true);
             expect(createButton.textContent).toMatch(/^Minimum amount is /);
+            expect(screen.getByTestId("invoice")).toBeInTheDocument();
         });
     });
 

--- a/tests/pages/Pay.spec.tsx
+++ b/tests/pages/Pay.spec.tsx
@@ -1,5 +1,5 @@
 import type * as SolidRouter from "@solidjs/router";
-import { useLocation } from "@solidjs/router";
+import { useLocation, useParams } from "@solidjs/router";
 import { render, screen, waitFor } from "@solidjs/testing-library";
 import { OutputType } from "boltz-core";
 import { getLockupTransaction, getSwapStatus } from "boltz-swaps/client";
@@ -94,6 +94,9 @@ vi.mock("../../src/utils/rescue", () => ({
 vi.mock("../../src/components/QrCode", () => ({
     default: () => <div data-testid="mock-qrcode" />,
 }));
+vi.mock("../../src/status/CommitmentCreated", () => ({
+    default: () => <div data-testid="commitment-created" />,
+}));
 
 const mockGetSwapStatus = vi.mocked(getSwapStatus);
 mockGetSwapStatus.mockResolvedValue({
@@ -127,6 +130,7 @@ vi.mock("localforage", () => ({
 }));
 
 const mockUseLocation = vi.mocked(useLocation);
+const mockUseParams = vi.mocked(useParams);
 mockUseLocation.mockReturnValue({
     hash: "",
     key: "",
@@ -162,6 +166,9 @@ describe("Pay", () => {
     beforeEach(() => {
         vi.clearAllMocks();
         window.history.replaceState({}, "", "/");
+        mockUseParams.mockReturnValue({
+            id: "123",
+        } as ReturnType<typeof useParams>);
         swapsGetItemMock.mockResolvedValue({
             id: "123",
             type: SwapType.Chain,
@@ -182,6 +189,24 @@ describe("Pay", () => {
         mockGetSwapStatus.mockResolvedValue({
             status: swapStatusFailed.TransactionRefunded,
         });
+    });
+
+    test("should not show commitment ids in the title", async () => {
+        const commitmentId = "commitment-12345678-1234-1234-1234-123456789abc";
+        mockUseParams.mockReturnValue({
+            id: commitmentId,
+        } as ReturnType<typeof useParams>);
+        swapsGetItemMock.mockResolvedValue({
+            id: commitmentId,
+            type: SwapType.Commitment,
+            assetReceive: BTC,
+            assetSend: LBTC,
+        } as SomeSwap);
+
+        renderPay();
+
+        const title = await screen.findByRole("heading", { level: 2 });
+        expect(title).not.toHaveTextContent(commitmentId);
     });
 
     test("should rename `transaction.refunded` to `swap.waitingForRefund` on ChainSwap", async () => {

--- a/tests/status/CommitmentCreated.spec.ts
+++ b/tests/status/CommitmentCreated.spec.ts
@@ -1,0 +1,153 @@
+import { BigNumber } from "bignumber.js";
+import type { Hash, PublicClient, TransactionReceipt } from "viem";
+
+import {
+    type CommitmentAmounts,
+    calculateCommittedSubmarineAmounts,
+    validateCommitmentInvoice,
+    validateCommitmentInvoiceInput,
+    waitForCommitmentLockupReceipt,
+} from "../../src/status/CommitmentCreated";
+import type Pair from "../../src/utils/Pair";
+import { validateInvoice } from "../../src/utils/validation";
+
+const invoice = "lnbcrt1mock";
+const invoiceSats = 40_720;
+
+vi.mock("../../src/utils/validation", async () => {
+    const actual = await vi.importActual("../../src/utils/validation");
+    const validateInvoice = vi.fn((input: string) => {
+        if (input === invoice) {
+            return invoiceSats;
+        }
+        throw new Error("invalid_invoice");
+    });
+
+    return {
+        ...actual,
+        validateInvoice,
+    };
+});
+
+describe("CommitmentCreated", () => {
+    const bolt12Offer =
+        "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qqtzzqcxyaupvt8xstdrl8vlun9ch2t28a94hq80agu6usv02rxvetfm3c";
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    const commitmentAmountsForInvoice = (
+        invoiceValue: string,
+    ): CommitmentAmounts =>
+        commitmentAmountsForSats(validateInvoice(invoiceValue));
+
+    const commitmentAmountsForSats = (sats: number): CommitmentAmounts => ({
+        pairHash: "pair-hash",
+        sendAmount: BigNumber(sats + 2),
+        receiveAmount: BigNumber(sats),
+    });
+
+    test("uses invoice-derived submarine send amount and fresh pair hash after commitment lockup", async () => {
+        const directPair = {
+            minerFees: 0,
+            calculateReceiveAmount: vi.fn().mockResolvedValue(BigNumber(2614)),
+            calculateSendAmount: vi.fn().mockResolvedValue(BigNumber(2614)),
+            creationData: vi.fn().mockResolvedValue({
+                pairHash: "fresh-pair-hash",
+            }),
+        } as unknown as Pair;
+
+        const amounts = await calculateCommittedSubmarineAmounts(
+            directPair,
+            BigNumber(2615),
+        );
+
+        expect(directPair.calculateReceiveAmount).toHaveBeenCalledWith(
+            BigNumber(2615),
+            0,
+        );
+        expect(directPair.calculateSendAmount).toHaveBeenCalledWith(
+            BigNumber(2614),
+            0,
+        );
+        expect(directPair.creationData).toHaveBeenCalledWith(
+            BigNumber(2614),
+            0,
+        );
+        expect(amounts.sendAmount).toEqual(BigNumber(2614));
+        expect(amounts.receiveAmount).toEqual(BigNumber(2614));
+        expect(amounts.pairHash).toEqual("fresh-pair-hash");
+    });
+
+    test("accepts BIP21 invoices like the create page invoice input", () => {
+        const amounts = commitmentAmountsForInvoice(invoice);
+
+        expect(
+            validateCommitmentInvoice(`bitcoin:?lightning=${invoice}`, amounts),
+        ).toEqual({
+            invoice,
+            sats: validateInvoice(invoice),
+        });
+    });
+
+    test("accepts deferred invoice inputs", () => {
+        vi.mocked(validateInvoice).mockClear();
+
+        expect(
+            validateCommitmentInvoiceInput(
+                `bitcoin:?lno=${bolt12Offer}`,
+                commitmentAmountsForSats(invoiceSats),
+            ),
+        ).toEqual({
+            invoice: bolt12Offer,
+            originalDestination: bolt12Offer,
+            sats: invoiceSats,
+        });
+        expect(validateInvoice).not.toHaveBeenCalled();
+    });
+
+    test("rejects invoices with the wrong amount", () => {
+        expect(() =>
+            validateCommitmentInvoice(`lightning:${invoice}`, {
+                ...commitmentAmountsForInvoice(invoice),
+                receiveAmount: BigNumber(validateInvoice(invoice) + 1),
+            }),
+        ).toThrow("invalid_invoice");
+    });
+
+    test("retries commitment lockup receipt lookup after transient failures", async () => {
+        const hash = `0x${"1".repeat(64)}` as Hash;
+        const receipt = { blockNumber: 123n } as TransactionReceipt;
+        const provider = {
+            waitForTransactionReceipt: vi
+                .fn()
+                .mockRejectedValueOnce(new Error("temporary rpc failure"))
+                .mockResolvedValueOnce(receipt),
+        } as unknown as PublicClient;
+
+        await expect(
+            waitForCommitmentLockupReceipt(provider, hash, 1, 0),
+        ).resolves.toBe(receipt);
+        expect(provider.waitForTransactionReceipt).toHaveBeenCalledTimes(2);
+        expect(provider.waitForTransactionReceipt).toHaveBeenCalledWith({
+            hash,
+            confirmations: 1,
+            timeout: 1,
+        });
+    });
+
+    test("stops commitment lockup receipt lookup after the configured attempts", async () => {
+        const hash = `0x${"1".repeat(64)}` as Hash;
+        const provider = {
+            waitForTransactionReceipt: vi
+                .fn()
+                .mockRejectedValue(new Error("rpc timeout")),
+        } as unknown as PublicClient;
+
+        await expect(
+            waitForCommitmentLockupReceipt(provider, hash, 1, 0, 2),
+        ).rejects.toThrow("rpc timeout");
+        expect(provider.waitForTransactionReceipt).toHaveBeenCalledTimes(2);
+    });
+});

--- a/tests/utils/Pair.spec.ts
+++ b/tests/utils/Pair.spec.ts
@@ -700,7 +700,7 @@ describe("Pair", () => {
             expect.objectContaining({
                 from: LN,
                 to: "USDT0-POL",
-                blockers: ["first hop type is reverse"],
+                blockers: ["first hop is not a chain swap"],
                 route: [
                     {
                         from: LN,

--- a/tests/utils/connectedMaximum.spec.ts
+++ b/tests/utils/connectedMaximum.spec.ts
@@ -1,0 +1,199 @@
+import { BigNumber } from "bignumber.js";
+import {
+    type BridgeDriver,
+    type BridgeRoute,
+    bridgeRegistry,
+} from "boltz-swaps/bridge";
+import { AssetKind, NetworkTransport } from "boltz-swaps/types";
+
+import { config } from "../../src/config";
+import { RBTC, USDT0 } from "../../src/consts/Assets";
+import type { ConnectedWallet, Signer } from "../../src/context/Web3";
+import { getConnectedMaximum } from "../../src/utils/connectedMaximum";
+import { baseAssetAmountToInternal } from "../../src/utils/denomination";
+
+const {
+    createTokenContractMock,
+    estimateFeesPerGasMock,
+    getNativeBalanceMock,
+} = vi.hoisted(() => ({
+    createTokenContractMock: vi.fn(),
+    estimateFeesPerGasMock: vi.fn(),
+    getNativeBalanceMock: vi.fn(),
+}));
+
+vi.mock("boltz-swaps/evm/contracts", async () => {
+    const actual = await vi.importActual("boltz-swaps/evm/contracts");
+
+    return {
+        ...actual,
+        createTokenContract: createTokenContractMock,
+    };
+});
+
+vi.mock("../../src/utils/chains/balance", () => ({
+    getAssetNativeBalance: getNativeBalanceMock,
+}));
+
+vi.mock("../../src/utils/provider", () => ({
+    estimateFeesPerGas: estimateFeesPerGasMock,
+}));
+
+const originalAssets = structuredClone(config.assets ?? {});
+const routedToken = "USDT0-POL";
+
+const signer = {
+    address: "0x0000000000000000000000000000000000000001",
+} as unknown as Signer;
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    config.assets = {
+        ...originalAssets,
+        [RBTC]: {
+            ...originalAssets[RBTC],
+            type: AssetKind.EVMNative,
+            network: {
+                ...originalAssets[RBTC]?.network,
+                nativeCurrency: {
+                    name: RBTC,
+                    symbol: RBTC,
+                    decimals: 18,
+                },
+            },
+        },
+        [routedToken]: {
+            type: AssetKind.ERC20,
+            token: {
+                address: "0x0000000000000000000000000000000000000002",
+                decimals: 6,
+                routeVia: USDT0,
+            },
+        },
+    } as typeof config.assets;
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    config.assets = originalAssets;
+});
+
+describe("baseAssetAmountToInternal", () => {
+    test("converts native asset base units to sats", () => {
+        expect(
+            baseAssetAmountToInternal(RBTC, 1_000_000_000_000_000_000n),
+        ).toEqual(BigNumber(100_000_000));
+    });
+
+    test("keeps routed ERC20 balances in token base units", () => {
+        expect(baseAssetAmountToInternal(routedToken, 1_234_567n)).toEqual(
+            BigNumber(1_234_567),
+        );
+    });
+});
+
+describe("getConnectedMaximum", () => {
+    test("uses the connected bridge wallet for pre-bridge assets", async () => {
+        const route: BridgeRoute = {
+            sourceAsset: routedToken,
+            destinationAsset: USDT0,
+        };
+        const getSourceTokenBalance = vi.fn(() => Promise.resolve(123_456n));
+        const driver = {
+            getTransport: vi.fn(() => NetworkTransport.Solana),
+            getSourceTokenBalance,
+        } as unknown as BridgeDriver;
+        const connectedWallet = {
+            address: "solana-address",
+            transport: NetworkTransport.Solana,
+            rdns: "wallet",
+        } as ConnectedWallet;
+        vi.spyOn(bridgeRegistry, "getPreRoute").mockReturnValue(route);
+        vi.spyOn(bridgeRegistry, "requireDriverForRoute").mockReturnValue(
+            driver,
+        );
+
+        await expect(
+            getConnectedMaximum({
+                fromAsset: routedToken,
+                connectedWallet,
+            }),
+        ).resolves.toEqual(BigNumber(123_456));
+
+        expect(getSourceTokenBalance).toHaveBeenCalledWith(
+            route,
+            "solana-address",
+        );
+    });
+
+    test("returns undefined for pre-bridge assets when the connected wallet transport differs", async () => {
+        const route: BridgeRoute = {
+            sourceAsset: routedToken,
+            destinationAsset: USDT0,
+        };
+        const getSourceTokenBalance = vi.fn();
+        const driver = {
+            getTransport: vi.fn(() => NetworkTransport.Solana),
+            getSourceTokenBalance,
+        } as unknown as BridgeDriver;
+        vi.spyOn(bridgeRegistry, "getPreRoute").mockReturnValue(route);
+        vi.spyOn(bridgeRegistry, "requireDriverForRoute").mockReturnValue(
+            driver,
+        );
+
+        await expect(
+            getConnectedMaximum({
+                fromAsset: routedToken,
+                connectedWallet: {
+                    address: "0xevm",
+                    transport: NetworkTransport.Evm,
+                    rdns: "wallet",
+                },
+            }),
+        ).resolves.toBeUndefined();
+
+        expect(getSourceTokenBalance).not.toHaveBeenCalled();
+    });
+
+    test("subtracts the lockup gas reserve from native EVM balances", async () => {
+        vi.spyOn(bridgeRegistry, "getPreRoute").mockReturnValue(undefined);
+        getNativeBalanceMock.mockResolvedValue(1_000_000_000_000_092_000n);
+        estimateFeesPerGasMock.mockResolvedValue({ gasPrice: 2n });
+
+        await expect(
+            getConnectedMaximum({
+                fromAsset: RBTC,
+                signer,
+            }),
+        ).resolves.toEqual(BigNumber(100_000_000));
+    });
+
+    test("uses ERC20 signer balances directly", async () => {
+        const balanceOf = vi.fn(() => Promise.resolve(654_321n));
+        createTokenContractMock.mockReturnValue({
+            read: {
+                balanceOf,
+            },
+        });
+        vi.spyOn(bridgeRegistry, "getPreRoute").mockReturnValue(undefined);
+
+        await expect(
+            getConnectedMaximum({
+                fromAsset: routedToken,
+                signer,
+            }),
+        ).resolves.toEqual(BigNumber(654_321));
+
+        expect(balanceOf).toHaveBeenCalledWith([signer.address]);
+    });
+
+    test("returns undefined without a compatible bridge wallet or signer", async () => {
+        vi.spyOn(bridgeRegistry, "getPreRoute").mockReturnValue(undefined);
+
+        await expect(
+            getConnectedMaximum({
+                fromAsset: RBTC,
+            }),
+        ).resolves.toBeUndefined();
+    });
+});

--- a/tests/utils/evmLockup.spec.ts
+++ b/tests/utils/evmLockup.spec.ts
@@ -1,0 +1,11 @@
+import { getNativeEvmLockupSpendableBalance } from "../../src/utils/evmLockup";
+
+describe("getNativeEvmLockupSpendableBalance", () => {
+    test("reserves lockup gas from the native balance", () => {
+        expect(getNativeEvmLockupSpendableBalance(100_000n, 2n)).toBe(8_000n);
+    });
+
+    test("returns zero when the gas reserve exceeds the balance", () => {
+        expect(getNativeEvmLockupSpendableBalance(10_000n, 2n)).toBe(0n);
+    });
+});

--- a/tests/utils/invoice.spec.ts
+++ b/tests/utils/invoice.spec.ts
@@ -1,4 +1,5 @@
 import BigNumber from "bignumber.js";
+import { getConfiguredNetwork } from "boltz-swaps/config";
 
 import { BTC, LBTC, LN } from "../../src/consts/Assets";
 import {
@@ -96,16 +97,21 @@ describe("invoice", () => {
     });
 
     describe("isInvoice", () => {
-        test.each`
-            expected | invoice
-            ${true}  | ${"lnbcrt623210n1pj8hfdspp5mhcxq3qgzn779zs0c02na32henclzt55uga68kck6tknyw0y59qsdqqcqzzsxqyz5vqsp54wll9s5jphgcjqzpnamqeszvfdz937pjels2cqr84pltjsqv2asq9qyyssq49028nqec7uz5vk73peg5a4fkxhltw90kkmupfradjp0sus6g5zxs6njedk8ml3qgdls3dfjfvd7z3py5qgst9fnzz5pwcr5564sf6sqtrlfzz"}
-            ${false} | ${"lnbc678450n1pj8hf4kpp5kxh4x93kvxt43q0k0q6t3fp6gfhgusqxsajj6lcexsrg4lzm7rrqdq5g9kxy7fqd9h8vmmfvdjscqzzsxqyz5vqsp5n4rzwr2lzw68082ws4tjjerp2t5eluny75xx54jr530x073tvvzs9qyyssq3f43e2mzqx07zzt529ux480nj00908p3u5qdwhyuk3qrcepaqsjxqjhcnfde4ta74c3dkxkhwscxfhdm5v0y7qh7np22v9xc220taacqjanm3m"}
-        `(
-            "regtest: should detect $invoice as invoice",
-            ({ expected, invoice }) => {
-                expect(isInvoice(invoice)).toEqual(expected);
-            },
-        );
+        const mainnetInvoice =
+            "lnbc678450n1pj8hf4kpp5kxh4x93kvxt43q0k0q6t3fp6gfhgusqxsajj6lcexsrg4lzm7rrqdq5g9kxy7fqd9h8vmmfvdjscqzzsxqyz5vqsp5n4rzwr2lzw68082ws4tjjerp2t5eluny75xx54jr530x073tvvzs9qyyssq3f43e2mzqx07zzt529ux480nj00908p3u5qdwhyuk3qrcepaqsjxqjhcnfde4ta74c3dkxkhwscxfhdm5v0y7qh7np22v9xc220taacqjanm3m";
+        const regtestInvoice =
+            "lnbcrt623210n1pj8hfdspp5mhcxq3qgzn779zs0c02na32henclzt55uga68kck6tknyw0y59qsdqqcqzzsxqyz5vqsp54wll9s5jphgcjqzpnamqeszvfdz937pjels2cqr84pltjsqv2asq9qyyssq49028nqec7uz5vk73peg5a4fkxhltw90kkmupfradjp0sus6g5zxs6njedk8ml3qgdls3dfjfvd7z3py5qgst9fnzz5pwcr5564sf6sqtrlfzz";
+
+        test("accepts bolt11 invoices for the configured network", () => {
+            const network = getConfiguredNetwork();
+            const configuredInvoice =
+                network === "regtest" ? regtestInvoice : mainnetInvoice;
+            const otherNetworkInvoice =
+                network === "regtest" ? mainnetInvoice : regtestInvoice;
+
+            expect(isInvoice(configuredInvoice)).toBe(true);
+            expect(isInvoice(otherNetworkInvoice)).toBe(false);
+        });
     });
 
     describe("getAssetByBip21Prefix", () => {

--- a/tests/utils/rescue.spec.ts
+++ b/tests/utils/rescue.spec.ts
@@ -11,6 +11,7 @@ import {
 import {
     RescueAction,
     createRescueList,
+    hasSwapTimedOut,
     isSwapClaimable,
 } from "../../src/utils/rescue";
 import type {
@@ -223,6 +224,27 @@ describe("rescue", () => {
                 ).toEqual(false);
             },
         );
+    });
+
+    describe("hasSwapTimedOut", () => {
+        test("uses commitment lockup timeout block height", () => {
+            const swap = {
+                type: SwapType.Commitment,
+                timeoutBlockHeight: 123,
+            } as SomeSwap;
+
+            expect(hasSwapTimedOut(swap, 122)).toBe(false);
+            expect(hasSwapTimedOut(swap, 123)).toBe(true);
+        });
+
+        test("does not time out commitments without persisted timeout data", () => {
+            expect(
+                hasSwapTimedOut(
+                    { type: SwapType.Commitment } as SomeSwap,
+                    Number.MAX_SAFE_INTEGER,
+                ),
+            ).toBe(false);
+        });
     });
 
     describe("createRescueList", () => {

--- a/tests/utils/swapCreator.spec.ts
+++ b/tests/utils/swapCreator.spec.ts
@@ -4,6 +4,7 @@ import { BTC, LBTC, LN, USDT0 } from "../../src/consts/Assets";
 import {
     type BridgeDetail,
     type SwapBase,
+    createLocalSwapId,
     getFinalAssetReceive,
     getFinalAssetSend,
     getPostBridgeDetail,
@@ -36,6 +37,11 @@ const makeSwap = (overrides: Partial<SwapBase>): SwapBase =>
         ...overrides,
     }) as SwapBase;
 
+describe("createLocalSwapId", () => {
+    test("creates local-only ids from eight random bytes", () => {
+        expect(createLocalSwapId()).toMatch(/^[0-9a-f]{16}$/);
+    });
+});
 describe("getPreBridgeDetail", () => {
     test("returns the bridge when its position is Pre", () => {
         const bridge = makeBridge("USDT0-ETH", USDT0, SwapPosition.Pre);


### PR DESCRIPTION
Right base branch for https://github.com/BoltzExchange/boltz-web-app/pull/1475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “Set max” now derives the spendable maximum from the connected wallet (including gas-aware native EVM calculations).
  * Pre-route sending/locking can use an exact input source amount for quoting.

* **Improvements**
  * Bridge/swap sending now consistently tracks, passes, and persists the source amount end-to-end.
  * Hop-based lockups support an optional input override.
  * Swap Limits now shows only the maximum selector, with improved enable/loading behavior and a dedicated “max” action.

* **Localization**
  * Removed the “min” translation key.

* **Tests**
  * Updated and added coverage for max-only limits, connected maximum, and native EVM spendable balance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->