### PR TITLE
chore: override mempool api url with env var in github actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,8 @@ jobs:
             - run: bun run prettier:check
 
             - run: bun run test
+              env:
+                  VITE_MEMPOOL_API_URL: ${{ vars.VITE_MEMPOOL_API_URL }}
 
             - run: bun run tsc
 

--- a/packages/boltz-swaps/src/presets/mainnet.ts
+++ b/packages/boltz-swaps/src/presets/mainnet.ts
@@ -41,6 +41,7 @@ export type MainnetAsset =
 
 export type MainnetConfigOverrides = {
     boltzApiUrl?: string;
+    btcMempoolApiUrl?: string;
     cctpApiUrl?: string;
     cctpExplorerUrl?: string;
     layerZeroExplorerUrl?: string;
@@ -107,7 +108,9 @@ const buildCoreAssets = (
                 },
                 {
                     id: Explorer.Mempool,
-                    normal: "https://mempool.space/api",
+                    normal:
+                        overrides.btcMempoolApiUrl ??
+                        "https://mempool.space/api",
                     tor: "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/api",
                 },
             ],

--- a/src/configs/mainnet.ts
+++ b/src/configs/mainnet.ts
@@ -6,6 +6,7 @@ import { usdt0CanSendOverrides } from "src/configs/usdt0";
 const mainnetPreset = buildMainnetConfig({
     rpcUrls: envRpcUrls,
     canSend: usdt0CanSendOverrides,
+    btcMempoolApiUrl: import.meta.env.VITE_MEMPOOL_API_URL || undefined,
 });
 
 const config = {

--- a/src/utils/fiat.ts
+++ b/src/utils/fiat.ts
@@ -203,7 +203,13 @@ export const getBtcPriceMempool = async (currency: Currency) => {
         requestTimeoutDuration,
     );
     try {
-        const response = await fetch(config.rateProviders.Mempool, opts);
+        const mempoolApiUrl = import.meta.env.VITE_MEMPOOL_API_URL;
+        const response = await fetch(
+            mempoolApiUrl
+                ? `${mempoolApiUrl}/v1/prices`
+                : config.rateProviders.Mempool,
+            opts,
+        );
         const data = (await response.json()) as { [currency: string]: number };
         return BigNumber(data[currency]);
     } catch (e) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bitcoin mempool API endpoint is now configurable through environment variables, allowing custom sources while maintaining backward compatibility with the default endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->