### PR TITLE
Post message notifier for swap completion events

### DIFF
--- a/docs/urlParams.md
+++ b/docs/urlParams.md
@@ -103,3 +103,30 @@ rescue file is offered; the value below opens the 12 word mnemonic backup
 instead. Available value is:
 
 - `mnemonic`
+
+## Parent origin
+
+`parentOrigin` sets the target origin for `postMessage` notifications sent to
+the parent window when the app is embedded as an iframe. It must be used
+alongside `embedded=true`. When a swap reaches a final status (success or
+failure), the app sends a message to `window.parent` with the swap ID and
+status:
+
+```json
+{
+    "type": "boltz-swap-status",
+    "swapId": "abc123",
+    "status": "invoice.settled"
+}
+```
+
+The parent page should listen for these messages and validate the origin:
+
+```javascript
+window.addEventListener("message", (event) => {
+    if (event.origin !== "https://boltz.exchange") return;
+    if (event.data?.type === "boltz-swap-status") {
+        // Handle swap completion
+    }
+});
+```

--- a/e2e/postMessage.spec.ts
+++ b/e2e/postMessage.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "@playwright/test";
+
+import {
+    generateBitcoinBlock,
+    getBitcoinAddress,
+    payInvoiceLnd,
+    waitForNodesToSync,
+} from "./utils";
+
+test.describe("postMessage parent notification", () => {
+    test.beforeEach(async () => {
+        await generateBitcoinBlock();
+        await waitForNodesToSync();
+    });
+
+    test("notifies parent window when reverse swap reaches final status", async ({
+        page,
+    }) => {
+        test.setTimeout(180_000);
+
+        const baseUrl = process.env.CI
+            ? "http://localhost:4173"
+            : "http://localhost:5173";
+
+        await page.route(`${baseUrl}/e2e-parent-test`, async (route) => {
+            await route.fulfill({
+                contentType: "text/html",
+                body: `<!DOCTYPE html>
+<html>
+<head><title>Parent Test Page</title></head>
+<body>
+  <iframe id="boltz-iframe" src="${baseUrl}/?embedded=true&parentOrigin=${baseUrl}" style="width:100%;height:100vh;border:none;"></iframe>
+  <script>
+    window.receivedMessages = [];
+    window.addEventListener('message', function(event) {
+      if (event.origin === '${baseUrl}') {
+        window.receivedMessages.push(event.data);
+      }
+    });
+  </script>
+</body>
+</html>`,
+            });
+        });
+
+        await page.goto(`${baseUrl}/e2e-parent-test`);
+
+        const iframe = page.frameLocator("#boltz-iframe");
+
+        await page.waitForTimeout(2000);
+
+        const receiveAmount = "0.01";
+        const inputReceiveAmount = iframe.locator(
+            "input[data-testid='receiveAmount']",
+        );
+        await inputReceiveAmount.fill(receiveAmount);
+
+        const inputSendAmount = iframe.locator(
+            "input[data-testid='sendAmount']",
+        );
+        await expect(inputSendAmount).not.toHaveValue("");
+
+        const inputOnchainAddress = iframe.locator(
+            "input[data-testid='onchainAddress']",
+        );
+        await inputOnchainAddress.fill(await getBitcoinAddress());
+
+        const buttonCreateSwap = iframe.locator(
+            "button[data-testid='create-swap-button']",
+        );
+        await expect(buttonCreateSwap).toBeEnabled();
+        await buttonCreateSwap.click();
+
+        const payInvoiceTitle = iframe.locator(
+            "h2[data-testid='pay-invoice-title']",
+        );
+        await expect(payInvoiceTitle).toBeVisible({ timeout: 60_000 });
+
+        const spanLightningInvoice = iframe.locator("span[class='btn']");
+        await spanLightningInvoice.click();
+
+        const iframeElement = await page
+            .locator("#boltz-iframe")
+            .elementHandle();
+        const frame = await iframeElement!.contentFrame();
+        const lightningInvoice = await frame!.evaluate(() => {
+            return navigator.clipboard.readText();
+        });
+        expect(lightningInvoice).toBeDefined();
+
+        await payInvoiceLnd(lightningInvoice);
+
+        await expect
+            .poll(
+                async () => {
+                    return await page.evaluate<
+                        Array<{
+                            type: string;
+                            status: string;
+                        }>
+                    >(() => {
+                        const w = window as unknown as {
+                            receivedMessages: Array<{
+                                type: string;
+                                status: string;
+                            }>;
+                        };
+                        return w.receivedMessages.filter(
+                            (m) =>
+                                m.type === "boltz-swap-status" &&
+                                (m.status === "invoice.settled" ||
+                                    m.status === "transaction.claimed"),
+                        );
+                    });
+                },
+                { timeout: 60_000 },
+            )
+            .toHaveLength(1);
+    });
+});

--- a/e2e/postMessage.spec.ts
+++ b/e2e/postMessage.spec.ts
@@ -1,31 +1,31 @@
 import { expect, test } from "@playwright/test";
 
 import {
-  generateBitcoinBlock,
-  getBitcoinAddress,
-  payInvoiceLnd,
-  waitForNodesToSync,
+    generateBitcoinBlock,
+    getBitcoinAddress,
+    payInvoiceLnd,
+    waitForNodesToSync,
 } from "./utils";
 
 test.describe("postMessage parent notification", () => {
-  test.beforeEach(async () => {
-    await generateBitcoinBlock();
-    await waitForNodesToSync();
-  });
+    test.beforeEach(async () => {
+        await generateBitcoinBlock();
+        await waitForNodesToSync();
+    });
 
-  test("notifies parent window when reverse swap reaches final status", async ({
-    page,
-  }) => {
-    test.setTimeout(180_000);
+    test("notifies parent window when reverse swap reaches final status", async ({
+        page,
+    }) => {
+        test.setTimeout(180_000);
 
-    const baseUrl = process.env.CI
-      ? "http://localhost:4173"
-      : "http://localhost:5173";
+        const baseUrl = process.env.CI
+            ? "http://localhost:4173"
+            : "http://localhost:5173";
 
-    await page.route(`${baseUrl}/e2e-parent-test`, async (route) => {
-      await route.fulfill({
-        contentType: "text/html",
-        body: `<!DOCTYPE html>
+        await page.route(`${baseUrl}/e2e-parent-test`, async (route) => {
+            await route.fulfill({
+                contentType: "text/html",
+                body: `<!DOCTYPE html>
 <html>
 <head><title>Parent Test Page</title></head>
 <body>
@@ -40,83 +40,83 @@ test.describe("postMessage parent notification", () => {
   </script>
 </body>
 </html>`,
-      });
+            });
+        });
+
+        await page.goto(`${baseUrl}/e2e-parent-test`);
+
+        const iframe = page.frameLocator("#boltz-iframe");
+
+        await page.waitForTimeout(2000);
+
+        const receiveAmount = "0.01";
+        const inputReceiveAmount = iframe.locator(
+            "input[data-testid='receiveAmount']",
+        );
+        await inputReceiveAmount.fill(receiveAmount);
+
+        const inputSendAmount = iframe.locator(
+            "input[data-testid='sendAmount']",
+        );
+        await expect(inputSendAmount).not.toHaveValue("");
+
+        const inputOnchainAddress = iframe.locator(
+            "input[data-testid='onchainAddress']",
+        );
+        await inputOnchainAddress.fill(await getBitcoinAddress());
+
+        const buttonCreateSwap = iframe.locator(
+            "button[data-testid='create-swap-button']",
+        );
+        await expect(buttonCreateSwap).toBeEnabled();
+        await buttonCreateSwap.click();
+
+        const payInvoiceTitle = iframe.locator(
+            "h2[data-testid='pay-invoice-title']",
+        );
+        await expect(payInvoiceTitle).toBeVisible({ timeout: 60_000 });
+
+        const spanLightningInvoice = iframe.locator("span[class='btn']");
+        await spanLightningInvoice.click();
+
+        const iframeElement = await page
+            .locator("#boltz-iframe")
+            .elementHandle();
+        const frame = await iframeElement!.contentFrame();
+        const lightningInvoice = await frame!.evaluate(() => {
+            return navigator.clipboard.readText();
+        });
+        expect(lightningInvoice).toBeDefined();
+
+        await payInvoiceLnd(lightningInvoice);
+
+        await expect
+            .poll(
+                async () => {
+                    return await page.evaluate<
+                        Array<{
+                            type: string;
+                            status: string;
+                        }>
+                    >(() => {
+                        const w = window as unknown as {
+                            receivedMessages: Array<{
+                                type: string;
+                                status: string;
+                            }>;
+                        };
+                        return w.receivedMessages.filter(
+                            (m) =>
+                                m.type === "boltz-swap-status" &&
+                                (m.status === "invoice.settled" ||
+                                    m.status === "transaction.claimed"),
+                        );
+                    });
+                },
+                { timeout: 60_000 },
+            )
+            .toHaveLength(1);
+        // clear mempool
+        await generateBitcoinBlock();
     });
-
-    await page.goto(`${baseUrl}/e2e-parent-test`);
-
-    const iframe = page.frameLocator("#boltz-iframe");
-
-    await page.waitForTimeout(2000);
-
-    const receiveAmount = "0.01";
-    const inputReceiveAmount = iframe.locator(
-      "input[data-testid='receiveAmount']",
-    );
-    await inputReceiveAmount.fill(receiveAmount);
-
-    const inputSendAmount = iframe.locator(
-      "input[data-testid='sendAmount']",
-    );
-    await expect(inputSendAmount).not.toHaveValue("");
-
-    const inputOnchainAddress = iframe.locator(
-      "input[data-testid='onchainAddress']",
-    );
-    await inputOnchainAddress.fill(await getBitcoinAddress());
-
-    const buttonCreateSwap = iframe.locator(
-      "button[data-testid='create-swap-button']",
-    );
-    await expect(buttonCreateSwap).toBeEnabled();
-    await buttonCreateSwap.click();
-
-    const payInvoiceTitle = iframe.locator(
-      "h2[data-testid='pay-invoice-title']",
-    );
-    await expect(payInvoiceTitle).toBeVisible({ timeout: 60_000 });
-
-    const spanLightningInvoice = iframe.locator("span[class='btn']");
-    await spanLightningInvoice.click();
-
-    const iframeElement = await page
-      .locator("#boltz-iframe")
-      .elementHandle();
-    const frame = await iframeElement!.contentFrame();
-    const lightningInvoice = await frame!.evaluate(() => {
-      return navigator.clipboard.readText();
-    });
-    expect(lightningInvoice).toBeDefined();
-
-    await payInvoiceLnd(lightningInvoice);
-
-    await expect
-      .poll(
-        async () => {
-          return await page.evaluate<
-            Array<{
-              type: string;
-              status: string;
-            }>
-          >(() => {
-            const w = window as unknown as {
-              receivedMessages: Array<{
-                type: string;
-                status: string;
-              }>;
-            };
-            return w.receivedMessages.filter(
-              (m) =>
-                m.type === "boltz-swap-status" &&
-                (m.status === "invoice.settled" ||
-                  m.status === "transaction.claimed"),
-            );
-          });
-        },
-        { timeout: 60_000 },
-      )
-      .toHaveLength(1);
-    // clear mempool
-    await generateBitcoinBlock();
-  });
 });

--- a/e2e/postMessage.spec.ts
+++ b/e2e/postMessage.spec.ts
@@ -1,31 +1,31 @@
 import { expect, test } from "@playwright/test";
 
 import {
-    generateBitcoinBlock,
-    getBitcoinAddress,
-    payInvoiceLnd,
-    waitForNodesToSync,
+  generateBitcoinBlock,
+  getBitcoinAddress,
+  payInvoiceLnd,
+  waitForNodesToSync,
 } from "./utils";
 
 test.describe("postMessage parent notification", () => {
-    test.beforeEach(async () => {
-        await generateBitcoinBlock();
-        await waitForNodesToSync();
-    });
+  test.beforeEach(async () => {
+    await generateBitcoinBlock();
+    await waitForNodesToSync();
+  });
 
-    test("notifies parent window when reverse swap reaches final status", async ({
-        page,
-    }) => {
-        test.setTimeout(180_000);
+  test("notifies parent window when reverse swap reaches final status", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
 
-        const baseUrl = process.env.CI
-            ? "http://localhost:4173"
-            : "http://localhost:5173";
+    const baseUrl = process.env.CI
+      ? "http://localhost:4173"
+      : "http://localhost:5173";
 
-        await page.route(`${baseUrl}/e2e-parent-test`, async (route) => {
-            await route.fulfill({
-                contentType: "text/html",
-                body: `<!DOCTYPE html>
+    await page.route(`${baseUrl}/e2e-parent-test`, async (route) => {
+      await route.fulfill({
+        contentType: "text/html",
+        body: `<!DOCTYPE html>
 <html>
 <head><title>Parent Test Page</title></head>
 <body>
@@ -40,81 +40,83 @@ test.describe("postMessage parent notification", () => {
   </script>
 </body>
 </html>`,
-            });
-        });
-
-        await page.goto(`${baseUrl}/e2e-parent-test`);
-
-        const iframe = page.frameLocator("#boltz-iframe");
-
-        await page.waitForTimeout(2000);
-
-        const receiveAmount = "0.01";
-        const inputReceiveAmount = iframe.locator(
-            "input[data-testid='receiveAmount']",
-        );
-        await inputReceiveAmount.fill(receiveAmount);
-
-        const inputSendAmount = iframe.locator(
-            "input[data-testid='sendAmount']",
-        );
-        await expect(inputSendAmount).not.toHaveValue("");
-
-        const inputOnchainAddress = iframe.locator(
-            "input[data-testid='onchainAddress']",
-        );
-        await inputOnchainAddress.fill(await getBitcoinAddress());
-
-        const buttonCreateSwap = iframe.locator(
-            "button[data-testid='create-swap-button']",
-        );
-        await expect(buttonCreateSwap).toBeEnabled();
-        await buttonCreateSwap.click();
-
-        const payInvoiceTitle = iframe.locator(
-            "h2[data-testid='pay-invoice-title']",
-        );
-        await expect(payInvoiceTitle).toBeVisible({ timeout: 60_000 });
-
-        const spanLightningInvoice = iframe.locator("span[class='btn']");
-        await spanLightningInvoice.click();
-
-        const iframeElement = await page
-            .locator("#boltz-iframe")
-            .elementHandle();
-        const frame = await iframeElement!.contentFrame();
-        const lightningInvoice = await frame!.evaluate(() => {
-            return navigator.clipboard.readText();
-        });
-        expect(lightningInvoice).toBeDefined();
-
-        await payInvoiceLnd(lightningInvoice);
-
-        await expect
-            .poll(
-                async () => {
-                    return await page.evaluate<
-                        Array<{
-                            type: string;
-                            status: string;
-                        }>
-                    >(() => {
-                        const w = window as unknown as {
-                            receivedMessages: Array<{
-                                type: string;
-                                status: string;
-                            }>;
-                        };
-                        return w.receivedMessages.filter(
-                            (m) =>
-                                m.type === "boltz-swap-status" &&
-                                (m.status === "invoice.settled" ||
-                                    m.status === "transaction.claimed"),
-                        );
-                    });
-                },
-                { timeout: 60_000 },
-            )
-            .toHaveLength(1);
+      });
     });
+
+    await page.goto(`${baseUrl}/e2e-parent-test`);
+
+    const iframe = page.frameLocator("#boltz-iframe");
+
+    await page.waitForTimeout(2000);
+
+    const receiveAmount = "0.01";
+    const inputReceiveAmount = iframe.locator(
+      "input[data-testid='receiveAmount']",
+    );
+    await inputReceiveAmount.fill(receiveAmount);
+
+    const inputSendAmount = iframe.locator(
+      "input[data-testid='sendAmount']",
+    );
+    await expect(inputSendAmount).not.toHaveValue("");
+
+    const inputOnchainAddress = iframe.locator(
+      "input[data-testid='onchainAddress']",
+    );
+    await inputOnchainAddress.fill(await getBitcoinAddress());
+
+    const buttonCreateSwap = iframe.locator(
+      "button[data-testid='create-swap-button']",
+    );
+    await expect(buttonCreateSwap).toBeEnabled();
+    await buttonCreateSwap.click();
+
+    const payInvoiceTitle = iframe.locator(
+      "h2[data-testid='pay-invoice-title']",
+    );
+    await expect(payInvoiceTitle).toBeVisible({ timeout: 60_000 });
+
+    const spanLightningInvoice = iframe.locator("span[class='btn']");
+    await spanLightningInvoice.click();
+
+    const iframeElement = await page
+      .locator("#boltz-iframe")
+      .elementHandle();
+    const frame = await iframeElement!.contentFrame();
+    const lightningInvoice = await frame!.evaluate(() => {
+      return navigator.clipboard.readText();
+    });
+    expect(lightningInvoice).toBeDefined();
+
+    await payInvoiceLnd(lightningInvoice);
+
+    await expect
+      .poll(
+        async () => {
+          return await page.evaluate<
+            Array<{
+              type: string;
+              status: string;
+            }>
+          >(() => {
+            const w = window as unknown as {
+              receivedMessages: Array<{
+                type: string;
+                status: string;
+              }>;
+            };
+            return w.receivedMessages.filter(
+              (m) =>
+                m.type === "boltz-swap-status" &&
+                (m.status === "invoice.settled" ||
+                  m.status === "transaction.claimed"),
+            );
+          });
+        },
+        { timeout: 60_000 },
+      )
+      .toHaveLength(1);
+    // clear mempool
+    await generateBitcoinBlock();
+  });
 });

--- a/src/components/SwapChecker.tsx
+++ b/src/components/SwapChecker.tsx
@@ -13,6 +13,7 @@ import { useGlobalContext } from "../context/Global";
 import { type SwapStatusTransaction, usePayContext } from "../context/Pay";
 import { formatError } from "../utils/errors";
 import { getApiUrl } from "../utils/helper";
+import { useParentNotifier } from "../utils/notifyParent";
 import type { SomeSwap } from "../utils/swapCreator";
 
 type SwapStatus = {
@@ -150,6 +151,7 @@ export const SwapChecker = () => {
         shouldIgnoreBackendStatus,
     } = usePayContext();
     const { updateSwapStatus, getSwap, getSwaps } = useGlobalContext();
+    const { notifyParent } = useParentNotifier();
 
     let ws: BoltzWebSocket | undefined = undefined;
 
@@ -197,6 +199,14 @@ export const SwapChecker = () => {
         if (data.status) {
             updatePendingSwaps(currentSwap, data);
             await updateSwapStatus(currentSwap.id, data.status);
+
+            if (swapStatusFinal.includes(data.status)) {
+                notifyParent({
+                    type: "boltz-swap-status",
+                    swapId: currentSwap.id,
+                    status: data.status,
+                });
+            }
         }
     };
 

--- a/src/consts/Enums.ts
+++ b/src/consts/Enums.ts
@@ -21,6 +21,7 @@ export enum UrlParam {
     Theme = "theme",
     LockOutput = "lockOutput",
     Backup = "backup",
+    ParentOrigin = "parentOrigin",
 }
 
 export enum AssetSelection {

--- a/src/context/Create.tsx
+++ b/src/context/Create.tsx
@@ -245,6 +245,7 @@ const handleUrlParams = (
         UrlParam.Embedded,
         UrlParam.Theme,
         UrlParam.LockOutput,
+        UrlParam.ParentOrigin,
     ];
 
     if (

--- a/src/context/Global.tsx
+++ b/src/context/Global.tsx
@@ -102,6 +102,8 @@ export type GlobalContextType = {
     setBitcoinOnly: Setter<boolean>;
     embeddedMode: Accessor<boolean>;
     setEmbeddedMode: Setter<boolean>;
+    parentOrigin: Accessor<string | undefined>;
+    setParentOrigin: Setter<string | undefined>;
     // functions
     t: tFn;
     notify: notifyFn;
@@ -147,6 +149,7 @@ const GlobalContext = createContext<GlobalContextType>();
 const GlobalProvider = (props: {
     children: JSX.Element;
     initialEmbeddedMode?: boolean;
+    initialParentOrigin?: string;
 }) => {
     const [online, setOnline] = createSignal<boolean>(true);
     const [pairs, setPairs] = createSignal<Pairs | undefined>(undefined);
@@ -511,6 +514,10 @@ const GlobalProvider = (props: {
         props.initialEmbeddedMode ?? false,
     );
 
+    const [parentOrigin, setParentOrigin] = createSignal<string | undefined>(
+        props.initialParentOrigin,
+    );
+
     createEffect(() => {
         if (isMobile()) {
             setZeroConf(true);
@@ -594,6 +601,8 @@ const GlobalProvider = (props: {
                 setBitcoinOnly,
                 embeddedMode,
                 setEmbeddedMode,
+                parentOrigin,
+                setParentOrigin,
                 // functions
                 t,
                 notify,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -81,6 +81,7 @@ window.addEventListener("error", resourceErrorHandler, true);
 const urlParams = new URLSearchParams(window.location.search);
 const embeddedParam = urlParams.get("embedded");
 const themeParam = urlParams.get("theme");
+const parentOriginParam = urlParams.get("parentOrigin");
 
 const isEmbedded = embeddedParam === "true";
 const validThemes = ["default", "pro", "light"];
@@ -101,7 +102,9 @@ const App = (props: RouteSectionProps) => {
     const isEmbeddedRoot = () => isEmbedded && location.pathname === "/";
 
     return (
-        <GlobalProvider initialEmbeddedMode={isEmbedded}>
+        <GlobalProvider
+            initialEmbeddedMode={isEmbedded}
+            initialParentOrigin={parentOriginParam ?? undefined}>
             <FiatProvider>
                 <Web3SignerProvider>
                     <WalletConnect />

--- a/src/utils/notifyParent.ts
+++ b/src/utils/notifyParent.ts
@@ -4,25 +4,28 @@ import { useGlobalContext } from "../context/Global";
 import { formatError } from "../utils/errors";
 
 export const useParentNotifier = () => {
-    const { embeddedMode, parentOrigin } = useGlobalContext();
+  const { embeddedMode, parentOrigin } = useGlobalContext();
 
-    const notifyParent = (message: unknown) => {
-        const origin = parentOrigin();
-        if (
-            !embeddedMode() ||
-            !origin ||
-            origin === "*" ||
-            window.parent === window
-        ) {
-            return;
-        }
+  const notifyParent = (
+    message: { type: string } & Record<string, unknown>,
+  ) => {
+    const origin = parentOrigin();
+    if (
+      !embeddedMode() ||
+      !origin ||
+      origin === "*" ||
+      // true means we are not inside an iframe
+      window.parent === window
+    ) {
+      return;
+    }
 
-        try {
-            window.parent.postMessage(message, origin);
-        } catch (e) {
-            log.error("failed to notify parent window", formatError(e));
-        }
-    };
+    try {
+      window.parent.postMessage(message, origin);
+    } catch (e) {
+      log.error("failed to notify parent window", formatError(e));
+    }
+  };
 
-    return { notifyParent };
+  return { notifyParent };
 };

--- a/src/utils/notifyParent.ts
+++ b/src/utils/notifyParent.ts
@@ -1,0 +1,16 @@
+import { useGlobalContext } from "../context/Global";
+
+export const useParentNotifier = () => {
+    const { embeddedMode, parentOrigin } = useGlobalContext();
+
+    const notifyParent = (message: unknown) => {
+        const origin = parentOrigin();
+        if (!embeddedMode() || !origin || window.parent === window) {
+            return;
+        }
+
+        window.parent.postMessage(message, origin);
+    };
+
+    return { notifyParent };
+};

--- a/src/utils/notifyParent.ts
+++ b/src/utils/notifyParent.ts
@@ -4,28 +4,28 @@ import { useGlobalContext } from "../context/Global";
 import { formatError } from "../utils/errors";
 
 export const useParentNotifier = () => {
-  const { embeddedMode, parentOrigin } = useGlobalContext();
+    const { embeddedMode, parentOrigin } = useGlobalContext();
 
-  const notifyParent = (
-    message: { type: string } & Record<string, unknown>,
-  ) => {
-    const origin = parentOrigin();
-    if (
-      !embeddedMode() ||
-      !origin ||
-      origin === "*" ||
-      // true means we are not inside an iframe
-      window.parent === window
-    ) {
-      return;
-    }
+    const notifyParent = (
+        message: { type: string } & Record<string, unknown>,
+    ) => {
+        const origin = parentOrigin();
+        if (
+            !embeddedMode() ||
+            !origin ||
+            origin === "*" ||
+            // true means we are not inside an iframe
+            window.parent === window
+        ) {
+            return;
+        }
 
-    try {
-      window.parent.postMessage(message, origin);
-    } catch (e) {
-      log.error("failed to notify parent window", formatError(e));
-    }
-  };
+        try {
+            window.parent.postMessage(message, origin);
+        } catch (e) {
+            log.error("failed to notify parent window", formatError(e));
+        }
+    };
 
-  return { notifyParent };
+    return { notifyParent };
 };

--- a/src/utils/notifyParent.ts
+++ b/src/utils/notifyParent.ts
@@ -1,15 +1,27 @@
+import log from "loglevel";
+
 import { useGlobalContext } from "../context/Global";
+import { formatError } from "../utils/errors";
 
 export const useParentNotifier = () => {
     const { embeddedMode, parentOrigin } = useGlobalContext();
 
     const notifyParent = (message: unknown) => {
         const origin = parentOrigin();
-        if (!embeddedMode() || !origin || window.parent === window) {
+        if (
+            !embeddedMode() ||
+            !origin ||
+            origin === "*" ||
+            window.parent === window
+        ) {
             return;
         }
 
-        window.parent.postMessage(message, origin);
+        try {
+            window.parent.postMessage(message, origin);
+        } catch (e) {
+            log.error("failed to notify parent window", formatError(e));
+        }
     };
 
     return { notifyParent };

--- a/tests/utils/notifyParent.spec.ts
+++ b/tests/utils/notifyParent.spec.ts
@@ -35,7 +35,7 @@ describe("useParentNotifier", () => {
 
     test("sends postMessage when embedded mode is active with a parent origin", () => {
         const { notifyParent } = useParentNotifier();
-        const message = { type: "test", data: "hello" };
+        const message = { type: "test" as string, data: "hello" };
 
         notifyParent(message);
 

--- a/tests/utils/notifyParent.spec.ts
+++ b/tests/utils/notifyParent.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { useParentNotifier } from "../../src/utils/notifyParent";
+
+const { embeddedModeMock, parentOriginMock } = vi.hoisted(() => ({
+    embeddedModeMock: vi.fn(),
+    parentOriginMock: vi.fn(),
+}));
+
+vi.mock("../../src/context/Global", () => ({
+    useGlobalContext: () => ({
+        embeddedMode: embeddedModeMock,
+        parentOrigin: parentOriginMock,
+    }),
+}));
+
+describe("useParentNotifier", () => {
+    const postMessageMock = vi.fn();
+    const mockParent = { postMessage: postMessageMock } as unknown as Window;
+
+    beforeEach(() => {
+        embeddedModeMock.mockReturnValue(true);
+        parentOriginMock.mockReturnValue("https://example.com");
+        Object.defineProperty(window, "parent", {
+            value: mockParent,
+            writable: true,
+            configurable: true,
+        });
+        postMessageMock.mockClear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test("sends postMessage when embedded mode is active with a parent origin", () => {
+        const { notifyParent } = useParentNotifier();
+        const message = { type: "test", data: "hello" };
+
+        notifyParent(message);
+
+        expect(postMessageMock).toHaveBeenCalledTimes(1);
+        expect(postMessageMock).toHaveBeenCalledWith(
+            message,
+            "https://example.com",
+        );
+    });
+
+    test("does not send postMessage when not in embedded mode", () => {
+        embeddedModeMock.mockReturnValue(false);
+        const { notifyParent } = useParentNotifier();
+
+        notifyParent({ type: "test" });
+
+        expect(postMessageMock).not.toHaveBeenCalled();
+    });
+
+    test("does not send postMessage when parentOrigin is not set", () => {
+        parentOriginMock.mockReturnValue(undefined);
+        const { notifyParent } = useParentNotifier();
+
+        notifyParent({ type: "test" });
+
+        expect(postMessageMock).not.toHaveBeenCalled();
+    });
+
+    test("does not send postMessage when window is not inside an iframe", () => {
+        Object.defineProperty(window, "parent", {
+            value: window,
+            writable: true,
+            configurable: true,
+        });
+        const { notifyParent } = useParentNotifier();
+
+        notifyParent({ type: "test" });
+
+        expect(postMessageMock).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Given the app is embedded as an iFrame (embedded=true) and a parentOrigin=https://example.com is provided allows to send final swap status to the parent as a postMessage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for a parentOrigin URL parameter and sending status notifications to the parent window when a swap reaches a final status.

* **Documentation**
  * Added docs describing parentOrigin, example notification payloads, and guidance for validating incoming postMessage events.

* **Tests**
  * Added unit and end-to-end tests verifying parent-window postMessage notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->