### PR TITLE
feat: URL param for rescue backup via mnemonic

### DIFF
--- a/docs/urlParams.md
+++ b/docs/urlParams.md
@@ -94,3 +94,12 @@ from the URL after being applied. Available values are:
 
 - `USD`
 - `EUR`
+
+## Backup
+
+On the swap status page, `backup` selects which rescue key backup method is
+shown when a backup of the rescue key is required. By default the downloadable
+rescue file is offered; the value below opens the 12 word mnemonic backup
+instead. Available value is:
+
+- `mnemonic`

--- a/e2e/rescue/rescueFile.spec.ts
+++ b/e2e/rescue/rescueFile.spec.ts
@@ -76,6 +76,46 @@ test.describe("Rescue file", () => {
         await expect(page.getByTestId("copy_address")).toBeVisible();
     });
 
+    test("should open the mnemonic backup with ?backup=mnemonic", async ({
+        page,
+    }) => {
+        await page.goto("/");
+        await setupSwapAssets(page);
+        await fillSwapDetails(page);
+
+        await expect(page).toHaveURL(/\/swap\/.+/);
+        const swapId = getCurrentSwapId(page);
+        expect(swapId).toBeTruthy();
+
+        // By default the backup flow offers the downloadable rescue file
+        await expect(
+            page.getByRole("heading", {
+                name: dict.en.download_boltz_rescue_key,
+                exact: true,
+            }),
+        ).toBeVisible();
+
+        // Re-opening the same swap with the param forces the 12 word path
+        await page.goto(`/swap/${swapId}?backup=mnemonic`);
+
+        await expect(
+            page.getByRole("heading", {
+                name: dict.en.backup_boltz_rescue_key,
+                exact: true,
+            }),
+        ).toBeVisible();
+        await expect(page.locator(".mnemonic-item")).toHaveCount(12);
+        await expect(
+            page.getByRole("button", { name: dict.en.user_saved_key }),
+        ).toBeVisible();
+        await expect(
+            page.getByRole("heading", {
+                name: dict.en.download_boltz_rescue_key,
+                exact: true,
+            }),
+        ).toBeHidden();
+    });
+
     test("should show entries for swaps with no lockup transaction as disabled", async ({
         page,
     }) => {

--- a/src/consts/Enums.ts
+++ b/src/consts/Enums.ts
@@ -20,6 +20,7 @@ export enum UrlParam {
     Embedded = "embedded",
     Theme = "theme",
     LockOutput = "lockOutput",
+    Backup = "backup",
 }
 
 export enum AssetSelection {

--- a/src/pages/Pay.tsx
+++ b/src/pages/Pay.tsx
@@ -16,7 +16,7 @@ import {
     onCleanup,
 } from "solid-js";
 
-import BackupFlow from "../components/BackupFlow";
+import BackupFlow, { BackupStep } from "../components/BackupFlow";
 import BlockExplorer, {
     BlockExplorerTargetKind,
 } from "../components/BlockExplorer";
@@ -35,6 +35,7 @@ import {
     refundableAssets,
 } from "../consts/Assets";
 import { copyIconTimeout } from "../consts/CopyContent";
+import { UrlParam } from "../consts/Enums";
 import {
     swapStatusFailed,
     swapStatusPending,
@@ -67,10 +68,17 @@ import {
     isRefundableSwapType,
 } from "../utils/rescue";
 import type { ChainSwap, SomeSwap, SubmarineSwap } from "../utils/swapCreator";
+import { getUrlParam } from "../utils/urlParams";
 
 const Pay = () => {
     const params = useParams();
     const navigate = useNavigate();
+
+    const initialBackupStep =
+        getUrlParam(UrlParam.Backup) === BackupStep.Mnemonic
+            ? BackupStep.Mnemonic
+            : undefined;
+
     const location = useLocation<{
         timedOutRefundable?: boolean | undefined;
         waitForSwapTimeout?: boolean | undefined;
@@ -413,7 +421,10 @@ const Pay = () => {
                 when={!backupVerificationRequired()}
                 fallback={
                     <div class="frame">
-                        <BackupFlow resetKey={params.id} />
+                        <BackupFlow
+                            resetKey={params.id}
+                            initialStep={initialBackupStep}
+                        />
                         <SettingsMenu />
                     </div>
                 }>

--- a/tests/pages/Pay.spec.tsx
+++ b/tests/pages/Pay.spec.tsx
@@ -157,6 +157,7 @@ const renderPay = (backupDone: boolean = true) => {
 describe("Pay", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        window.history.replaceState({}, "", "/");
         swapsGetItemMock.mockResolvedValue({
             id: "123",
             type: SwapType.Chain,
@@ -257,6 +258,26 @@ describe("Pay", () => {
 
         await screen.findByText(dict.en.download_boltz_rescue_key);
         expect(mockGetSwapStatus).not.toHaveBeenCalled();
+    });
+
+    test("should start backup flow on mnemonic step when ?backup=mnemonic is set", async () => {
+        window.history.replaceState({}, "", "/?backup=mnemonic");
+
+        renderPay(false);
+
+        await screen.findByText(dict.en.backup_boltz_rescue_key);
+        expect(
+            screen.queryByText(dict.en.download_boltz_rescue_key),
+        ).toBeNull();
+    });
+
+    test("should ignore unknown backup URL param values", async () => {
+        window.history.replaceState({}, "", "/?backup=bogus");
+
+        renderPay(false);
+
+        await screen.findByText(dict.en.download_boltz_rescue_key);
+        expect(screen.queryByText(dict.en.backup_boltz_rescue_key)).toBeNull();
     });
 
     test("should fetch status once backup has been verified", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a `backup` URL parameter to select which rescue key backup method is shown.

* **Documentation**
  * Documented the new `backup` URL query parameter and its supported option(s).

* **Tests**
  * Added unit and end-to-end tests to verify backup-flow routing and correct backup step behavior when `?backup=` is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->