### PR TITLE
feat: add unblinded liquid claim tx link

### DIFF
--- a/e2e/chainSwaps/zeroAmount.spec.ts
+++ b/e2e/chainSwaps/zeroAmount.spec.ts
@@ -50,7 +50,11 @@ test.describe("Chain Swap 0-amount", () => {
 
         const txIdLink = page.getByText("open claim transaction");
 
-        const txId = (await txIdLink.getAttribute("href"))!.split("/").pop();
+        // Liquid claim links carry a "#blinded=" fragment; strip it for the txid
+        const txId = (await txIdLink.getAttribute("href"))!
+            .split("/")
+            .pop()!
+            .split("#")[0];
         expect(txId).toBeDefined();
 
         const txInfo = JSON.parse(await getElementsWalletTx(txId!));

--- a/src/components/BlockExplorer.tsx
+++ b/src/components/BlockExplorer.tsx
@@ -21,13 +21,21 @@ const BlockExplorer = (props: {
         | "claim_tx"
         | "refund_tx"
         | "bridge_status";
+    // Liquid only: "#blinded=" fragment appended to view the tx unblinded
+    blinded?: string;
 }) => {
     const { t } = useGlobalContext();
 
-    const href = () =>
-        props.kind === BlockExplorerTargetKind.Tx
-            ? blockExplorerLink(props.asset, true, props.id, props.explorer)
-            : blockExplorerLink(props.asset, false, props.id);
+    const href = () => {
+        const base =
+            props.kind === BlockExplorerTargetKind.Tx
+                ? blockExplorerLink(props.asset, true, props.id, props.explorer)
+                : blockExplorerLink(props.asset, false, props.id);
+        if (base !== undefined && props.blinded !== undefined) {
+            return `${base}#blinded=${props.blinded}`;
+        }
+        return base;
+    };
 
     const typeLabel = () =>
         props.typeLabel ||

--- a/src/components/BlockExplorerLink.tsx
+++ b/src/components/BlockExplorerLink.tsx
@@ -1,8 +1,17 @@
 import { bridgeRegistry } from "boltz-swaps/bridge";
 import { ExplorerKind, SwapType } from "boltz-swaps/types";
-import { type Accessor, Match, Show, Switch, createMemo } from "solid-js";
+import {
+    type Accessor,
+    Match,
+    Show,
+    Switch,
+    createMemo,
+    createResource,
+} from "solid-js";
 
-import { isEvmAsset } from "../consts/Assets";
+import { LBTC, isEvmAsset } from "../consts/Assets";
+import { useGlobalContext } from "../context/Global";
+import { getClaimTransactionBlindingData } from "../utils/claim";
 import {
     type SomeSwap,
     getPostBridgeDetail,
@@ -20,6 +29,7 @@ const claimTxLabel = (explorer: ExplorerKind | undefined) =>
 const ChainSwapLink = (props: {
     swap: Accessor<SomeSwap>;
     swapStatus: Accessor<string>;
+    blinded: Accessor<string | undefined>;
 }) => {
     const hasBeenClaimed = () => props.swap().claimTx !== undefined;
 
@@ -52,6 +62,7 @@ const ChainSwapLink = (props: {
                     typeLabel={
                         hasBeenClaimed() ? claimTxLabel(explorer()) : undefined
                     }
+                    blinded={props.blinded()}
                 />
             }>
             {/* Showing addresses makes no sense for EVM based chains.
@@ -72,6 +83,8 @@ const BlockExplorerLinkInner = (props: {
     swap: Accessor<SomeSwap>;
     swapStatus: Accessor<string>;
 }) => {
+    const { deriveKey } = useGlobalContext();
+
     const bridgeSendPending = () => {
         const s = props.swap();
         return (
@@ -80,6 +93,17 @@ const BlockExplorerLinkInner = (props: {
             s.commitmentLockupTxHash === undefined
         );
     };
+
+    // Liquid claim transactions are confidential. Build the explorer
+    // "#blinded=" fragment on demand so the claim link reveals its amount.
+    const [blinded] = createResource(
+        () =>
+            props.swap().assetReceive === LBTC &&
+            props.swap().claimTx !== undefined
+                ? props.swap()
+                : undefined,
+        (swap) => getClaimTransactionBlindingData(deriveKey, swap),
+    );
 
     return (
         <Show
@@ -101,6 +125,7 @@ const BlockExplorerLinkInner = (props: {
                     <ChainSwapLink
                         swap={props.swap}
                         swapStatus={props.swapStatus}
+                        blinded={blinded}
                     />
                 }>
                 <Switch>
@@ -128,6 +153,7 @@ const BlockExplorerLinkInner = (props: {
                                 explorer={bridgeRegistry.getExplorerKind(
                                     props.swap().bridge,
                                 )}
+                                blinded={blinded()}
                             />
                         </Show>
                     </Match>

--- a/src/utils/blindedExplorer.ts
+++ b/src/utils/blindedExplorer.ts
@@ -1,0 +1,60 @@
+import { hex } from "@scure/base";
+import log from "loglevel";
+
+import { LBTC } from "../consts/Assets";
+import secp from "../lazy/secp";
+import type { LiquidTransactionOutputWithKey } from "./compat";
+
+// Per blinded output, the Blockstream explorer expects a comma separated tuple
+// in its "#blinded=" URL fragment:
+//   <value_in_satoshis>,<asset>,<value_blinder>,<asset_blinder>
+// The asset id and both blinders are hex encoded in *reverse* byte order, as
+// the explorer reverses each value again before handing it to libwally.
+// See Blockstream/esplora: client/src/lib/libwally.js (parseHex) and
+// client/src/driver/blinding.js (parseBlinders).
+const reverseHex = (bytes: Uint8Array): string =>
+    hex.encode(Uint8Array.from(bytes).reverse());
+
+export type BlindingData = {
+    value: string;
+    asset: Uint8Array;
+    valueBlindingFactor: Uint8Array;
+    assetBlindingFactor: Uint8Array;
+};
+
+export const formatBlindingData = (unblinded: BlindingData): string =>
+    [
+        unblinded.value,
+        reverseHex(unblinded.asset),
+        reverseHex(unblinded.valueBlindingFactor),
+        reverseHex(unblinded.assetBlindingFactor),
+    ].join(",");
+
+// Builds the "#blinded=" fragment for the lockup output spent by a claim
+// transaction. Providing the input blinders is enough: the explorer deduces
+// the (single) blinded claim output from the known input and explicit fee.
+export const getClaimBlindingData = async (
+    asset: string,
+    output: LiquidTransactionOutputWithKey,
+): Promise<string | undefined> => {
+    if (
+        asset !== LBTC ||
+        output.blindingPrivateKey === undefined ||
+        output.rangeProof === undefined ||
+        output.rangeProof.length === 0
+    ) {
+        return undefined;
+    }
+
+    try {
+        const { confidential } = await secp.get();
+        const unblinded = confidential.unblindOutputWithKey(
+            output,
+            output.blindingPrivateKey,
+        );
+        return formatBlindingData(unblinded);
+    } catch (e) {
+        log.warn("Could not build claim unblinding data", e);
+        return undefined;
+    }
+};

--- a/src/utils/claim.ts
+++ b/src/utils/claim.ts
@@ -11,7 +11,9 @@ import {
 import type { LiquidClaimDetails } from "boltz-core/liquid";
 import {
     getChainSwapClaimDetails,
+    getChainSwapTransactions,
     getPartialReverseClaimSignature,
+    getReverseTransaction,
     getSubmarineClaimDetails,
     postChainSwapDetails,
     postSubmarineClaimDetails,
@@ -24,8 +26,10 @@ import log from "loglevel";
 import { type AssetType, LBTC, RBTC, isEvmAsset } from "../consts/Assets";
 import type { deriveKeyFn } from "../context/Global";
 import secp from "../lazy/secp";
+import { getClaimBlindingData } from "./blindedExplorer";
 import { broadcastTransaction } from "./blockchain";
 import {
+    type LiquidTransactionOutputWithKey,
     type TransactionInterface,
     decodeAddress,
     getConstructClaimTransaction,
@@ -43,6 +47,7 @@ import { decodeInvoice } from "./invoice";
 import {
     type ChainSwap,
     type ReverseSwap,
+    type SomeSwap,
     type SubmarineSwap,
     getRelevantAssetForSwap,
 } from "./swapCreator";
@@ -388,6 +393,54 @@ export const findSwapOutputVout = (
 ): number | undefined => {
     const { tweaked } = getClaimTaprootContext(deriveKey, swap);
     return findSwapOutput(tweaked, lockupTx)?.vout;
+};
+
+// Builds the Blockstream "#blinded=" fragment for a Liquid claim transaction on
+// demand: it re-fetches the lockup output the claim spent and unblinds it with
+// the swap's blinding key. Returns undefined for non-Liquid swaps, before the
+// claim exists, or if anything required is missing.
+export const getClaimTransactionBlindingData = async (
+    deriveKey: deriveKeyFn,
+    swap: SomeSwap,
+): Promise<string | undefined> => {
+    if (
+        swap.assetReceive !== LBTC ||
+        swap.claimTx === undefined ||
+        (swap.type !== SwapType.Reverse && swap.type !== SwapType.Chain)
+    ) {
+        return undefined;
+    }
+
+    try {
+        const claimableSwap = swap as ClaimableSwap;
+
+        // The claim spends the server's lockup output: the reverse lockup for
+        // reverse swaps, the server lockup leg for chain swaps. (The chain
+        // userLock is the asset we sent, not the one we claim.)
+        const lockupHex =
+            swap.type === SwapType.Reverse
+                ? (await getReverseTransaction(swap.id)).hex
+                : (await getChainSwapTransactions(swap.id)).serverLock
+                      .transaction.hex;
+        if (lockupHex === undefined) {
+            return undefined;
+        }
+
+        const lockupTx = getTransaction(swap.assetReceive).fromHex(lockupHex);
+        const { tweaked } = getClaimTaprootContext(deriveKey, claimableSwap);
+        const swapOutput = findSwapOutput(tweaked, lockupTx);
+        if (swapOutput === undefined) {
+            return undefined;
+        }
+
+        return getClaimBlindingData(swap.assetReceive, {
+            ...swapOutput,
+            blindingPrivateKey: parseBlindingKey(claimableSwap, false),
+        } as unknown as LiquidTransactionOutputWithKey);
+    } catch (e) {
+        log.warn("Could not build claim unblinding data", e);
+        return undefined;
+    }
 };
 
 export const claim = async <T extends ReverseSwap | ChainSwap>(

--- a/tests/utils/blindedExplorer.spec.ts
+++ b/tests/utils/blindedExplorer.spec.ts
@@ -1,0 +1,91 @@
+import { hex } from "@scure/base";
+import { Buffer } from "buffer";
+import { describe, expect, test } from "vitest";
+
+import { BTC, LBTC } from "../../src/consts/Assets";
+import {
+    formatBlindingData,
+    getClaimBlindingData,
+} from "../../src/utils/blindedExplorer";
+import type { LiquidTransactionOutputWithKey } from "../../src/utils/compat";
+
+const reverse = (b: Uint8Array) => Uint8Array.from(b).reverse();
+
+describe("blindedExplorer", () => {
+    test("formatBlindingData reverses asset and blinders", () => {
+        const asset = Uint8Array.from(Array.from({ length: 32 }, (_, i) => i));
+        const vbf = Uint8Array.from(
+            Array.from({ length: 32 }, (_, i) => i + 32),
+        );
+        const abf = Uint8Array.from(
+            Array.from({ length: 32 }, (_, i) => i + 64),
+        );
+
+        expect(
+            formatBlindingData({
+                value: "12345",
+                asset,
+                valueBlindingFactor: vbf,
+                assetBlindingFactor: abf,
+            }),
+        ).toEqual(
+            [
+                "12345",
+                hex.encode(reverse(asset)),
+                hex.encode(reverse(vbf)),
+                hex.encode(reverse(abf)),
+            ].join(","),
+        );
+    });
+
+    // Fixture using the canonical Liquid L-BTC asset id: liquidjs hands us the
+    // asset in internal byte order, so feeding that in must produce the display
+    // id (networks.liquid.assetHash) back. Pins bytes, field order and
+    // separators against an externally known value.
+    test("formatBlindingData emits the canonical explorer fragment", () => {
+        const assetDisplay =
+            "6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d";
+        const vbfDisplay =
+            "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+        const abfDisplay =
+            "ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100";
+
+        expect(
+            formatBlindingData({
+                value: "100000000",
+                asset: reverse(hex.decode(assetDisplay)),
+                valueBlindingFactor: reverse(hex.decode(vbfDisplay)),
+                assetBlindingFactor: reverse(hex.decode(abfDisplay)),
+            }),
+        ).toEqual(`100000000,${assetDisplay},${vbfDisplay},${abfDisplay}`);
+    });
+
+    const output = {
+        rangeProof: Buffer.alloc(64, 1),
+        blindingPrivateKey: Buffer.alloc(32, 2),
+    } as unknown as LiquidTransactionOutputWithKey;
+
+    test("getClaimBlindingData returns undefined for non-Liquid assets", async () => {
+        await expect(
+            getClaimBlindingData(BTC, output),
+        ).resolves.toBeUndefined();
+    });
+
+    test("getClaimBlindingData returns undefined without a blinding key", async () => {
+        await expect(
+            getClaimBlindingData(LBTC, {
+                ...output,
+                blindingPrivateKey: undefined,
+            } as LiquidTransactionOutputWithKey),
+        ).resolves.toBeUndefined();
+    });
+
+    test("getClaimBlindingData returns undefined without a rangeproof", async () => {
+        await expect(
+            getClaimBlindingData(LBTC, {
+                ...output,
+                rangeProof: Buffer.alloc(0),
+            } as unknown as LiquidTransactionOutputWithKey),
+        ).resolves.toBeUndefined();
+    });
+});


### PR DESCRIPTION
Regulated entities accepting Liquid deposits want to see unblinded transaction proof if a deposit is flagged. Had to do this manually for support tickets recently and it's annoying. So this PR adds an "unblinded" blockstream.info link on swap success pages with an L-BTC claim, so the otherwise-confidential amount (+asset) is visible.

Neat trick that I realized when constructing these manually: we only ship the lockup input's blinders and the explorer then deduces the claim output's (there is only one!) hidden amount itself via confidential-tx conservation (in = out + fee), so we never need any other blinding key.

<img width="673" height="543" alt="image" src="https://github.com/user-attachments/assets/5ecbd767-3010-4a4b-b1d8-2b0101fab3f2" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Block explorer links for Liquid (LBTC) claim transactions now display confidential transaction details, enabling users to view complete unblinded data including transaction values and asset information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->