### PR TITLE
feat: display network badge on all pages

### DIFF
--- a/src/components/FeeComparisonTable.tsx
+++ b/src/components/FeeComparisonTable.tsx
@@ -3,11 +3,12 @@ import { SwapType } from "boltz-swaps/types";
 import { VsArrowSmallRight } from "solid-icons/vs";
 import { For, Show } from "solid-js";
 
-import { LN, getAssetDisplaySymbol, isBitcoinOnlyPair } from "../consts/Assets";
+import { LN, isBitcoinOnlyPair } from "../consts/Assets";
 import { useGlobalContext } from "../context/Global";
 import ExternalLink from "./ExternalLink";
 import { getFeeHighlightClass } from "./Fees";
 import LoadingSpinner from "./LoadingSpinner";
+import { SwapListAssetIcon } from "./SwapIcons";
 
 type SwapFees = {
     assetSend: string;
@@ -134,16 +135,12 @@ export const FeeComparisonTable = (props: {
                                     onClick={() => props.onSelect(opportunity)}>
                                     <td>
                                         <div class="swaplist-asset">
-                                            <span
-                                                data-asset={getAssetDisplaySymbol(
-                                                    opportunity.assetSend,
-                                                )}
+                                            <SwapListAssetIcon
+                                                asset={opportunity.assetSend}
                                             />
                                             <VsArrowSmallRight />
-                                            <span
-                                                data-asset={getAssetDisplaySymbol(
-                                                    opportunity.assetReceive,
-                                                )}
+                                            <SwapListAssetIcon
+                                                asset={opportunity.assetReceive}
                                             />
                                         </div>
                                     </td>

--- a/src/components/SwapIcons.tsx
+++ b/src/components/SwapIcons.tsx
@@ -2,12 +2,22 @@ import type { RestorableSwap } from "boltz-swaps/client";
 import { VsArrowSmallRight } from "solid-icons/vs";
 import { Show } from "solid-js";
 
-import { getAssetDisplaySymbol } from "../consts/Assets";
+import { getAssetDisplaySymbol, getNetworkBadge } from "../consts/Assets";
+import "../style/asset.scss";
 import {
     type SomeSwap,
     getFinalAssetReceive,
     getFinalAssetSend,
 } from "../utils/swapCreator";
+
+export const SwapListAssetIcon = (props: { asset: string }) => (
+    <span
+        class={`asset asset-${getAssetDisplaySymbol(props.asset)}`}
+        data-asset={getAssetDisplaySymbol(props.asset)}
+        data-network={getNetworkBadge(props.asset)}>
+        <span class="icon" />
+    </span>
+);
 
 export const SwapIcons = (props: { swap: SomeSwap | RestorableSwap }) => {
     return (
@@ -15,24 +25,18 @@ export const SwapIcons = (props: { swap: SomeSwap | RestorableSwap }) => {
             when={"assetSend" in props.swap}
             fallback={
                 <span class="swaplist-asset">
-                    <span
-                        data-asset={getAssetDisplaySymbol(
-                            (props.swap as RestorableSwap).to,
-                        )}
+                    <SwapListAssetIcon
+                        asset={(props.swap as RestorableSwap).to}
                     />
                 </span>
             }>
             <span class="swaplist-asset">
-                <span
-                    data-asset={getAssetDisplaySymbol(
-                        getFinalAssetSend(props.swap as SomeSwap, true),
-                    )}
+                <SwapListAssetIcon
+                    asset={getFinalAssetSend(props.swap as SomeSwap, true)}
                 />
                 <VsArrowSmallRight />
-                <span
-                    data-asset={getAssetDisplaySymbol(
-                        getFinalAssetReceive(props.swap as SomeSwap, true),
-                    )}
+                <SwapListAssetIcon
+                    asset={getFinalAssetReceive(props.swap as SomeSwap, true)}
                 />
             </span>
         </Show>

--- a/src/components/SwapListLogs.tsx
+++ b/src/components/SwapListLogs.tsx
@@ -2,16 +2,10 @@ import { useNavigate } from "@solidjs/router";
 import type { LogRefundData, RskRescueMode } from "boltz-swaps/types";
 import { type Accessor, For, Show, createMemo } from "solid-js";
 
-import { type AssetType, getAssetDisplaySymbol } from "../consts/Assets";
 import { useGlobalContext } from "../context/Global";
 import "../style/swaplist.scss";
 import { cropString } from "../utils/helper";
-
-const AssetIcon = (props: { asset: AssetType }) => (
-    <span class="swaplist-asset swaplist-asset-single">
-        <span data-asset={getAssetDisplaySymbol(props.asset)} />
-    </span>
-);
+import { SwapListAssetIcon } from "./SwapIcons";
 
 const SwapListLogs = (props: {
     swaps: Accessor<LogRefundData[]>;
@@ -42,7 +36,9 @@ const SwapListLogs = (props: {
                             <a class="btn-small hidden-mobile" href="#">
                                 {t("view")}
                             </a>
-                            <AssetIcon asset={swap.asset} />
+                            <span class="swaplist-asset swaplist-asset-single">
+                                <SwapListAssetIcon asset={swap.asset} />
+                            </span>
                             <span class="swaplist-asset-id">
                                 {t("id")}:&nbsp;
                                 <span class="monospace">

--- a/src/pages/external-rescue/Recovery.tsx
+++ b/src/pages/external-rescue/Recovery.tsx
@@ -10,6 +10,7 @@ import {
     USDT0,
     WBTC,
     getAssetDisplaySymbol,
+    getNetworkBadge,
 } from "../../consts/Assets";
 import type { tFn } from "../../context/Global";
 import { RescueAction } from "../../utils/rescue";
@@ -31,28 +32,24 @@ export const recoveryOptions: RecoveryOption[] = [
     {
         asset: TBTC,
         className: "asset-TBTC",
-        network: "arbitrum",
         actions: [RescueAction.Refund, RescueAction.Claim],
         methods: [RecoveryMethod.Key, RecoveryMethod.Wallet],
     },
     {
         asset: WBTC,
         className: "asset-WBTC",
-        network: "arbitrum",
         actions: [RescueAction.Refund, RescueAction.Claim],
         methods: [RecoveryMethod.Key, RecoveryMethod.Wallet],
     },
     {
         asset: USDT0,
         className: "asset-USDT",
-        network: "arbitrum",
         actions: [RescueAction.Refund, RescueAction.Claim],
         methods: [RecoveryMethod.Key, RecoveryMethod.Wallet],
     },
     {
         asset: USDC,
         className: "asset-USDC",
-        network: "arbitrum",
         actions: [RescueAction.Refund, RescueAction.Claim],
         methods: [RecoveryMethod.Key, RecoveryMethod.Wallet],
     },
@@ -116,7 +113,9 @@ const RequirementIcon = (props: {
 );
 
 const AssetIcon = (props: RecoveryOption) => (
-    <span class={`asset ${props.className}`} data-network={props.network}>
+    <span
+        class={`asset ${props.className}`}
+        data-network={getNetworkBadge(props.asset)}>
         <span class="icon" />
     </span>
 );

--- a/src/pages/external-rescue/Results.tsx
+++ b/src/pages/external-rescue/Results.tsx
@@ -7,10 +7,9 @@ import Pagination, {
     desktopItemsPerPage,
     mobileItemsPerPage,
 } from "../../components/Pagination";
-import { SwapIcons } from "../../components/SwapIcons";
+import { SwapIcons, SwapListAssetIcon } from "../../components/SwapIcons";
 import { getSwapListHeight } from "../../components/SwapList";
 import { hiddenInformation } from "../../components/settings/PrivacyMode";
-import { getAssetDisplaySymbol } from "../../consts/Assets";
 import { useGlobalContext } from "../../context/Global";
 import { formatAmount, formatDenomination } from "../../utils/denomination";
 import type { GasAbstractionSweep } from "../../utils/gasAbstractionSweep";
@@ -27,7 +26,7 @@ import type { ExternalRescueSearch } from "./useExternalRescueSearch";
 
 const EvmAssetIcon = (props: { asset: string }) => (
     <span class="swaplist-asset swaplist-asset-single">
-        <span data-asset={getAssetDisplaySymbol(props.asset)} />
+        <SwapListAssetIcon asset={props.asset} />
     </span>
 );
 

--- a/src/pages/external-rescue/types.ts
+++ b/src/pages/external-rescue/types.ts
@@ -28,7 +28,6 @@ export type RecoveryAction = RescueAction.Claim | RescueAction.Refund;
 export type RecoveryOption = {
     asset: string;
     className: string;
-    network?: string;
     actions: RecoveryAction[];
     methods: RecoveryMethod[];
 };

--- a/src/pages/products/Pro.tsx
+++ b/src/pages/products/Pro.tsx
@@ -95,9 +95,15 @@ const Pro = () => {
                         />
                         <div class="caption">
                             <div class="swaplist-asset">
-                                <span data-asset={BTC} />
+                                <span
+                                    class="swaplist-asset-static-icon"
+                                    data-asset={BTC}
+                                />
                                 <VsArrowSmallRight />
-                                <span data-asset={LN} />
+                                <span
+                                    class="swaplist-asset-static-icon"
+                                    data-asset={LN}
+                                />
                             </div>
                             <p data-type="regular">
                                 {t("boltz_pro_regular_fee")}

--- a/src/style/swaplist.scss
+++ b/src/style/swaplist.scss
@@ -52,12 +52,46 @@
     align-items: center;
     margin: 0 10px;
 }
-.swaplist-asset span {
+
+.swaplist-asset .asset,
+.swaplist-asset-static-icon {
+    width: 17px;
+    height: 17px;
+    transform: scale(1.5);
+}
+
+.swaplist-asset .asset {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    line-height: 0;
+}
+
+.swaplist-asset .icon {
+    width: 17px;
+    height: 17px;
+}
+
+.swaplist-asset-static-icon {
     width: 17px;
     height: 17px;
     background-repeat: no-repeat;
     background-size: 100%;
-    transform: scale(1.5);
+}
+
+.swaplist-asset .asset .icon {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+.swaplist-asset [data-network] .icon::after {
+    bottom: -1px;
+    right: -1px;
+    width: 9px;
+    height: 9px;
+    background-size: 9px 9px;
 }
 
 .swaplist-asset-single {
@@ -66,36 +100,36 @@
     margin: 0 10px 0 25px;
 }
 
-.swaplist-asset span[data-asset="LN"] {
+.swaplist-asset-static-icon[data-asset="LN"] {
     background-image: vars.$lightning_icon;
     background-size: 66%;
     background-position: center;
 }
-.swaplist-asset span[data-asset="BTC"] {
+.swaplist-asset-static-icon[data-asset="BTC"] {
     background-image: vars.$bitcoin_icon;
 }
-.swaplist-asset span[data-asset="LBTC"] {
+.swaplist-asset-static-icon[data-asset="LBTC"] {
     background-image: vars.$liquid_icon;
 }
-.swaplist-asset span[data-asset="RBTC"] {
+.swaplist-asset-static-icon[data-asset="RBTC"] {
     background-image: vars.$rootstock_icon;
 }
-.swaplist-asset span[data-asset="TBTC"] {
+.swaplist-asset-static-icon[data-asset="TBTC"] {
     background-image: vars.$tbtc_icon;
     background-size: 80%;
     background-position: center;
 }
-.swaplist-asset span[data-asset="WBTC"] {
+.swaplist-asset-static-icon[data-asset="WBTC"] {
     background-image: vars.$wbtc_icon;
     background-size: 80%;
     background-position: center;
 }
-.swaplist-asset span[data-asset="USDT"] {
+.swaplist-asset-static-icon[data-asset="USDT"] {
     background-image: vars.$usdt0_icon;
     background-size: 76%;
     background-position: center;
 }
-.swaplist-asset span[data-asset="USDC"] {
+.swaplist-asset-static-icon[data-asset="USDC"] {
     background-image: vars.$usdc_icon;
     background-size: 80%;
     background-position: center;


### PR DESCRIPTION
USDT, USDC, TBTC and WBTC network badges were only being displayed during the swap creation.
Added it to the other pages:
<img width="499" height="117" alt="image" src="https://github.com/user-attachments/assets/361e530a-f21e-4097-809f-844886202f3d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded recovery methods for TBTC, WBTC, USDT0, and USDC to include additional recovery options.

* **Improvements**
  * Unified asset icon rendering across swap lists, logs, and external rescue pages for consistent visuals.
  * Refined swap-list icon styling and sizing for better alignment and badge placement.
  * Updated product page chart caption to show explicit asset icons for BTC and LN.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->