### PR TITLE
chore: bump regtest

### DIFF
--- a/boltz.conf.patch
+++ b/boltz.conf.patch
@@ -29,7 +29,7 @@ index a07ff9d..4d83f3a 100755
 -  swapMaximal = 2880
 -  swapTaproot = 10080
 +  chain = 180
-+  reverse = 180
++  reverse = 240
 +  swapMinimal = 400
 +  swapMaximal = 450
 +  swapTaproot = 1200
@@ -46,7 +46,7 @@ index a07ff9d..4d83f3a 100755
 -  swapMaximal = 2880
 -  swapTaproot = 10080
 +  chain = 100
-+  reverse = 100
++  reverse = 240
 +  swapMinimal = 100
 +  swapMaximal = 200
 +  swapTaproot = 500


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a repository subproject reference to a newer pinned commit.

* **Configuration**
  * Reduced various pair timeout settings (global defaults and per-pair values) to shorter durations, affecting swap/chain timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->