### PR TITLE
feat: show original source/destination for dex swaps on external rescue

### DIFF
--- a/boltz.conf.patch
+++ b/boltz.conf.patch
@@ -70,3 +70,34 @@ index 63c2646..0c2bb9d 100755
  
  [[currencies]]
  symbol = "BTC"
+diff --git a/regtest/images/boltz-backend/arbitrum.conf b/regtest/images/boltz-backend/arbitrum.conf
+index 82a8593..96f705d 100644
+--- a/regtest/images/boltz-backend/arbitrum.conf
++++ b/regtest/images/boltz-backend/arbitrum.conf
+@@ -29,6 +29,26 @@ swapTypes = ["chain"]
+   swapMaximal = 2880
+   swapTaproot = 10080
+ 
++# Reverse swaps (LN -> TBTC) power the reverse DEX swap e2e coverage.
++[[pairs]]
++base = "TBTC"
++quote = "BTC"
++rate = 1
++fee = 0
++swapInFee = 0
++
++maxSwapAmount = 1_000_000
++minSwapAmount = 2_500
++
++swapTypes = ["reverse"]
++
++  [pairs.timeoutDelta]
++  chain = 1440
++  reverse = 1440
++  swapMinimal = 1440
++  swapMaximal = 2880
++  swapTaproot = 10080
++
+ [arbitrum]
+ networkName = "Arbitrum"
+ providerEndpoint = "ws://anvil-arb:8545"

--- a/e2e/arbitrum/originalAssetExternalRescue.spec.ts
+++ b/e2e/arbitrum/originalAssetExternalRescue.spec.ts
@@ -1,0 +1,570 @@
+import type { Page } from "@playwright/test";
+import { createWalletClient, http, parseUnits } from "viem";
+
+import dict from "../../src/i18n/i18n";
+import { injectWalletProvider } from "../fixtures/ethereum";
+import {
+    execCommand,
+    generateBitcoinBlock,
+    generateLiquidBlock,
+    getLiquidAddress,
+} from "../utils";
+import {
+    type Address,
+    type PublicClient,
+    actionTimeout,
+    approveAndSend,
+    arbitrumE2eChain,
+    arbitrumRpcUrl,
+    clearBrowserStorage,
+    clearEoaDelegation,
+    createSwap,
+    describeArbitrumE2e,
+    expect,
+    fundErc20FromWhale,
+    getArbitrumWalletAddress,
+    getRegtestTokenAddress,
+    getStoredSwap,
+    getTokenBalance,
+    lbtcSendAmount,
+    mineArbitrumBlocks,
+    scanAndSelectExternalResult,
+    stablesFundingSource,
+    test,
+    usdt0EthSendAmount,
+    waitForDexQuote,
+    waitForLockupTxHash,
+    waitForMetadataPatch,
+    waitForStablePairHash,
+} from "./shared";
+
+const originalAssetRescueTimeout = 240_000;
+const usdt0FundingAmount = parseUnits("500", 6);
+const refundWalletIndex = 8;
+const claimWalletIndex = 9;
+// Deliberately different from the wallet used for the rescue so the test
+// proves funds go to the original destination, not the connected signer.
+const claimDestinationIndex = 7;
+const walletlessRefundWalletIndex = 6;
+const walletlessClaimDestinationIndex = 5;
+const precedenceFunderIndex = 4;
+const precedenceConnectedIndex = 3;
+
+const blockCommitmentSubmission = async (page: Page) => {
+    let commitmentPosts = 0;
+
+    await page.route("**/v2/commitment/*", async (route, request) => {
+        const isRefund = new URL(request.url()).pathname.endsWith("/refund");
+        if (request.method() !== "POST" || isRefund) {
+            await route.continue();
+            return;
+        }
+
+        commitmentPosts += 1;
+        await route.fulfill({
+            status: 400,
+            contentType: "application/json",
+            body: JSON.stringify({
+                error: "insufficient amount: 16643 < 16650",
+            }),
+        });
+    });
+
+    return () => commitmentPosts;
+};
+
+const elementsSendToAddressNoRbf = (address: string, amount: string) =>
+    execCommand(
+        `elements-cli-sim-client -named sendtoaddress address="${address}" amount=${amount} replaceable=false`,
+    );
+
+const expectNoConnectWalletButton = async (page: Page) => {
+    await expect(
+        page.getByRole("button", {
+            name: new RegExp(dict.en.connect_wallet, "i"),
+        }),
+    ).toHaveCount(0);
+};
+
+type ArbitrumE2e = {
+    publicClient: PublicClient;
+    rpcUrl: string;
+};
+
+const lockPreDexUsdt0Commitment = async ({
+    arbitrum,
+    page,
+    rescueFilePath,
+    walletIndex,
+}: {
+    arbitrum: ArbitrumE2e;
+    page: Page;
+    rescueFilePath: string;
+    walletIndex: number;
+}) => {
+    const walletAddress = await getArbitrumWalletAddress(
+        arbitrum.publicClient,
+        walletIndex,
+    );
+    const token = getRegtestTokenAddress("USDT0");
+
+    await fundErc20FromWhale({
+        publicClient: arbitrum.publicClient,
+        chain: arbitrumE2eChain,
+        rpcUrl: arbitrum.rpcUrl,
+        token,
+        whale: stablesFundingSource,
+        recipient: walletAddress,
+        amount: usdt0FundingAmount,
+    });
+    await clearEoaDelegation(arbitrum.publicClient, walletAddress);
+    await injectWalletProvider({
+        page,
+        publicClient: arbitrum.publicClient,
+        walletClient: createWalletClient({
+            account: walletAddress,
+            chain: arbitrumE2eChain,
+            transport: http(arbitrumRpcUrl(), { timeout: actionTimeout }),
+        }),
+        chain: arbitrumE2eChain,
+    });
+    const commitmentPosts = await blockCommitmentSubmission(page);
+
+    await waitForDexQuote({
+        tokenIn: getRegtestTokenAddress("USDT0"),
+        tokenOut: getRegtestTokenAddress("TBTC"),
+        amountIn: parseUnits("39.996", 6),
+        label: "USDT0 -> TBTC",
+    });
+    await waitForStablePairHash("chain", "TBTC", "L-BTC");
+
+    const swapId = await createSwap(
+        page,
+        "USDT0",
+        "L-BTC",
+        await getLiquidAddress(),
+        usdt0EthSendAmount,
+        { walletAddress, rescueFilePath },
+    );
+    const metadataPatch = waitForMetadataPatch(page, swapId);
+
+    await approveAndSend(page, walletAddress);
+    await waitForLockupTxHash(page, swapId);
+    await metadataPatch;
+
+    await expect(page.getByText(dict.en.commitment_rejected_line)).toBeVisible({
+        timeout: actionTimeout,
+    });
+    expect(commitmentPosts()).toBeGreaterThan(0);
+
+    const balanceAfterLockup = await getTokenBalance(
+        arbitrum.publicClient,
+        token,
+        walletAddress,
+    );
+
+    await clearBrowserStorage(page);
+
+    return { balanceAfterLockup, swapId, token, walletAddress };
+};
+
+const refundToOriginalUsdt0 = async ({
+    arbitrum,
+    page,
+    token,
+    walletAddress,
+    balanceAfterLockup,
+    walletless = false,
+}: {
+    arbitrum: ArbitrumE2e;
+    page: Page;
+    token: Address;
+    walletAddress: Address;
+    balanceAfterLockup: bigint;
+    walletless?: boolean;
+}) => {
+    await waitForDexQuote({
+        tokenIn: getRegtestTokenAddress("TBTC"),
+        tokenOut: getRegtestTokenAddress("USDT0"),
+        amountIn: parseUnits("0.0007", 18),
+        label: "TBTC -> USDT0 refund",
+    });
+
+    const refundButton = page.getByRole("button", {
+        name: dict.en.refund,
+        exact: true,
+    });
+    await expect(refundButton).toBeVisible({ timeout: actionTimeout });
+    await expect(refundButton).toBeEnabled({ timeout: actionTimeout });
+    if (walletless) {
+        await expectNoConnectWalletButton(page);
+    }
+    await refundButton.click();
+
+    await expect(page.getByText(dict.en.refunded)).toBeVisible({
+        timeout: actionTimeout,
+    });
+    await expect
+        .poll(
+            async () =>
+                await getTokenBalance(
+                    arbitrum.publicClient,
+                    token,
+                    walletAddress,
+                ),
+            {
+                timeout: actionTimeout,
+                message: "external rescue refunds the original USDT0 asset",
+            },
+        )
+        .toBeGreaterThan(balanceAfterLockup);
+};
+
+const lockPostDexUsdt0Swap = async ({
+    page,
+    destinationAddress,
+    rescueFilePath,
+}: {
+    page: Page;
+    destinationAddress: Address;
+    rescueFilePath: string;
+}) => {
+    await waitForDexQuote({
+        tokenIn: getRegtestTokenAddress("TBTC"),
+        tokenOut: getRegtestTokenAddress("USDT0"),
+        amountIn: parseUnits(lbtcSendAmount, 18),
+        label: "TBTC -> USDT0",
+    });
+    await waitForStablePairHash("chain", "L-BTC", "TBTC");
+
+    const swapId = await createSwap(
+        page,
+        "L-BTC",
+        "USDT0",
+        destinationAddress,
+        lbtcSendAmount,
+        { rescueFilePath },
+    );
+
+    const storedSwap = await getStoredSwap(page, swapId);
+    expect(storedSwap?.originalDestination?.toLowerCase()).toBe(
+        destinationAddress.toLowerCase(),
+    );
+
+    await page
+        .locator("div[data-testid='pay-onchain-buttons']")
+        .getByText("address")
+        .click();
+    const lockupAddress = await page.evaluate(() =>
+        navigator.clipboard.readText(),
+    );
+    expect(lockupAddress).toBeDefined();
+
+    await elementsSendToAddressNoRbf(lockupAddress, lbtcSendAmount);
+    await generateLiquidBlock();
+
+    await clearBrowserStorage(page);
+
+    return swapId;
+};
+
+const claimToOriginalDestination = async ({
+    arbitrum,
+    page,
+    token,
+    destinationAddress,
+    destinationBalanceBefore,
+}: {
+    arbitrum: ArbitrumE2e;
+    page: Page;
+    token: Address;
+    destinationAddress: Address;
+    destinationBalanceBefore: bigint;
+}) => {
+    const continueButton = page.getByRole("button", {
+        name: dict.en.continue,
+        exact: true,
+    });
+    await expect(continueButton).toBeVisible({ timeout: actionTimeout });
+    await continueButton.click();
+
+    await expect(page.getByText(dict.en.claimed)).toBeVisible({
+        timeout: actionTimeout,
+    });
+    await mineArbitrumBlocks(arbitrum.publicClient, 1);
+    await expect
+        .poll(
+            async () =>
+                await getTokenBalance(
+                    arbitrum.publicClient,
+                    token,
+                    destinationAddress,
+                ),
+            {
+                timeout: actionTimeout,
+                message:
+                    "external rescue claims USDT0 to the original destination",
+            },
+        )
+        .toBeGreaterThan(destinationBalanceBefore);
+};
+
+describeArbitrumE2e("Arbitrum original-asset external rescue e2e", () => {
+    test.describe.configure({ mode: "serial" });
+
+    test.beforeEach(async () => {
+        await generateBitcoinBlock();
+        await generateLiquidBlock();
+    });
+
+    test("refunds a pre-DEX commitment lockup back to USDT0", async ({
+        arbitrum,
+        page,
+    }, testInfo) => {
+        test.setTimeout(originalAssetRescueTimeout);
+
+        const rescueFilePath = testInfo.outputPath("rescue-file.json");
+        const { balanceAfterLockup, swapId, token, walletAddress } =
+            await lockPreDexUsdt0Commitment({
+                arbitrum,
+                page,
+                rescueFilePath,
+                walletIndex: refundWalletIndex,
+            });
+
+        await scanAndSelectExternalResult({
+            page,
+            swapId,
+            walletAddress,
+            rescueFilePath,
+            action: dict.en.refund,
+            assets: ["USDT", "LBTC"],
+        });
+
+        await refundToOriginalUsdt0({
+            arbitrum,
+            page,
+            token,
+            walletAddress,
+            balanceAfterLockup,
+        });
+    });
+
+    test("refunds a pre-DEX commitment lockup without a connected wallet", async ({
+        arbitrum,
+        page,
+    }, testInfo) => {
+        test.setTimeout(originalAssetRescueTimeout);
+
+        const rescueFilePath = testInfo.outputPath("rescue-file.json");
+        const { balanceAfterLockup, swapId, token, walletAddress } =
+            await lockPreDexUsdt0Commitment({
+                arbitrum,
+                page,
+                rescueFilePath,
+                walletIndex: walletlessRefundWalletIndex,
+            });
+
+        await scanAndSelectExternalResult({
+            page,
+            swapId,
+            rescueFilePath,
+            action: dict.en.refund,
+            assets: ["USDT", "LBTC"],
+        });
+
+        // The destination can only come from the lockup receipt
+        await refundToOriginalUsdt0({
+            arbitrum,
+            page,
+            token,
+            walletAddress,
+            balanceAfterLockup,
+            walletless: true,
+        });
+    });
+
+    test("refunds a pre-DEX lockup to the connected wallet over the original funder", async ({
+        arbitrum,
+        context,
+        page,
+    }, testInfo) => {
+        test.setTimeout(originalAssetRescueTimeout);
+
+        const rescueFilePath = testInfo.outputPath("rescue-file.json");
+        const { balanceAfterLockup, swapId, token, walletAddress } =
+            await lockPreDexUsdt0Commitment({
+                arbitrum,
+                page,
+                rescueFilePath,
+                walletIndex: precedenceFunderIndex,
+            });
+
+        // The injected provider is bound to one account per page, so the
+        // rescue with a different wallet runs on a fresh page
+        const connectedAddress = await getArbitrumWalletAddress(
+            arbitrum.publicClient,
+            precedenceConnectedIndex,
+        );
+        const rescuePage = await context.newPage();
+        await injectWalletProvider({
+            page: rescuePage,
+            publicClient: arbitrum.publicClient,
+            walletClient: createWalletClient({
+                account: connectedAddress,
+                chain: arbitrumE2eChain,
+                transport: http(arbitrumRpcUrl(), { timeout: actionTimeout }),
+            }),
+            chain: arbitrumE2eChain,
+        });
+
+        const connectedBalanceBefore = await getTokenBalance(
+            arbitrum.publicClient,
+            token,
+            connectedAddress,
+        );
+
+        await scanAndSelectExternalResult({
+            page: rescuePage,
+            swapId,
+            walletAddress: connectedAddress,
+            rescueFilePath,
+            action: dict.en.refund,
+            assets: ["USDT", "LBTC"],
+        });
+
+        await refundToOriginalUsdt0({
+            arbitrum,
+            page: rescuePage,
+            token,
+            walletAddress: connectedAddress,
+            balanceAfterLockup: connectedBalanceBefore,
+        });
+
+        // The original funder must not receive the refund
+        expect(
+            await getTokenBalance(arbitrum.publicClient, token, walletAddress),
+        ).toBe(balanceAfterLockup);
+
+        await rescuePage.close();
+    });
+
+    test("claims a post-DEX lockup to the original USDT0 destination", async ({
+        arbitrum,
+        page,
+    }, testInfo) => {
+        test.setTimeout(originalAssetRescueTimeout);
+
+        const rescueFilePath = testInfo.outputPath("rescue-file.json");
+        const walletAddress = await getArbitrumWalletAddress(
+            arbitrum.publicClient,
+            claimWalletIndex,
+        );
+        const destinationAddress = await getArbitrumWalletAddress(
+            arbitrum.publicClient,
+            claimDestinationIndex,
+        );
+        const token = getRegtestTokenAddress("USDT0");
+
+        await clearEoaDelegation(arbitrum.publicClient, walletAddress);
+        await injectWalletProvider({
+            page,
+            publicClient: arbitrum.publicClient,
+            walletClient: createWalletClient({
+                account: walletAddress,
+                chain: arbitrumE2eChain,
+                transport: http(arbitrumRpcUrl(), { timeout: actionTimeout }),
+            }),
+            chain: arbitrumE2eChain,
+        });
+
+        const destinationBalanceBefore = await getTokenBalance(
+            arbitrum.publicClient,
+            token,
+            destinationAddress,
+        );
+        const walletBalanceBefore = await getTokenBalance(
+            arbitrum.publicClient,
+            token,
+            walletAddress,
+        );
+
+        const swapId = await lockPostDexUsdt0Swap({
+            page,
+            destinationAddress,
+            rescueFilePath,
+        });
+
+        await scanAndSelectExternalResult({
+            page,
+            swapId,
+            walletAddress,
+            rescueFilePath,
+            action: dict.en.claim,
+            assets: ["LBTC", "USDT"],
+        });
+
+        await claimToOriginalDestination({
+            arbitrum,
+            page,
+            token,
+            destinationAddress,
+            destinationBalanceBefore,
+        });
+
+        // The connected rescue wallet must not receive the claimed funds.
+        expect(
+            await getTokenBalance(arbitrum.publicClient, token, walletAddress),
+        ).toBe(walletBalanceBefore);
+    });
+
+    test("claims a post-DEX lockup to the original destination without a wallet", async ({
+        arbitrum,
+        page,
+    }, testInfo) => {
+        test.setTimeout(originalAssetRescueTimeout);
+
+        // No wallet provider is injected at all
+        const rescueFilePath = testInfo.outputPath("rescue-file.json");
+        const destinationAddress = await getArbitrumWalletAddress(
+            arbitrum.publicClient,
+            walletlessClaimDestinationIndex,
+        );
+        const token = getRegtestTokenAddress("USDT0");
+
+        const destinationBalanceBefore = await getTokenBalance(
+            arbitrum.publicClient,
+            token,
+            destinationAddress,
+        );
+
+        const swapId = await lockPostDexUsdt0Swap({
+            page,
+            destinationAddress,
+            rescueFilePath,
+        });
+
+        await scanAndSelectExternalResult({
+            page,
+            swapId,
+            rescueFilePath,
+            action: dict.en.claim,
+            assets: ["LBTC", "USDT"],
+        });
+
+        const continueButton = page.getByRole("button", {
+            name: dict.en.continue,
+            exact: true,
+        });
+        await expect(continueButton).toBeVisible({ timeout: actionTimeout });
+        await expectNoConnectWalletButton(page);
+
+        await claimToOriginalDestination({
+            arbitrum,
+            page,
+            token,
+            destinationAddress,
+            destinationBalanceBefore,
+        });
+    });
+});

--- a/e2e/arbitrum/reverseDexExternalRescue.spec.ts
+++ b/e2e/arbitrum/reverseDexExternalRescue.spec.ts
@@ -1,0 +1,199 @@
+import type { Page } from "@playwright/test";
+import fs from "node:fs";
+import { type PublicClient, createWalletClient, http, parseUnits } from "viem";
+
+import { config } from "../../src/config";
+import dict from "../../src/i18n/i18n";
+import { injectWalletProvider } from "../fixtures/ethereum";
+import { generateBitcoinBlock, payInvoiceLndBackground } from "../utils";
+import {
+    actionTimeout,
+    arbitrumE2eChain,
+    arbitrumRpcUrl,
+    clearBrowserStorage,
+    clearEoaDelegation,
+    createSwap,
+    describeArbitrumE2e,
+    expect,
+    getArbitrumWalletAddress,
+    getRegtestTokenAddress,
+    getStoredSwap,
+    getTokenBalance,
+    mineArbitrumBlocks,
+    scanAndSelectExternalResult,
+    test,
+    waitForDexQuote,
+    waitForStablePairHash,
+} from "./shared";
+
+const reverseDexRescueTimeout = 240_000;
+const lnSendAmount = "0.001";
+const rescueWalletIndex = 6;
+// Deliberately different from the wallet used for the rescue so the test
+// proves funds go to the original destination, not the connected signer.
+const destinationIndex = 5;
+
+const getLightningInvoice = async (page: Page) => {
+    const href = await page
+        .locator("a[href^='lightning:']")
+        .first()
+        .getAttribute("href", { timeout: actionTimeout });
+    const invoice = href?.replace(/^lightning:/, "") ?? "";
+    expect(invoice.toLowerCase()).toMatch(/^lnbcrt/);
+    return invoice;
+};
+
+const waitForSwapLockupConfirmed = async (
+    publicClient: PublicClient,
+    swapId: string,
+) => {
+    await expect
+        .poll(
+            async () => {
+                await mineArbitrumBlocks(publicClient, 1);
+                const response = await fetch(
+                    `${config.apiUrl.normal}/v2/swap/${swapId}`,
+                    { signal: AbortSignal.timeout(10_000) },
+                );
+                if (!response.ok) {
+                    return "";
+                }
+
+                const swap = (await response.json()) as { status?: unknown };
+                return typeof swap.status === "string" ? swap.status : "";
+            },
+            {
+                timeout: actionTimeout * 2,
+                intervals: [2_000, 3_000, 5_000],
+                message: "Boltz confirms the reverse swap TBTC lockup",
+            },
+        )
+        .toBe("transaction.confirmed");
+};
+
+describeArbitrumE2e("Arbitrum reverse DEX swap external rescue e2e", () => {
+    test.describe.configure({ mode: "serial" });
+
+    test.beforeEach(async () => {
+        await generateBitcoinBlock();
+    });
+
+    test("claims a reverse DEX swap to the original USDT0 destination", async ({
+        arbitrum,
+        page,
+    }, testInfo) => {
+        test.setTimeout(reverseDexRescueTimeout);
+
+        const rescueFilePath = testInfo.outputPath("rescue-file.json");
+        const walletAddress = await getArbitrumWalletAddress(
+            arbitrum.publicClient,
+            rescueWalletIndex,
+        );
+        const destinationAddress = await getArbitrumWalletAddress(
+            arbitrum.publicClient,
+            destinationIndex,
+        );
+        const token = getRegtestTokenAddress("USDT0");
+
+        await clearEoaDelegation(arbitrum.publicClient, walletAddress);
+        await injectWalletProvider({
+            page,
+            publicClient: arbitrum.publicClient,
+            walletClient: createWalletClient({
+                account: walletAddress,
+                chain: arbitrumE2eChain,
+                transport: http(arbitrumRpcUrl(), { timeout: actionTimeout }),
+            }),
+            chain: arbitrumE2eChain,
+        });
+
+        await waitForDexQuote({
+            tokenIn: getRegtestTokenAddress("TBTC"),
+            tokenOut: getRegtestTokenAddress("USDT0"),
+            amountIn: parseUnits(lnSendAmount, 18),
+            label: "TBTC -> USDT0",
+        });
+        await waitForStablePairHash("reverse", "BTC", "TBTC");
+
+        const destinationBalanceBefore = await getTokenBalance(
+            arbitrum.publicClient,
+            token,
+            destinationAddress,
+        );
+        const walletBalanceBefore = await getTokenBalance(
+            arbitrum.publicClient,
+            token,
+            walletAddress,
+        );
+
+        const swapId = await createSwap(
+            page,
+            "LN",
+            "USDT0",
+            destinationAddress,
+            lnSendAmount,
+            { rescueFilePath },
+        );
+
+        const storedSwap = await getStoredSwap(page, swapId);
+        expect(storedSwap?.originalDestination?.toLowerCase()).toBe(
+            destinationAddress.toLowerCase(),
+        );
+
+        if (!fs.existsSync(rescueFilePath)) {
+            const storedRescueFile = await page.evaluate(() =>
+                window.localStorage.getItem("rescueFile"),
+            );
+            expect(storedRescueFile).toBeTruthy();
+            fs.writeFileSync(rescueFilePath, storedRescueFile!);
+        }
+
+        const invoice = await getLightningInvoice(page);
+
+        await clearBrowserStorage(page);
+        await page.goto("about:blank");
+
+        payInvoiceLndBackground(invoice);
+        await waitForSwapLockupConfirmed(arbitrum.publicClient, swapId);
+
+        await scanAndSelectExternalResult({
+            page,
+            swapId,
+            walletAddress,
+            rescueFilePath,
+            action: dict.en.claim,
+            assets: ["LN", "USDT"],
+        });
+
+        const continueButton = page.getByRole("button", {
+            name: dict.en.continue,
+            exact: true,
+        });
+        await expect(continueButton).toBeVisible({ timeout: actionTimeout });
+        await continueButton.click();
+
+        await expect(page.getByText(dict.en.claimed)).toBeVisible({
+            timeout: actionTimeout,
+        });
+        await mineArbitrumBlocks(arbitrum.publicClient, 1);
+        await expect
+            .poll(
+                async () =>
+                    await getTokenBalance(
+                        arbitrum.publicClient,
+                        token,
+                        destinationAddress,
+                    ),
+                {
+                    timeout: actionTimeout,
+                    message:
+                        "external rescue claims USDT0 to the original destination",
+                },
+            )
+            .toBeGreaterThan(destinationBalanceBefore);
+
+        expect(
+            await getTokenBalance(arbitrum.publicClient, token, walletAddress),
+        ).toBe(walletBalanceBefore);
+    });
+});

--- a/e2e/arbitrum/shared.ts
+++ b/e2e/arbitrum/shared.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from "@playwright/test";
+import type { Locator, Page, Response } from "@playwright/test";
 import { oftAbi } from "boltz-swaps/oft";
 import {
     type Address,
@@ -212,6 +212,7 @@ type StoredSwap = {
     bridge?: { txHash?: Hex };
     lockupTx?: Hex;
     commitmentLockupTxHash?: Hex;
+    originalDestination?: string;
 };
 
 export const getStoredSwap = async (
@@ -690,6 +691,226 @@ export const expectOftSendTx = async (
     expect(isAddressEqual(sent.args.fromAddress, walletAddress)).toBe(true);
     expect(sent.args.amountSentLD).toBeGreaterThan(0n);
     expect(sent.args.amountReceivedLD).toBeGreaterThan(0n);
+};
+
+export const getArbitrumWalletAddress = async (
+    pageClient: PublicClient,
+    index: number,
+): Promise<Address> => {
+    const accounts = (await pageClient.request({
+        method: "eth_accounts",
+        params: [],
+    } as never)) as Address[];
+    const walletAddress = accounts[index];
+    if (walletAddress === undefined) {
+        throw new Error(`Arbitrum account #${index} is not available in Anvil`);
+    }
+
+    return getAddress(walletAddress);
+};
+
+export const clearBrowserStorage = async (page: Page) => {
+    await page.evaluate(async () => {
+        window.localStorage.clear();
+
+        await Promise.all(
+            ["swaps", "lastUsedEvmIndex"].map(
+                (name) =>
+                    new Promise<void>((resolve, reject) => {
+                        const request = indexedDB.deleteDatabase(name);
+                        request.onsuccess = () => resolve();
+                        request.onerror = () => reject(request.error);
+                        request.onblocked = () =>
+                            reject(new Error(`deleting ${name} was blocked`));
+                    }),
+            ),
+        );
+    });
+};
+
+const isMetadataPatchResponse = (response: Response, swapId: string) => {
+    const request = response.request();
+    if (request.method() !== "PATCH") {
+        return false;
+    }
+
+    return new URL(response.url()).pathname === `/v2/swap/${swapId}/metadata`;
+};
+
+export const waitForMetadataPatch = async (page: Page, swapId: string) => {
+    const response = await page.waitForResponse(
+        (res) => isMetadataPatchResponse(res, swapId),
+        { timeout: actionTimeout },
+    );
+
+    expect(response.ok()).toBe(true);
+    const body = response.request().postDataJSON() as { metadata?: unknown };
+    expect(typeof body.metadata).toBe("string");
+    expect(body.metadata).toMatch(/^[0-9a-f]+$/);
+
+    return response;
+};
+
+const hasRestoredMetadataForSwap = (body: unknown, swapId: string) =>
+    Array.isArray(body) &&
+    body.some((value) => {
+        if (typeof value !== "object" || value === null) {
+            return false;
+        }
+
+        const swap = value as { id?: unknown; metadata?: unknown };
+        return (
+            swap.id === swapId &&
+            typeof swap.metadata === "string" &&
+            /^[0-9a-f]+$/.test(swap.metadata)
+        );
+    });
+
+export const waitForMetadataRestore = async (page: Page, swapId: string) => {
+    await page.waitForResponse(
+        async (response) => {
+            const request = response.request();
+            if (
+                request.method() !== "POST" ||
+                new URL(response.url()).pathname !== "/v2/swap/restore" ||
+                !response.ok()
+            ) {
+                return false;
+            }
+
+            return hasRestoredMetadataForSwap(
+                await response.json().catch(() => undefined),
+                swapId,
+            );
+        },
+        { timeout: actionTimeout },
+    );
+};
+
+const fetchPairHash = async (
+    endpoint: "chain" | "reverse",
+    from: string,
+    to: string,
+) => {
+    const response = await fetch(
+        `${config.apiUrl.normal}/v2/swap/${endpoint}`,
+        {
+            signal: AbortSignal.timeout(10_000),
+        },
+    );
+    if (!response.ok) {
+        return undefined;
+    }
+
+    const pairs = (await response.json()) as Record<
+        string,
+        Record<string, { hash?: unknown }>
+    >;
+    const hash = pairs[from]?.[to]?.hash;
+    return typeof hash === "string" ? hash : undefined;
+};
+
+export const waitForStablePairHash = async (
+    endpoint: "chain" | "reverse",
+    from: string,
+    to: string,
+) => {
+    let previous: string | undefined;
+    let stableReads = 0;
+
+    await expect
+        .poll(
+            async () => {
+                const hash = await fetchPairHash(endpoint, from, to).catch(
+                    () => undefined,
+                );
+                if (hash === undefined) {
+                    previous = undefined;
+                    stableReads = 0;
+                    return "";
+                }
+
+                if (hash === previous) {
+                    stableReads += 1;
+                } else {
+                    previous = hash;
+                    stableReads = 0;
+                }
+
+                return stableReads >= 2 ? hash : "";
+            },
+            {
+                timeout: actionTimeout,
+                intervals: [1_000, 2_000, 2_000],
+                message: `${from} -> ${to} ${endpoint} pair hash is stable`,
+            },
+        )
+        .toMatch(/^[0-9a-f]{64}$/);
+};
+
+export const expectAssetPair = async (
+    item: Locator,
+    from: string,
+    to: string,
+) => {
+    await expect(item.locator(`.asset[data-asset='${from}']`)).toBeVisible();
+    await expect(item.locator(`.asset[data-asset='${to}']`)).toBeVisible();
+};
+
+export const startExternalRescue = async (page: Page) => {
+    await page.goto("/rescue");
+    await page
+        .getByRole("button", { name: dict.en.rescue_external_swap })
+        .click();
+};
+
+export const scanAndSelectExternalResult = async ({
+    page,
+    swapId,
+    walletAddress,
+    rescueFilePath,
+    action,
+    assets,
+}: {
+    page: Page;
+    swapId: string;
+    // Omitted: the scan runs with only the rescue key
+    walletAddress?: Address;
+    rescueFilePath: string;
+    action: string;
+    assets: [string, string];
+}) => {
+    const resultItems = page.locator(".rescue-external-results .swaplist-item");
+    const actionItem = resultItems
+        .filter({
+            has: page.getByRole("link", {
+                name: action,
+                exact: true,
+            }),
+        })
+        .first();
+
+    await expect(async () => {
+        await startExternalRescue(page);
+        await page.getByTestId("refundUpload").setInputFiles(rescueFilePath);
+        if (walletAddress !== undefined) {
+            await connectWallet(page, walletAddress);
+        }
+        const metadataRestore = waitForMetadataRestore(page, swapId);
+        await page
+            .getByRole("button", { name: dict.en.rescue, exact: true })
+            .click();
+        await metadataRestore;
+
+        await expect(actionItem).toBeVisible({ timeout: actionTimeout });
+        await expect(resultItems).toHaveCount(1);
+        await expectAssetPair(actionItem, ...assets);
+    }).toPass({
+        timeout: actionTimeout * 2,
+        intervals: [2_000, 5_000, 10_000],
+    });
+
+    await actionItem.click();
 };
 
 export type { Address, Hex, PublicClient, WalletClient };

--- a/e2e/submarineSwap.spec.ts
+++ b/e2e/submarineSwap.spec.ts
@@ -1,7 +1,9 @@
 import { expect, test } from "@playwright/test";
 import BigNumber from "bignumber.js";
+import { SwapType } from "boltz-swaps/types";
 
-import { btcToSat } from "../src/utils/denomination";
+import { calculateSendAmount } from "../src/utils/calculate";
+import { btcToSat, satToBtc } from "../src/utils/denomination";
 import {
     addReferral,
     bitcoinSendToAddress,
@@ -11,6 +13,7 @@ import {
     generateInvoiceWithRoutingHint,
     getLiquidAddress,
     getReferrals,
+    getSubmarinePairFees,
     lookupInvoiceLnd,
     setReferral,
     verifyRescueFile,
@@ -24,6 +27,11 @@ test.describe("Submarine swap", () => {
     });
 
     test("Submarine swap BTC/BTC", async ({ page }) => {
+        // The miner fee component of the quote depends on the backend's
+        // current fee estimate, so the expectation must be derived from the
+        // live pair data rather than hardcoded.
+        const fees = await getSubmarinePairFees("BTC", "BTC");
+
         await page.goto("/");
 
         const divFlipAssets = page.locator("#flip-assets");
@@ -35,10 +43,18 @@ test.describe("Submarine swap", () => {
         );
         await inputReceiveAmount.fill(receiveAmount);
 
+        const expectedSendAmount = satToBtc(
+            calculateSendAmount(
+                btcToSat(BigNumber(receiveAmount)),
+                fees.percentage,
+                fees.minerFees,
+                SwapType.Submarine,
+            ),
+        ).toString();
         const inputSendAmount = page.locator("input[data-testid='sendAmount']");
         const sendAmount = await expectApproxAmount(
             inputSendAmount,
-            "0.01001031",
+            expectedSendAmount,
         );
 
         const invoiceInput = page.locator("input[data-testid='invoice']");

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -435,6 +435,18 @@ export const generateInvoiceWithRoutingHint = async (
     return swapRes.invoice as string;
 };
 
+export const getSubmarinePairFees = async (
+    from: string,
+    to: string,
+): Promise<{ percentage: number; minerFees: number }> => {
+    const res = await axios.get(`${config.apiUrl!.normal}/v2/swap/submarine`);
+    const fees = res.data?.[from]?.[to]?.fees;
+    if (fees === undefined) {
+        throw new Error(`no submarine pair fees for ${from} -> ${to}`);
+    }
+    return fees as { percentage: number; minerFees: number };
+};
+
 export const fetchBip21Invoice = async (invoice: string) => {
     const requestContext = await request.newContext();
 

--- a/packages/boltz-swaps/src/client.ts
+++ b/packages/boltz-swaps/src/client.ts
@@ -183,6 +183,14 @@ type RestorableSwapDetails = {
 
 export type EmptyResponse = Record<string, never>;
 
+type RestorableEvmClaimDetails = {
+    contractAddress: string;
+    claimAddress: string;
+    transaction?: { id: string };
+    amount?: number;
+    timeoutBlockHeight: number;
+};
+
 export type RestorableSwap = {
     id: string;
     type: SwapType;
@@ -190,9 +198,11 @@ export type RestorableSwap = {
     from: string;
     to: string;
     createdAt: number;
+    preimageHash?: string;
     claimPrivateKey?: string;
     claimDetails?: RestorableSwapDetails;
     refundDetails?: RestorableSwapDetails;
+    evmClaimDetails?: RestorableEvmClaimDetails;
     metadata?: string;
 };
 

--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -602,7 +602,14 @@ const CreateButton = () => {
                           )
                         : undefined;
 
-                const payload = buildSwapMetadataPayload({ dex, bridge });
+                const payload = buildSwapMetadataPayload({
+                    dex,
+                    bridge,
+                    originalDestination:
+                        dex !== undefined || bridge !== undefined
+                            ? getOriginalDestination()
+                            : undefined,
+                });
                 const mnemonic = rescueFile()?.mnemonic;
                 if (payload === undefined || mnemonic === undefined) {
                     return undefined;

--- a/src/components/RefundButton.tsx
+++ b/src/components/RefundButton.tsx
@@ -343,7 +343,8 @@ const buildRefundFollowUpCalls = async (
             );
         }
 
-        resolvedDestination = await resolveBridgeSender(bridge);
+        resolvedDestination =
+            bridge.refundAddress ?? (await resolveBridgeSender(bridge));
     }
 
     if (dexDetails === undefined || dexDetails.position !== SwapPosition.Pre) {

--- a/src/context/Rescue.tsx
+++ b/src/context/Rescue.tsx
@@ -1,5 +1,4 @@
 import type { RestorableSwap } from "boltz-swaps/client";
-import type { LogRefundData } from "boltz-swaps/types";
 import {
     type Accessor,
     type JSX,
@@ -10,6 +9,7 @@ import {
 } from "solid-js";
 
 import type { AssetType } from "../consts/Assets";
+import type { EvmRescueResult } from "../pages/external-rescue/types";
 import { type ECKeys, ECPair } from "../utils/ecpair";
 import { type RescueFile, deriveKey } from "../utils/rescueFile";
 
@@ -23,8 +23,8 @@ export type RescueContextType = {
     rescuableSwaps: Accessor<RestorableSwap[]>;
     setRescuableSwaps: Setter<RestorableSwap[]>;
 
-    evmRescuableSwaps: Accessor<LogRefundData[]>;
-    setEvmRescuableSwaps: Setter<LogRefundData[]>;
+    evmRescuableSwaps: Accessor<EvmRescueResult[]>;
+    setEvmRescuableSwaps: Setter<EvmRescueResult[]>;
 
     validRescueKey: Accessor<boolean>;
     setValidRescueKey: Setter<boolean>;
@@ -42,7 +42,7 @@ export const RescueProvider = (props: { children: JSX.Element }) => {
         [],
     );
     const [evmRescuableSwaps, setEvmRescuableSwaps] = createSignal<
-        LogRefundData[]
+        EvmRescueResult[]
     >([]);
     const [validRescueKey, setValidRescueKey] = createSignal<boolean>(false);
 

--- a/src/pages/RescueEvm.tsx
+++ b/src/pages/RescueEvm.tsx
@@ -1,25 +1,34 @@
 import { useNavigate, useParams } from "@solidjs/router";
 import BigNumber from "bignumber.js";
-import { assetAmountToSats, createAssetProvider } from "boltz-swaps/evm";
+import { quoteDexAmountIn } from "boltz-swaps/client";
+import {
+    assetAmountToSats,
+    createAssetProvider,
+    satsToAssetAmount,
+} from "boltz-swaps/evm";
 import { isEmptyPreimageHash } from "boltz-swaps/evm/commitment";
 import {
     getLogsFromReceipt,
     getTimelockBlockNumber,
 } from "boltz-swaps/evm/logs";
-import { AssetKind, RskRescueMode } from "boltz-swaps/types";
+import { getSignerForGasAbstraction } from "boltz-swaps/evm/transaction";
+import { AssetKind, RskRescueMode, SwapPosition } from "boltz-swaps/types";
 import log from "loglevel";
 import {
     Match,
     type Setter,
     Show,
     Switch,
+    createMemo,
     createResource,
     createSignal,
 } from "solid-js";
+import { getAddress } from "viem";
 
 import BlockExplorer, {
     BlockExplorerTargetKind,
 } from "../components/BlockExplorer";
+import ConnectWallet from "../components/ConnectWallet";
 import ContractTransaction from "../components/ContractTransaction";
 import LoadingSpinner from "../components/LoadingSpinner";
 import { RefundEvm as RefundButton } from "../components/RefundButton";
@@ -36,16 +45,119 @@ import { useGlobalContext } from "../context/Global";
 import { useRescueContext } from "../context/Rescue";
 import { useWeb3Signer } from "../context/Web3";
 import { GasNeededToClaim } from "../rif/Signer";
+import {
+    claimHops,
+    getClaimAssetForRoute,
+} from "../status/TransactionConfirmed";
 import { formatAmount, formatDenomination } from "../utils/denomination";
 import { formatError } from "../utils/errors";
+import { resolveLockupTokenFunder } from "../utils/evmLockup";
 import { claimAsset } from "../utils/evmTransaction";
 import { cropString } from "../utils/helper";
 import { estimateFeesPerGas } from "../utils/provider";
+import { fetchDexQuote } from "../utils/quoter";
 import { getTimeoutEta } from "../utils/rescue";
 import { GasAbstractionType } from "../utils/swapCreator";
+import { getEvmDisplayAssets } from "./external-rescue/Results";
+import { normalizeEvmId } from "./external-rescue/scan";
 import type { EvmRescueResult } from "./external-rescue/types";
 
 type RescueData = EvmRescueResult & { currentHeight: bigint };
+type EvmRefundDisplayAmount = {
+    amount: BigNumber;
+    asset: string;
+};
+
+type EvmRefundDisplayQuoteParams = {
+    amount: bigint;
+    asset: string;
+    chain: string;
+    tokenIn: string;
+    tokenOut: string;
+};
+
+const getEvmRefundDexDetails = (refundData: EvmRescueResult) =>
+    refundData.dex ?? refundData.restoredSwap?.dex;
+
+const getEvmRefundBridgeDetails = (refundData: EvmRescueResult) =>
+    refundData.bridge ?? refundData.restoredSwap?.bridge;
+
+export const getEvmRefundDisplayAmount = (
+    refundData: EvmRescueResult,
+    asset: string,
+): EvmRefundDisplayAmount => {
+    const dex = getEvmRefundDexDetails(refundData);
+    const displayAsset =
+        getEvmDisplayAssets({
+            ...refundData,
+            action: RskRescueMode.Refund,
+            asset: asset as AssetType,
+        })[0] ?? asset;
+
+    if (dex?.position === SwapPosition.Pre) {
+        return {
+            amount: new BigNumber(dex.quoteAmount.toString()),
+            asset: displayAsset,
+        };
+    }
+
+    return {
+        amount: new BigNumber(
+            assetAmountToSats(refundData.amount, asset).toString(),
+        ),
+        asset,
+    };
+};
+
+export const getEvmRefundDisplayQuoteParams = (
+    refundData: EvmRescueResult,
+    asset: string,
+): EvmRefundDisplayQuoteParams | undefined => {
+    const dex = getEvmRefundDexDetails(refundData);
+    const hopDexDetails =
+        dex?.position === SwapPosition.Pre
+            ? dex.hops[0]?.dexDetails
+            : undefined;
+
+    if (hopDexDetails === undefined || refundData.tokenAddress === undefined) {
+        return undefined;
+    }
+
+    return {
+        amount: refundData.amount,
+        asset: getEvmRefundDisplayAmount(refundData, asset).asset,
+        chain: hopDexDetails.chain,
+        tokenIn: refundData.tokenAddress,
+        tokenOut: hopDexDetails.tokenIn,
+    };
+};
+
+const fetchEvmRefundDisplayQuote = async (
+    params: EvmRefundDisplayQuoteParams,
+): Promise<EvmRefundDisplayAmount | undefined> => {
+    try {
+        const [quote] = await quoteDexAmountIn(
+            params.chain,
+            params.tokenIn,
+            params.tokenOut,
+            params.amount,
+        );
+
+        if (quote === undefined) {
+            return undefined;
+        }
+
+        return {
+            amount: new BigNumber(quote.quote),
+            asset: params.asset,
+        };
+    } catch (error) {
+        log.warn("failed to fetch EVM refund display quote", {
+            error: formatError(error),
+        });
+        return undefined;
+    }
+};
 
 const RefundState = (props: {
     asset: string;
@@ -58,6 +170,20 @@ const RefundState = (props: {
     const { rescueFile } = useRescueContext();
 
     const isErc20 = () => getKindForAsset(props.asset) === AssetKind.ERC20;
+    const dexDetails = () => getEvmRefundDexDetails(props.refundData);
+    const bridgeDetails = () => getEvmRefundBridgeDetails(props.refundData);
+    const displayQuoteParams = createMemo(() =>
+        getEvmRefundDisplayQuoteParams(props.refundData, props.asset),
+    );
+    const [quotedDisplayAmount] = createResource(
+        displayQuoteParams,
+        fetchEvmRefundDisplayQuote,
+    );
+    const displayQuoteLoading = () =>
+        displayQuoteParams() !== undefined && quotedDisplayAmount.loading;
+    const displayAmount = () =>
+        quotedDisplayAmount() ??
+        getEvmRefundDisplayAmount(props.refundData, props.asset);
 
     const gasAbstraction = () => {
         if (isErc20() && rescueFile()) {
@@ -69,45 +195,95 @@ const RefundState = (props: {
         return undefined;
     };
 
+    // Pre-bridge refunds resolve their destination from the bridge instead
+    const needsResolvedDestination = () =>
+        dexDetails()?.position === SwapPosition.Pre &&
+        bridgeDetails()?.position !== SwapPosition.Pre;
+
+    const [resolvedFunder] = createResource(
+        () => {
+            if (signer() !== undefined || !isErc20() || !rescueFile()) {
+                return undefined;
+            }
+            if (!needsResolvedDestination()) {
+                return undefined;
+            }
+            const tokenIn = dexDetails()?.hops[0]?.dexDetails?.tokenIn;
+            if (tokenIn === undefined) {
+                return undefined;
+            }
+            return {
+                asset: props.asset,
+                tokenIn,
+                txHash: props.lockupTxHash,
+            };
+        },
+        (lookup) =>
+            resolveLockupTokenFunder(
+                lookup.asset,
+                lookup.tokenIn,
+                lookup.txHash,
+            ),
+    );
+
     const destination = () => {
         if (!isErc20() || !rescueFile()) {
             return undefined;
         }
         try {
-            return signer()?.address;
+            return (
+                signer()?.address ??
+                (resolvedFunder.state === "ready"
+                    ? resolvedFunder()
+                    : undefined)
+            );
         } catch {
             return undefined;
         }
     };
 
+    const destinationMissing = () =>
+        needsResolvedDestination() && destination() === undefined;
+
     return (
         <>
-            <p>
-                {t("refund")}{" "}
-                {formatAmount(
-                    new BigNumber(
-                        assetAmountToSats(
-                            props.refundData.amount,
-                            props.asset,
-                        ).toString(),
-                    ),
-                    denomination(),
-                    separator(),
-                    props.asset,
-                )}{" "}
-                {formatDenomination(denomination(), props.asset)}
-            </p>
+            <div class="rescue-evm-refund-amount">
+                <span>{t("refund")}</span>
+                <Show
+                    when={!displayQuoteLoading()}
+                    fallback={
+                        <LoadingSpinner class="inner-spinner inline-spinner" />
+                    }>
+                    <span>
+                        {formatAmount(
+                            displayAmount().amount,
+                            denomination(),
+                            separator(),
+                            displayAmount().asset,
+                        )}{" "}
+                        {formatDenomination(
+                            denomination(),
+                            displayAmount().asset,
+                        )}
+                    </span>
+                </Show>
+            </div>
 
+            <Show
+                when={
+                    signer() === undefined &&
+                    gasAbstraction()?.signer !== undefined &&
+                    destinationMissing() &&
+                    !resolvedFunder.loading
+                }>
+                <ConnectWallet asset={props.asset} />
+            </Show>
             <RefundButton
                 asset={props.asset}
                 swapId={props.refundData.restoredSwap?.id}
-                dexDetails={
-                    props.refundData.dex ?? props.refundData.restoredSwap?.dex
-                }
-                bridge={
-                    props.refundData.bridge ??
-                    props.refundData.restoredSwap?.bridge
-                }
+                dexDetails={dexDetails()}
+                bridge={bridgeDetails()}
+                disabled={destinationMissing()}
                 setRefundTxId={
                     props.setRefundTxId as Setter<string | undefined>
                 }
@@ -117,6 +293,15 @@ const RefundState = (props: {
                 transactionSigner={gasAbstraction()?.signer}
                 destination={destination()}
             />
+            <Show
+                when={
+                    signer() === undefined &&
+                    gasAbstraction()?.signer === undefined
+                }>
+                <button class="btn" disabled>
+                    {t("refund")}
+                </button>
+            </Show>
             <hr />
             <BlockExplorer
                 typeLabel={"lockup_tx"}
@@ -135,23 +320,82 @@ const ClaimState = (props: {
     setClaimTxId: Setter<string>;
 }) => {
     const navigate = useNavigate();
-    const { t } = useGlobalContext();
+    const { t, slippage } = useGlobalContext();
     const { signer, getEtherSwap, getErc20Swap, getGasAbstractionSigner } =
         useWeb3Signer();
     const { evmRescuableSwaps, rescueFile } = useRescueContext();
     const params = useParams();
 
     const preimage = () => {
+        const preimageHash = normalizeEvmId(
+            props.claimData.restoredSwap?.preimageHash ??
+                props.claimData.preimageHash,
+        );
         const swapFromContext = evmRescuableSwaps().find(
-            (s) => s.preimageHash === props.claimData.preimageHash,
+            (s) => normalizeEvmId(s.preimageHash) === preimageHash,
         );
         return swapFromContext?.preimage
             ? Buffer.from(swapFromContext.preimage, "hex")
             : undefined;
     };
 
-    const getGasAbstraction = async (): Promise<GasAbstractionType> => {
-        if (props.asset === RBTC) {
+    const dexDetails = () =>
+        props.claimData.dex ?? props.claimData.restoredSwap?.dex;
+    const bridgeDetails = () =>
+        props.claimData.bridge ?? props.claimData.restoredSwap?.bridge;
+    const routedDex = () => {
+        const dex = dexDetails();
+        return dex?.position === SwapPosition.Post && dex.hops.length > 0
+            ? dex
+            : undefined;
+    };
+    const postBridge = () => {
+        const bridge = bridgeDetails();
+        return bridge?.position === SwapPosition.Post ? bridge : undefined;
+    };
+    const restoredReceiveAsset = () =>
+        props.claimData.restoredSwap?.to ?? props.asset;
+    const routeClaimAsset = () =>
+        getClaimAssetForRoute(restoredReceiveAsset(), dexDetails());
+    const finalReceiveAsset = () => {
+        if (routedDex() === undefined) {
+            return restoredReceiveAsset();
+        }
+
+        const bridge = postBridge();
+        if (bridge !== undefined) {
+            return bridge.destinationAsset;
+        }
+
+        const dex = routedDex();
+        if (dex !== undefined) {
+            return dex.hops[dex.hops.length - 1].to;
+        }
+
+        return restoredReceiveAsset();
+    };
+    const claimDestination = (useOriginalDestination: boolean) =>
+        useOriginalDestination
+            ? (props.claimData.restoredSwap?.originalDestination ??
+              signer()?.address)
+            : signer()?.address;
+
+    const canClaimWithoutWallet = () =>
+        routedDex() !== undefined &&
+        props.claimData.restoredSwap?.originalDestination !== undefined &&
+        getKindForAsset(routeClaimAsset()) === AssetKind.ERC20 &&
+        rescueFile() !== undefined;
+
+    const signerOverride = () =>
+        signer() ??
+        (canClaimWithoutWallet()
+            ? getGasAbstractionSigner(routeClaimAsset(), rescueFile())
+            : undefined);
+
+    const getGasAbstraction = async (
+        asset: string,
+    ): Promise<GasAbstractionType> => {
+        if (asset === RBTC) {
             const sig = signer();
             if (sig === undefined) {
                 throw new Error("missing signer for gas check");
@@ -167,7 +411,7 @@ const ClaimState = (props: {
             return GasAbstractionType.None;
         }
 
-        if (getKindForAsset(props.asset) === AssetKind.ERC20) {
+        if (getKindForAsset(asset) === AssetKind.ERC20) {
             return GasAbstractionType.Signer;
         }
 
@@ -178,13 +422,63 @@ const ClaimState = (props: {
         const currentPreimage = preimage();
         if (!currentPreimage) return;
 
-        const asset = props.asset;
+        const asset = routeClaimAsset();
         const { amount, claimAddress, refundAddress, timelock } =
             props.claimData;
+        const amountSats = assetAmountToSats(amount, asset);
 
         try {
-            const gasAbstraction = await getGasAbstraction();
+            const gasAbstraction = await getGasAbstraction(asset);
             const sig = signer();
+            const dex = routedDex();
+            const destination = claimDestination(dex !== undefined);
+            if (destination === undefined) {
+                throw new Error("missing claim destination");
+            }
+
+            if (dex !== undefined) {
+                const gasAbstractionSigner = getGasAbstractionSigner(
+                    asset,
+                    rescueFile(),
+                );
+                const claimSigner = getSignerForGasAbstraction(
+                    gasAbstraction,
+                    sig,
+                    gasAbstractionSigner,
+                );
+                const hopDexDetails = dex.hops[0].dexDetails;
+                if (claimSigner === undefined) {
+                    throw new Error("missing signer for routed claim");
+                }
+                if (hopDexDetails === undefined) {
+                    throw new Error("claim hop is missing DEX details");
+                }
+
+                const quote = await fetchDexQuote(
+                    hopDexDetails,
+                    satsToAssetAmount(amountSats, asset),
+                );
+                const transactionHash = await claimHops(
+                    dex.hops,
+                    gasAbstraction,
+                    asset,
+                    currentPreimage.toString("hex"),
+                    amountSats,
+                    refundAddress,
+                    Number(timelock),
+                    destination,
+                    () => claimSigner,
+                    getErc20Swap(asset),
+                    slippage(),
+                    quote,
+                    false,
+                    postBridge(),
+                );
+
+                props.setClaimTxId(transactionHash);
+                return;
+            }
+
             if (sig === undefined) {
                 throw new Error("missing signer for claim");
             }
@@ -193,11 +487,11 @@ const ClaimState = (props: {
                 gasAbstraction,
                 asset,
                 preimage: currentPreimage.toString("hex"),
-                amount: assetAmountToSats(amount, asset),
+                amount: amountSats,
                 claimAddress,
                 refundAddress,
                 timeoutBlockHeight: Number(timelock),
-                destination: sig.address,
+                destination: getAddress(destination),
                 signer: () => sig,
                 gasAbstractionSigner: getGasAbstractionSigner(
                     asset,
@@ -227,16 +521,28 @@ const ClaimState = (props: {
                     </button>
                 </>
             }>
-            <ContractTransaction
-                asset={props.asset}
-                onClick={claimTransaction}
-                buttonText={t("continue")}
-                promptText={t("transaction_prompt_receive", {
-                    button: t("continue"),
-                    asset: props.asset,
-                })}
-                waitingText={t("tx_ready_to_claim")}
-            />
+            <Show
+                when={signer() !== undefined || canClaimWithoutWallet()}
+                fallback={
+                    <>
+                        <ConnectWallet asset={routeClaimAsset()} />
+                        <button class="btn" disabled>
+                            {t("claim")}
+                        </button>
+                    </>
+                }>
+                <ContractTransaction
+                    asset={routeClaimAsset()}
+                    signerOverride={signerOverride}
+                    onClick={claimTransaction}
+                    buttonText={t("continue")}
+                    promptText={t("transaction_prompt_receive", {
+                        button: t("continue"),
+                        asset: finalReceiveAsset(),
+                    })}
+                    waitingText={t("tx_ready_to_claim")}
+                />
+            </Show>
         </Show>
     );
 };
@@ -250,7 +556,7 @@ const RescueEvm = () => {
 
     const { t } = useGlobalContext();
     const { evmRescuableSwaps } = useRescueContext();
-    const { signer, getEtherSwap, getErc20Swap } = useWeb3Signer();
+    const { getEtherSwap, getErc20Swap } = useWeb3Signer();
 
     const getSwapContract = (asset: string) =>
         getKindForAsset(asset) === AssetKind.ERC20
@@ -265,10 +571,6 @@ const RescueEvm = () => {
     );
 
     const [rescueData] = createResource<RescueData | undefined>(async () => {
-        if (signer() === undefined) {
-            return undefined;
-        }
-
         const provider = createAssetProvider(params.asset);
         const contract = getSwapContract(params.asset);
 
@@ -318,102 +620,91 @@ const RescueEvm = () => {
 
     return (
         <div class="frame">
-            <Show
-                when={signer() !== undefined}
-                fallback={<h2>{t("no_wallet")}</h2>}>
-                <Switch>
-                    <Match when={rescueData.state === "ready"}>
-                        <SettingsCog />
-                        <SettingsMenu />
-                        <h2
-                            class="frame-title"
-                            style={{ "margin-bottom": "6px" }}>
-                            {pageTitle()} {cropString(params.txHash, 15, 5)}
-                        </h2>
-                        <hr />
-                        <Switch>
-                            <Match when={canRefund()}>
-                                <Show
-                                    when={refundTxId() === undefined}
-                                    fallback={
-                                        <>
-                                            <p>{t("refunded")}</p>
-                                            <hr />
-                                            <BlockExplorer
-                                                typeLabel={"refund_tx"}
-                                                asset={params.asset}
-                                                kind={
-                                                    BlockExplorerTargetKind.Tx
-                                                }
-                                                id={refundTxId()!}
-                                            />
-                                        </>
-                                    }>
-                                    <RefundState
-                                        asset={params.asset}
-                                        lockupTxHash={params.txHash}
-                                        refundData={rescueData()!}
-                                        setRefundTxId={
-                                            setRefundTxId as Setter<string>
-                                        }
-                                    />
-                                </Show>
-                            </Match>
-                            <Match when={!isRefundAction()}>
-                                <Show
-                                    when={claimTxId() === undefined}
-                                    fallback={
-                                        <>
-                                            <p>{t("claimed")}</p>
-                                            <hr />
-                                            <BlockExplorer
-                                                typeLabel={"claim_tx"}
-                                                asset={params.asset}
-                                                kind={
-                                                    BlockExplorerTargetKind.Tx
-                                                }
-                                                id={claimTxId()!}
-                                            />
-                                        </>
-                                    }>
-                                    <ClaimState
-                                        asset={params.asset}
-                                        lockupTxHash={params.txHash}
-                                        claimData={rescueData()!}
-                                        setClaimTxId={
-                                            setClaimTxId as Setter<string>
-                                        }
-                                    />
-                                </Show>
-                            </Match>
-                            <Match
-                                when={isRefundAction() && !timelockExpired()}>
-                                <RefundEta
-                                    timeoutEta={() =>
-                                        getTimeoutEta(
-                                            params.asset as blockChainsAssets,
-                                            Number(rescueData()!.timelock),
-                                            Number(rescueData()!.currentHeight),
-                                        )
-                                    }
-                                    timeoutBlockHeight={() =>
-                                        Number(rescueData()!.timelock)
-                                    }
+            <Switch>
+                <Match when={rescueData.state === "ready"}>
+                    <SettingsCog />
+                    <SettingsMenu />
+                    <h2 class="frame-title" style={{ "margin-bottom": "6px" }}>
+                        {pageTitle()} {cropString(params.txHash, 15, 5)}
+                    </h2>
+                    <hr />
+                    <Switch>
+                        <Match when={canRefund()}>
+                            <Show
+                                when={refundTxId() === undefined}
+                                fallback={
+                                    <>
+                                        <p>{t("refunded")}</p>
+                                        <hr />
+                                        <BlockExplorer
+                                            typeLabel={"refund_tx"}
+                                            asset={params.asset}
+                                            kind={BlockExplorerTargetKind.Tx}
+                                            id={refundTxId()!}
+                                        />
+                                    </>
+                                }>
+                                <RefundState
                                     asset={params.asset}
+                                    lockupTxHash={params.txHash}
+                                    refundData={rescueData()!}
+                                    setRefundTxId={
+                                        setRefundTxId as Setter<string>
+                                    }
                                 />
-                            </Match>
-                        </Switch>
-                    </Match>
-                    <Match when={rescueData.state === "pending"}>
-                        <h2>{pageTitle()}</h2>
-                        <LoadingSpinner />
-                    </Match>
-                    <Match when={rescueData.state === "errored"}>
-                        <h2>{t("error")}</h2>
-                        <h3>{formatError(rescueData.error)}</h3>
-                    </Match>
-                </Switch>
-            </Show>
+                            </Show>
+                        </Match>
+                        <Match when={!isRefundAction()}>
+                            <Show
+                                when={claimTxId() === undefined}
+                                fallback={
+                                    <>
+                                        <p>{t("claimed")}</p>
+                                        <hr />
+                                        <BlockExplorer
+                                            typeLabel={"claim_tx"}
+                                            asset={params.asset}
+                                            kind={BlockExplorerTargetKind.Tx}
+                                            id={claimTxId()!}
+                                        />
+                                    </>
+                                }>
+                                <ClaimState
+                                    asset={params.asset}
+                                    lockupTxHash={params.txHash}
+                                    claimData={rescueData()!}
+                                    setClaimTxId={
+                                        setClaimTxId as Setter<string>
+                                    }
+                                />
+                            </Show>
+                        </Match>
+                        <Match when={isRefundAction() && !timelockExpired()}>
+                            <RefundEta
+                                timeoutEta={() =>
+                                    getTimeoutEta(
+                                        params.asset as blockChainsAssets,
+                                        Number(rescueData()!.timelock),
+                                        Number(rescueData()!.currentHeight),
+                                    )
+                                }
+                                timeoutBlockHeight={() =>
+                                    Number(rescueData()!.timelock)
+                                }
+                                asset={params.asset}
+                            />
+                        </Match>
+                    </Switch>
+                </Match>
+                <Match when={rescueData.state === "pending"}>
+                    <h2>{pageTitle()}</h2>
+                    <LoadingSpinner />
+                </Match>
+                <Match when={rescueData.state === "errored"}>
+                    <h2>{t("error")}</h2>
+                    <h3>{formatError(rescueData.error)}</h3>
+                </Match>
+            </Switch>
         </div>
     );
 };

--- a/src/pages/RescueEvm.tsx
+++ b/src/pages/RescueEvm.tsx
@@ -6,11 +6,7 @@ import {
     getLogsFromReceipt,
     getTimelockBlockNumber,
 } from "boltz-swaps/evm/logs";
-import {
-    AssetKind,
-    type LogRefundData,
-    RskRescueMode,
-} from "boltz-swaps/types";
+import { AssetKind, RskRescueMode } from "boltz-swaps/types";
 import log from "loglevel";
 import {
     Match,
@@ -47,8 +43,9 @@ import { cropString } from "../utils/helper";
 import { estimateFeesPerGas } from "../utils/provider";
 import { getTimeoutEta } from "../utils/rescue";
 import { GasAbstractionType } from "../utils/swapCreator";
+import type { EvmRescueResult } from "./external-rescue/types";
 
-type RescueData = LogRefundData & { currentHeight: bigint };
+type RescueData = EvmRescueResult & { currentHeight: bigint };
 
 const RefundState = (props: {
     asset: string;
@@ -103,6 +100,14 @@ const RefundState = (props: {
 
             <RefundButton
                 asset={props.asset}
+                swapId={props.refundData.restoredSwap?.id}
+                dexDetails={
+                    props.refundData.dex ?? props.refundData.restoredSwap?.dex
+                }
+                bridge={
+                    props.refundData.bridge ??
+                    props.refundData.restoredSwap?.bridge
+                }
                 setRefundTxId={
                     props.setRefundTxId as Setter<string | undefined>
                 }
@@ -244,6 +249,7 @@ const RescueEvm = () => {
     }>();
 
     const { t } = useGlobalContext();
+    const { evmRescuableSwaps } = useRescueContext();
     const { signer, getEtherSwap, getErc20Swap } = useWeb3Signer();
 
     const getSwapContract = (asset: string) =>
@@ -275,9 +281,17 @@ const RescueEvm = () => {
             ),
             getTimelockBlockNumber(provider, params.asset as AssetType),
         ]);
+        const contextData = evmRescuableSwaps().find(
+            (swap) =>
+                swap.action === params.action &&
+                swap.transactionHash.toLowerCase() ===
+                    params.txHash.toLowerCase(),
+        );
 
         return {
+            ...contextData,
             ...logData,
+            action: params.action,
             currentHeight: BigInt(currentHeight),
         };
     });

--- a/src/pages/RescueEvm.tsx
+++ b/src/pages/RescueEvm.tsx
@@ -642,7 +642,9 @@ const RescueEvm = () => {
                     <SettingsCog />
                     <SettingsMenu />
                     <h2 class="frame-title" style={{ "margin-bottom": "6px" }}>
-                        {pageTitle()} {cropString(params.txHash, 15, 5)}
+                        {pageTitle()}{" "}
+                        {contextData()?.restoredSwap?.id ??
+                            cropString(params.txHash, 15, 5)}
                     </h2>
                     <hr />
                     <Switch>

--- a/src/pages/RescueEvm.tsx
+++ b/src/pages/RescueEvm.tsx
@@ -49,6 +49,7 @@ import {
     claimHops,
     getClaimAssetForRoute,
 } from "../status/TransactionConfirmed";
+import { fromDexAmount } from "../utils/Pair";
 import { formatAmount, formatDenomination } from "../utils/denomination";
 import { formatError } from "../utils/errors";
 import { resolveLockupTokenFunder } from "../utils/evmLockup";
@@ -132,7 +133,7 @@ export const getEvmRefundDisplayQuoteParams = (
     };
 };
 
-const fetchEvmRefundDisplayQuote = async (
+export const fetchEvmRefundDisplayQuote = async (
     params: EvmRefundDisplayQuoteParams,
 ): Promise<EvmRefundDisplayAmount | undefined> => {
     try {
@@ -148,7 +149,7 @@ const fetchEvmRefundDisplayQuote = async (
         }
 
         return {
-            amount: new BigNumber(quote.quote),
+            amount: fromDexAmount(BigInt(quote.quote), params.asset),
             asset: params.asset,
         };
     } catch (error) {
@@ -570,7 +571,7 @@ const RescueEvm = () => {
         undefined,
     );
 
-    const [rescueData] = createResource<RescueData | undefined>(async () => {
+    const [chainData] = createResource(async () => {
         const provider = createAssetProvider(params.asset);
         const contract = getSwapContract(params.asset);
 
@@ -583,18 +584,34 @@ const RescueEvm = () => {
             ),
             getTimelockBlockNumber(provider, params.asset as AssetType),
         ]);
-        const contextData = evmRescuableSwaps().find(
+
+        return {
+            ...logData,
+            currentHeight: BigInt(currentHeight),
+        };
+    });
+
+    // Reactive so routed swap metadata still attaches when the scan
+    // populates the context after the on-chain data has resolved
+    const contextData = createMemo(() =>
+        evmRescuableSwaps().find(
             (swap) =>
                 swap.action === params.action &&
                 swap.transactionHash.toLowerCase() ===
                     params.txHash.toLowerCase(),
-        );
+        ),
+    );
+
+    const rescueData = createMemo<RescueData | undefined>(() => {
+        const data = chainData();
+        if (data === undefined) {
+            return undefined;
+        }
 
         return {
-            ...contextData,
-            ...logData,
+            ...contextData(),
+            ...data,
             action: params.action,
-            currentHeight: BigInt(currentHeight),
         };
     });
 
@@ -621,7 +638,7 @@ const RescueEvm = () => {
     return (
         <div class="frame">
             <Switch>
-                <Match when={rescueData.state === "ready"}>
+                <Match when={chainData.state === "ready"}>
                     <SettingsCog />
                     <SettingsMenu />
                     <h2 class="frame-title" style={{ "margin-bottom": "6px" }}>
@@ -696,13 +713,13 @@ const RescueEvm = () => {
                         </Match>
                     </Switch>
                 </Match>
-                <Match when={rescueData.state === "pending"}>
+                <Match when={chainData.state === "pending"}>
                     <h2>{pageTitle()}</h2>
                     <LoadingSpinner />
                 </Match>
-                <Match when={rescueData.state === "errored"}>
+                <Match when={chainData.state === "errored"}>
                     <h2>{t("error")}</h2>
-                    <h3>{formatError(rescueData.error)}</h3>
+                    <h3>{formatError(chainData.error)}</h3>
                 </Match>
             </Switch>
         </div>

--- a/src/pages/external-rescue/Recovery.tsx
+++ b/src/pages/external-rescue/Recovery.tsx
@@ -40,7 +40,7 @@ export const recoveryOptions: RecoveryOption[] = [
         asset: TBTC,
         className: "asset-TBTC",
         actions: [RescueAction.Refund, RescueAction.Claim],
-        methods: [RecoveryMethod.Key],
+        methods: [RecoveryMethod.Key, RecoveryMethod.Wallet],
     },
     {
         asset: WBTC,

--- a/src/pages/external-rescue/Recovery.tsx
+++ b/src/pages/external-rescue/Recovery.tsx
@@ -4,6 +4,7 @@ import { For, Match, Switch } from "solid-js";
 import {
     BTC,
     LBTC,
+    LN,
     RBTC,
     TBTC,
     USDC,
@@ -17,6 +18,12 @@ import { RescueAction } from "../../utils/rescue";
 import { RecoveryMethod, type RecoveryOption } from "./types";
 
 export const recoveryOptions: RecoveryOption[] = [
+    {
+        asset: LN,
+        className: "asset-LN",
+        actions: [RescueAction.Refund, RescueAction.Claim],
+        methods: [RecoveryMethod.Key],
+    },
     {
         asset: BTC,
         className: "asset-BTC",
@@ -33,25 +40,25 @@ export const recoveryOptions: RecoveryOption[] = [
         asset: TBTC,
         className: "asset-TBTC",
         actions: [RescueAction.Refund, RescueAction.Claim],
-        methods: [RecoveryMethod.Key, RecoveryMethod.Wallet],
+        methods: [RecoveryMethod.Key],
     },
     {
         asset: WBTC,
         className: "asset-WBTC",
         actions: [RescueAction.Refund, RescueAction.Claim],
-        methods: [RecoveryMethod.Key, RecoveryMethod.Wallet],
+        methods: [RecoveryMethod.Key],
     },
     {
         asset: USDT0,
         className: "asset-USDT",
         actions: [RescueAction.Refund, RescueAction.Claim],
-        methods: [RecoveryMethod.Key, RecoveryMethod.Wallet],
+        methods: [RecoveryMethod.Key],
     },
     {
         asset: USDC,
         className: "asset-USDC",
         actions: [RescueAction.Refund, RescueAction.Claim],
-        methods: [RecoveryMethod.Key, RecoveryMethod.Wallet],
+        methods: [RecoveryMethod.Key],
     },
     {
         asset: RBTC,

--- a/src/pages/external-rescue/Results.tsx
+++ b/src/pages/external-rescue/Results.tsx
@@ -152,7 +152,10 @@ const formatResultDetail = (
 const resultId = (result: UnifiedRescueResult) => {
     switch (result.source) {
         case RescueResultSource.Evm:
-            return cropString(result.swap.transactionHash, 15, 5);
+            return (
+                result.swap.restoredSwap?.id ??
+                cropString(result.swap.transactionHash, 15, 5)
+            );
         case RescueResultSource.Sweep:
             return cropString(result.swap.signer.address, 15, 5);
         case RescueResultSource.Restore:

--- a/src/pages/external-rescue/Results.tsx
+++ b/src/pages/external-rescue/Results.tsx
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { getGasAbstractionSweepDisplayAmount } from "boltz-swaps/evm";
-import { RskRescueMode } from "boltz-swaps/types";
+import { RskRescueMode, SwapType } from "boltz-swaps/types";
 import { VsArrowSmallRight } from "solid-icons/vs";
 import { For, Match, Show, Switch } from "solid-js";
 
@@ -12,6 +12,7 @@ import Pagination, {
 import { SwapIcons, SwapListAssetIcon } from "../../components/SwapIcons";
 import { getSwapListHeight } from "../../components/SwapList";
 import { hiddenInformation } from "../../components/settings/PrivacyMode";
+import { LN } from "../../consts/Assets";
 import { useGlobalContext } from "../../context/Global";
 import { formatAmount, formatDenomination } from "../../utils/denomination";
 import type { GasAbstractionSweep } from "../../utils/gasAbstractionSweep";
@@ -42,7 +43,10 @@ export const getEvmDisplayAssets = (swap: EvmRescueResult) => {
     const base = {
         bridge,
         dex: shouldUseDex ? dex : undefined,
-        assetSend: swap.restoredSwap?.from ?? swap.asset,
+        assetSend:
+            swap.restoredSwap?.type === SwapType.Reverse
+                ? LN
+                : (swap.restoredSwap?.from ?? swap.asset),
         assetReceive: swap.restoredSwap?.to ?? swap.asset,
     } as SwapBase;
     const assetSend = getFinalAssetSend(base, true);

--- a/src/pages/external-rescue/Results.tsx
+++ b/src/pages/external-rescue/Results.tsx
@@ -32,13 +32,6 @@ import {
 } from "./types";
 import type { ExternalRescueSearch } from "./useExternalRescueSearch";
 
-export const getEvmFinalAsset = (swap: EvmRescueResult) => {
-    const assets = getEvmDisplayAssets(swap);
-    return swap.action === RskRescueMode.Refund
-        ? assets[0]!
-        : assets[assets.length - 1]!;
-};
-
 export const getEvmDisplayAssets = (swap: EvmRescueResult) => {
     const bridge = swap.bridge ?? swap.restoredSwap?.bridge;
     const dex = swap.dex ?? swap.restoredSwap?.dex;

--- a/src/pages/external-rescue/Results.tsx
+++ b/src/pages/external-rescue/Results.tsx
@@ -1,5 +1,7 @@
 import BigNumber from "bignumber.js";
 import { getGasAbstractionSweepDisplayAmount } from "boltz-swaps/evm";
+import { RskRescueMode } from "boltz-swaps/types";
+import { VsArrowSmallRight } from "solid-icons/vs";
 import { For, Match, Show, Switch } from "solid-js";
 
 import LoadingSpinner from "../../components/LoadingSpinner";
@@ -15,19 +17,74 @@ import { formatAmount, formatDenomination } from "../../utils/denomination";
 import type { GasAbstractionSweep } from "../../utils/gasAbstractionSweep";
 import { cropString, isMobile } from "../../utils/helper";
 import { RescueAction } from "../../utils/rescue";
-import type { SomeSwap } from "../../utils/swapCreator";
+import {
+    type SomeSwap,
+    type SwapBase,
+    getFinalAssetReceive,
+    getFinalAssetSend,
+} from "../../utils/swapCreator";
 import { getSwapDate } from "./scan";
 import {
     BtcSearchState,
+    type EvmRescueResult,
     RescueResultSource,
     type UnifiedRescueResult,
 } from "./types";
 import type { ExternalRescueSearch } from "./useExternalRescueSearch";
 
-const EvmAssetIcon = (props: { asset: string }) => (
+export const getEvmFinalAsset = (swap: EvmRescueResult) => {
+    const assets = getEvmDisplayAssets(swap);
+    return swap.action === RskRescueMode.Refund
+        ? assets[0]!
+        : assets[assets.length - 1]!;
+};
+
+export const getEvmDisplayAssets = (swap: EvmRescueResult) => {
+    const bridge = swap.bridge ?? swap.restoredSwap?.bridge;
+    const dex = swap.dex ?? swap.restoredSwap?.dex;
+    const shouldUseDex =
+        swap.restoredSwap !== undefined ||
+        swap.action !== RskRescueMode.Refund ||
+        bridge !== undefined;
+    const base = {
+        bridge,
+        dex: shouldUseDex ? dex : undefined,
+        assetSend: swap.restoredSwap?.from ?? swap.asset,
+        assetReceive: swap.restoredSwap?.to ?? swap.asset,
+    } as SwapBase;
+    const assetSend = getFinalAssetSend(base, true);
+    const assetReceive = getFinalAssetReceive(base, true);
+
+    if (
+        swap.restoredSwap === undefined &&
+        swap.action === RskRescueMode.Refund
+    ) {
+        return [assetSend];
+    }
+
+    return assetSend === assetReceive ? [assetSend] : [assetSend, assetReceive];
+};
+
+const SingleAssetIcon = (props: { asset: string }) => (
     <span class="swaplist-asset swaplist-asset-single">
         <SwapListAssetIcon asset={props.asset} />
     </span>
+);
+
+const AssetPair = (props: { assets: string[] }) => (
+    <Show
+        when={props.assets[1]}
+        fallback={<SingleAssetIcon asset={props.assets[0]} />}>
+        <span class="swaplist-asset">
+            <SwapListAssetIcon asset={props.assets[0]} />
+            <VsArrowSmallRight />
+            <SwapListAssetIcon asset={props.assets[1]!} />
+        </span>
+    </Show>
+);
+
+const EvmAssetIcon = (props: { swap: EvmRescueResult }) => (
+    <AssetPair assets={getEvmDisplayAssets(props.swap)} />
 );
 
 const resultActionLabel = (
@@ -127,18 +184,18 @@ const UnifiedResultAssets = (props: { result: UnifiedRescueResult }) => (
         </Match>
         <Match when={props.result.source === RescueResultSource.Evm}>
             <EvmAssetIcon
-                asset={
+                swap={
                     (
                         props.result as Extract<
                             UnifiedRescueResult,
                             { source: RescueResultSource.Evm }
                         >
-                    ).swap.asset
+                    ).swap
                 }
             />
         </Match>
         <Match when={props.result.source === RescueResultSource.Sweep}>
-            <EvmAssetIcon
+            <SingleAssetIcon
                 asset={
                     (
                         props.result as Extract<
@@ -216,6 +273,10 @@ const UnifiedRescueList = (props: {
 
 export const Results = (props: ResultsProps) => {
     const { t } = useGlobalContext();
+    const layoutSlots = () =>
+        Array.from({
+            length: props.results.displaySlotCount(),
+        }) as never as SomeSwap[];
 
     return (
         <>
@@ -247,11 +308,7 @@ export const Results = (props: ResultsProps) => {
 
             <Show when={props.results.all().length > 0}>
                 <div class="rescue-external-results">
-                    <div
-                        style={getSwapListHeight(
-                            props.results.all() as never as SomeSwap[],
-                            isMobile(),
-                        )}>
+                    <div style={getSwapListHeight(layoutSlots(), isMobile())}>
                         <UnifiedRescueList results={props.results} />
                     </div>
                     <Pagination

--- a/src/pages/external-rescue/scan.ts
+++ b/src/pages/external-rescue/scan.ts
@@ -1,14 +1,31 @@
+import { sha256 } from "@noble/hashes/sha2.js";
+import { hex } from "@scure/base";
 import { type RestorableSwap, getRestorableSwaps } from "boltz-swaps/client";
-import { type SwapContract, isEmptyPreimageHash } from "boltz-swaps/evm";
-import { RskRescueMode } from "boltz-swaps/types";
+import {
+    type SwapContract,
+    isEmptyPreimageHash,
+    satsToAssetAmount,
+} from "boltz-swaps/evm";
+import { type AssetType, RskRescueMode, SwapPosition } from "boltz-swaps/types";
 import log from "loglevel";
+import { type Hex, getAddress, zeroAddress } from "viem";
 
 import { config } from "../../config";
 import { RBTC, TBTC, WBTC } from "../../consts/Assets";
 import { paginationLimit } from "../../consts/Pagination";
 import { formatError } from "../../utils/errors";
+import { fetcher } from "../../utils/helper";
 import { RescueAction } from "../../utils/rescue";
-import { type RescueFile, getXpub } from "../../utils/rescueFile";
+import {
+    evmAccountFromPrivateKey,
+    mnemonicToHDKey,
+} from "../../utils/rescueDerivation";
+import {
+    type RescueFile,
+    derivePreimageFromRescueKey,
+    getPathGasAbstraction,
+    getXpub,
+} from "../../utils/rescueFile";
 import type { SomeSwap } from "../../utils/swapCreator";
 import {
     type SwapMetadataLocalFields,
@@ -19,6 +36,7 @@ import {
     type EvmRescueResult,
     type EvmScanTarget,
     RescueResultSource,
+    type RestorableEvmClaimDetails,
     type RestoredEvmSwap,
     type UnifiedRescueResult,
 } from "./types";
@@ -42,8 +60,35 @@ export const arbitrumRescueAssets = [TBTC, WBTC] as const;
 export const normalizeEvmId = (value: string | undefined): string =>
     value?.toLowerCase().replace(/^0x/, "") ?? "";
 
+const getRestorableSwapKey = (swap: RestorableSwap): string => swap.id;
+
+export const mergeRestorableSwaps = (
+    ...swapGroups: RestorableSwap[][]
+): RestorableSwap[] => {
+    const merged = new Map<string, RestorableSwap>();
+
+    for (const swaps of swapGroups) {
+        for (const swap of swaps) {
+            const existing = merged.get(getRestorableSwapKey(swap));
+            merged.set(getRestorableSwapKey(swap), {
+                ...existing,
+                ...swap,
+                metadata: swap.metadata ?? existing?.metadata,
+                claimDetails: swap.claimDetails ?? existing?.claimDetails,
+                refundDetails: swap.refundDetails ?? existing?.refundDetails,
+                evmClaimDetails:
+                    swap.evmClaimDetails ?? existing?.evmClaimDetails,
+            });
+        }
+    }
+
+    return [...merged.values()];
+};
+
 type RestoredEvmMatchReason =
-    "metadata-lockup-transaction" | "metadata-commitment-transaction";
+    | "metadata-lockup-transaction"
+    | "metadata-commitment-transaction"
+    | "restore-claim-transaction";
 
 type RestoredEvmMatch = {
     restoredSwap: RestoredEvmSwap;
@@ -71,6 +116,8 @@ export const mergeEvmRescueResults = (
     for (const swap of next) {
         const key = getEvmResultKey(swap);
         const existing = merged.get(key);
+        // Restore-derived results carry placeholder blockNumber/amount/
+        // refundAddress; scan values must win regardless of arrival order.
         merged.set(key, {
             ...existing,
             ...swap,
@@ -78,6 +125,13 @@ export const mergeEvmRescueResults = (
             dex: swap.dex ?? existing?.dex,
             bridge: swap.bridge ?? existing?.bridge,
             preimage: swap.preimage ?? existing?.preimage,
+            blockNumber:
+                swap.blockNumber || (existing?.blockNumber ?? swap.blockNumber),
+            amount: swap.amount || (existing?.amount ?? swap.amount),
+            refundAddress:
+                swap.refundAddress === zeroAddress
+                    ? (existing?.refundAddress ?? swap.refundAddress)
+                    : swap.refundAddress,
         });
     }
 
@@ -86,6 +140,151 @@ export const mergeEvmRescueResults = (
 
 const hasPreimageHash = (swap: RestorableSwap): swap is RestoredEvmSwap =>
     swap.preimageHash !== undefined;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isRestorableEvmClaimDetails = (
+    value: unknown,
+): value is RestorableEvmClaimDetails => {
+    if (!isRecord(value)) {
+        return false;
+    }
+
+    if (
+        typeof value.contractAddress !== "string" ||
+        typeof value.claimAddress !== "string" ||
+        typeof value.timeoutBlockHeight !== "number"
+    ) {
+        return false;
+    }
+
+    if (
+        value.transaction !== undefined &&
+        (!isRecord(value.transaction) ||
+            typeof value.transaction.id !== "string")
+    ) {
+        return false;
+    }
+
+    if (value.amount !== undefined && typeof value.amount !== "number") {
+        return false;
+    }
+
+    return value.keyIndex === undefined || typeof value.keyIndex === "number";
+};
+
+export const getRestoredEvmClaimDetails = (
+    swap: RestorableSwap,
+): RestorableEvmClaimDetails | undefined => {
+    const evmClaimDetails = (swap as { evmClaimDetails?: unknown })
+        .evmClaimDetails;
+    if (isRestorableEvmClaimDetails(evmClaimDetails)) {
+        return evmClaimDetails;
+    }
+
+    const claimDetails = (swap as { claimDetails?: unknown }).claimDetails;
+    return isRestorableEvmClaimDetails(claimDetails) ? claimDetails : undefined;
+};
+
+export const getRestoredEvmClaimTransactionHash = (
+    swap: RestorableSwap,
+): string | undefined => getRestoredEvmClaimDetails(swap)?.transaction?.id;
+
+const getRestorableDetailKeyIndex = (value: unknown): number | undefined => {
+    if (!isRecord(value)) {
+        return undefined;
+    }
+
+    return typeof value.keyIndex === "number" ? value.keyIndex : undefined;
+};
+
+export const getRestoredEvmClaimKeyIndex = (
+    swap: RestorableSwap,
+): number | undefined =>
+    getRestorableDetailKeyIndex(
+        (swap as { evmClaimDetails?: unknown }).evmClaimDetails,
+    ) ??
+    getRestorableDetailKeyIndex(
+        (swap as { claimDetails?: unknown }).claimDetails,
+    );
+
+export const getRestoredEvmClaimAsset = (swap: RestoredEvmSwap): string => {
+    if (swap.dex?.position === SwapPosition.Post) {
+        return swap.dex.hops[0]?.from ?? swap.to;
+    }
+
+    return swap.to;
+};
+
+export const getRestoredEvmClaimChainId = (
+    swap: RestoredEvmSwap,
+): number | undefined =>
+    config.assets?.[getRestoredEvmClaimAsset(swap)]?.network?.chainId;
+
+const prefixHex = (value: string): Hex =>
+    (value.startsWith("0x") ? value : `0x${value}`) as Hex;
+
+export const mapRestoredEvmClaimResult = (
+    swap: RestoredEvmSwap,
+    preimage: string,
+): EvmRescueResult | undefined => {
+    const details = getRestoredEvmClaimDetails(swap);
+    const transactionHash = details?.transaction?.id;
+    const asset = getRestoredEvmClaimAsset(swap);
+
+    if (
+        details === undefined ||
+        transactionHash === undefined ||
+        normalizeEvmId(swap.preimageHash) === "" ||
+        config.assets?.[asset]?.network?.chainId === undefined
+    ) {
+        return undefined;
+    }
+
+    return {
+        action: RskRescueMode.Claim,
+        asset: asset as AssetType,
+        blockNumber: 0,
+        transactionHash: prefixHex(transactionHash),
+        preimageHash: normalizeEvmId(swap.preimageHash) as Hex,
+        preimage: normalizeEvmId(preimage) as Hex,
+        amount: satsToAssetAmount(details.amount ?? 0, asset),
+        claimAddress: getAddress(details.claimAddress),
+        refundAddress: zeroAddress,
+        timelock: BigInt(details.timeoutBlockHeight),
+        restoredSwap: swap,
+        dex: swap.dex,
+        bridge: swap.bridge,
+    };
+};
+
+export const mapRestoredEvmClaimResultFromRescueKey = (
+    swap: RestoredEvmSwap,
+    rescueFile: RescueFile,
+): EvmRescueResult | undefined => {
+    const keyIndex = getRestoredEvmClaimKeyIndex(swap);
+    const asset = getRestoredEvmClaimAsset(swap);
+    if (keyIndex === undefined) {
+        return undefined;
+    }
+
+    const preimage = derivePreimageFromRescueKey(
+        rescueFile,
+        keyIndex,
+        asset as AssetType,
+    );
+    const preimageHex = hex.encode(preimage);
+    const expectedHash = normalizeEvmId(swap.preimageHash);
+    if (
+        expectedHash === "" ||
+        normalizeEvmId(hex.encode(sha256(preimage))) !== expectedHash
+    ) {
+        return undefined;
+    }
+
+    return mapRestoredEvmClaimResult(swap, preimageHex);
+};
 
 const getRestoredEvmMatchDetails = (
     swap: EvmRescueResult,
@@ -108,6 +307,17 @@ const getRestoredEvmMatchDetails = (
             return {
                 restoredSwap: restored,
                 reason: "metadata-commitment-transaction",
+            };
+        }
+
+        if (
+            txHash !== "" &&
+            normalizeEvmId(getRestoredEvmClaimTransactionHash(restored)) ===
+                txHash
+        ) {
+            return {
+                restoredSwap: restored,
+                reason: "restore-claim-transaction",
             };
         }
     }
@@ -153,6 +363,7 @@ const getRestoredEvmSwapKey = (swap: RestoredEvmSwap) =>
     normalizeEvmId(swap.preimageHash) ||
     normalizeEvmId(swap.lockupTx) ||
     normalizeEvmId(swap.commitmentLockupTxHash) ||
+    normalizeEvmId(getRestoredEvmClaimTransactionHash(swap)) ||
     swap.id;
 
 export const mergeRestoredEvmSwaps = (
@@ -281,6 +492,96 @@ export const fetchPaginatedRestorableSwaps = async (
     return restorableSwaps;
 };
 
+export const getEvmRestoreChainIds = (): number[] =>
+    Array.from(
+        new Set(
+            Object.values(config.assets ?? {})
+                .map((asset) => asset.network?.chainId)
+                .filter(
+                    (chainId): chainId is number => typeof chainId === "number",
+                )
+                .filter(
+                    (chainId) =>
+                        chainId !== config.assets?.[RBTC]?.network?.chainId,
+                ),
+        ),
+    );
+
+export const getEvmRestoreAccounts = (
+    rescueFile: RescueFile,
+    chainIds = getEvmRestoreChainIds(),
+) => {
+    const hdKey = mnemonicToHDKey(rescueFile.mnemonic);
+    const seen = new Set<string>();
+
+    return chainIds.flatMap((chainId) => {
+        const account = evmAccountFromPrivateKey(
+            hdKey.derive(getPathGasAbstraction(chainId)).privateKey,
+        );
+        const key = account.address.toLowerCase();
+        if (seen.has(key)) {
+            return [];
+        }
+        seen.add(key);
+        return [{ chainId, account }];
+    });
+};
+
+export const getEvmRestoreMessage = (address: string, timestamp: number) =>
+    `Boltz swap restore\naddress: ${address}\ntimestamp: ${timestamp}`;
+
+export const getRestorableSwapsByEvmAddress = async (
+    account: ReturnType<typeof evmAccountFromPrivateKey>,
+    signal: AbortSignal,
+): Promise<RestorableSwap[]> => {
+    const timestamp = Math.floor(Date.now() / 1_000);
+    const address = getAddress(account.address);
+    const signature = await account.signMessage({
+        message: getEvmRestoreMessage(address, timestamp),
+    });
+
+    return await fetcher<RestorableSwap[]>(
+        "/v2/swap/restore",
+        {
+            address,
+            timestamp,
+            signature,
+        },
+        { signal },
+        30_000,
+    );
+};
+
+export const fetchEvmAddressRestorableSwaps = async (
+    rescueFile: RescueFile,
+    signal: AbortSignal,
+): Promise<RestorableSwap[]> => {
+    const results = await Promise.allSettled(
+        getEvmRestoreAccounts(rescueFile).map(async ({ account, chainId }) => ({
+            chainId,
+            address: account.address,
+            swaps: await getRestorableSwapsByEvmAddress(account, signal),
+        })),
+    );
+
+    const swaps: RestorableSwap[][] = [];
+    for (const result of results) {
+        if (result.status === "fulfilled") {
+            swaps.push(result.value.swaps);
+            continue;
+        }
+
+        if (!signal.aborted) {
+            log.warn(
+                "failed to restore swaps by EVM claim address:",
+                formatError(result.reason),
+            );
+        }
+    }
+
+    return mergeRestorableSwaps(...swaps);
+};
+
 type HydratedRestorableSwap = RestorableSwap & SwapMetadataLocalFields;
 
 export const mapHydratedRestorableSwaps = (
@@ -297,7 +598,9 @@ export const filterHydratedEvmSwaps = (
         (swap): swap is RestoredEvmSwap =>
             hasPreimageHash(swap) &&
             (normalizeEvmId(swap.lockupTx) !== "" ||
-                normalizeEvmId(swap.commitmentLockupTxHash) !== ""),
+                normalizeEvmId(swap.commitmentLockupTxHash) !== "" ||
+                normalizeEvmId(getRestoredEvmClaimTransactionHash(swap)) !==
+                    ""),
     );
 
 export const mapRestorableSwaps = async (
@@ -313,18 +616,19 @@ export const getEvmScanTargets = (
     getErc20Swap: (asset: string) => SwapContract,
     action: RskRescueMode,
     hasRescueFile: boolean,
+    includeRbtc = true,
 ): EvmScanTarget[] => {
     const targets: EvmScanTarget[] = [];
 
     const rskEndpoint = import.meta.env.VITE_RSK_LOG_SCAN_ENDPOINT;
-    if (rskEndpoint) {
+    if (!rskEndpoint) {
+        log.warn("rsk log endpoint not set");
+    } else if (includeRbtc) {
         targets.push({
             asset: RBTC,
             providerUrl: rskEndpoint,
             contract: getEtherSwap(RBTC),
         });
-    } else {
-        log.warn("rsk log endpoint not set");
     }
 
     const skipArbitrum = action === RskRescueMode.Refund && !hasRescueFile;

--- a/src/pages/external-rescue/scan.ts
+++ b/src/pages/external-rescue/scan.ts
@@ -74,6 +74,9 @@ export const mergeRestorableSwaps = (
                 ...existing,
                 ...swap,
                 metadata: swap.metadata ?? existing?.metadata,
+                preimageHash: swap.preimageHash ?? existing?.preimageHash,
+                claimPrivateKey:
+                    swap.claimPrivateKey ?? existing?.claimPrivateKey,
                 claimDetails: swap.claimDetails ?? existing?.claimDetails,
                 refundDetails: swap.refundDetails ?? existing?.refundDetails,
                 evmClaimDetails:

--- a/src/pages/external-rescue/scan.ts
+++ b/src/pages/external-rescue/scan.ts
@@ -10,12 +10,16 @@ import { formatError } from "../../utils/errors";
 import { RescueAction } from "../../utils/rescue";
 import { type RescueFile, getXpub } from "../../utils/rescueFile";
 import type { SomeSwap } from "../../utils/swapCreator";
-import { decryptSwapMetadata } from "../../utils/swapMetadata";
+import {
+    type SwapMetadataLocalFields,
+    hydrateRestorableSwapsMetadata,
+} from "../../utils/swapMetadata";
 import { mapSwap } from "../RefundRescue";
 import {
     type EvmRescueResult,
     type EvmScanTarget,
     RescueResultSource,
+    type RestoredEvmSwap,
     type UnifiedRescueResult,
 } from "./types";
 
@@ -34,6 +38,148 @@ const resultSourcePriority: Record<RescueResultSource, number> = {
 };
 
 export const arbitrumRescueAssets = [TBTC, WBTC] as const;
+
+export const normalizeEvmId = (value: string | undefined): string =>
+    value?.toLowerCase().replace(/^0x/, "") ?? "";
+
+type RestoredEvmMatchReason =
+    | "metadata-lockup-transaction"
+    | "metadata-commitment-transaction";
+
+type RestoredEvmMatch = {
+    restoredSwap: RestoredEvmSwap;
+    reason: RestoredEvmMatchReason;
+};
+
+const getEvmResultKey = (swap: EvmRescueResult) =>
+    [
+        swap.action,
+        swap.asset,
+        normalizeEvmId(swap.transactionHash),
+        normalizeEvmId(swap.preimageHash),
+    ].join(":");
+
+export const mergeEvmRescueResults = (
+    current: EvmRescueResult[],
+    next: EvmRescueResult[],
+): EvmRescueResult[] => {
+    const merged = new Map<string, EvmRescueResult>();
+
+    for (const swap of current) {
+        merged.set(getEvmResultKey(swap), swap);
+    }
+
+    for (const swap of next) {
+        const key = getEvmResultKey(swap);
+        const existing = merged.get(key);
+        merged.set(key, {
+            ...existing,
+            ...swap,
+            restoredSwap: swap.restoredSwap ?? existing?.restoredSwap,
+            dex: swap.dex ?? existing?.dex,
+            bridge: swap.bridge ?? existing?.bridge,
+            preimage: swap.preimage ?? existing?.preimage,
+        });
+    }
+
+    return [...merged.values()];
+};
+
+const hasPreimageHash = (swap: RestorableSwap): swap is RestoredEvmSwap =>
+    swap.preimageHash !== undefined;
+
+const getRestoredEvmMatchDetails = (
+    swap: EvmRescueResult,
+    restoredSwaps: RestoredEvmSwap[],
+): RestoredEvmMatch | undefined => {
+    const txHash = normalizeEvmId(swap.transactionHash);
+
+    for (const restored of restoredSwaps) {
+        if (txHash !== "" && normalizeEvmId(restored.lockupTx) === txHash) {
+            return {
+                restoredSwap: restored,
+                reason: "metadata-lockup-transaction",
+            };
+        }
+
+        if (
+            txHash !== "" &&
+            normalizeEvmId(restored.commitmentLockupTxHash) === txHash
+        ) {
+            return {
+                restoredSwap: restored,
+                reason: "metadata-commitment-transaction",
+            };
+        }
+    }
+
+    return undefined;
+};
+
+export const getRestoredEvmMatch = (
+    swap: EvmRescueResult,
+    restoredSwaps: RestoredEvmSwap[],
+): RestoredEvmSwap | undefined =>
+    getRestoredEvmMatchDetails(swap, restoredSwaps)?.restoredSwap;
+
+export const enrichEvmRescueResults = (
+    swaps: EvmRescueResult[],
+    restoredSwaps: RestoredEvmSwap[],
+): EvmRescueResult[] =>
+    swaps.map((swap) => {
+        const match = getRestoredEvmMatchDetails(swap, restoredSwaps);
+        if (match === undefined) {
+            return swap;
+        }
+
+        return {
+            ...swap,
+            restoredSwap: match.restoredSwap,
+            dex: match.restoredSwap.dex,
+            bridge: match.restoredSwap.bridge,
+        };
+    });
+
+export const mapRestoredEvmSwaps = async (
+    swaps: RestorableSwap[],
+    mnemonic: string,
+): Promise<RestoredEvmSwap[]> => {
+    return await hydrateRestorableSwapsMetadata(
+        swaps.filter(hasPreimageHash),
+        mnemonic,
+    ).then(filterHydratedEvmSwaps);
+};
+
+const getRestoredEvmSwapKey = (swap: RestoredEvmSwap) =>
+    normalizeEvmId(swap.preimageHash) ||
+    normalizeEvmId(swap.lockupTx) ||
+    normalizeEvmId(swap.commitmentLockupTxHash) ||
+    swap.id;
+
+export const mergeRestoredEvmSwaps = (
+    current: RestoredEvmSwap[],
+    next: RestoredEvmSwap[],
+): RestoredEvmSwap[] => {
+    const merged = new Map<string, RestoredEvmSwap>();
+
+    for (const swap of current) {
+        merged.set(getRestoredEvmSwapKey(swap), swap);
+    }
+
+    for (const swap of next) {
+        const key = getRestoredEvmSwapKey(swap);
+        const existing = merged.get(key);
+        merged.set(key, {
+            ...existing,
+            ...swap,
+            evmClaimDetails: swap.evmClaimDetails ?? existing?.evmClaimDetails,
+            dex: swap.dex ?? existing?.dex,
+            bridge: swap.bridge ?? existing?.bridge,
+        });
+    }
+
+    return [...merged.values()];
+};
 
 export const getSwapDate = (swap: {
     date?: number;
@@ -136,41 +282,32 @@ export const fetchPaginatedRestorableSwaps = async (
     return restorableSwaps;
 };
 
+type HydratedRestorableSwap = RestorableSwap & SwapMetadataLocalFields;
+
+export const mapHydratedRestorableSwaps = (
+    swaps: HydratedRestorableSwap[],
+): Partial<SomeSwap>[] =>
+    swaps
+        .map(mapSwap)
+        .filter((swap): swap is Partial<SomeSwap> => swap !== undefined);
+
+export const filterHydratedEvmSwaps = (
+    swaps: HydratedRestorableSwap[],
+): RestoredEvmSwap[] =>
+    swaps.filter(
+        (swap): swap is RestoredEvmSwap =>
+            hasPreimageHash(swap) &&
+            (normalizeEvmId(swap.lockupTx) !== "" ||
+                normalizeEvmId(swap.commitmentLockupTxHash) !== ""),
+    );
+
 export const mapRestorableSwaps = async (
     swaps: RestorableSwap[],
     mnemonic: string,
-): Promise<Partial<SomeSwap>[]> => {
-    const mapped = await Promise.all(
-        swaps.map(async (swap) => {
-            const base = mapSwap(swap);
-            if (base === undefined || swap.metadata === undefined) {
-                return base;
-            }
-
-            try {
-                const metadata = await decryptSwapMetadata(
-                    mnemonic,
-                    swap.id,
-                    swap.metadata,
-                );
-                return {
-                    ...base,
-                    ...metadata,
-                };
-            } catch (e) {
-                log.warn(
-                    `failed to decrypt metadata for swap ${swap.id}, falling back to on-chain assets:`,
-                    formatError(e),
-                );
-                return base;
-            }
-        }),
+): Promise<Partial<SomeSwap>[]> =>
+    mapHydratedRestorableSwaps(
+        await hydrateRestorableSwapsMetadata(swaps, mnemonic),
     );
-
-    return mapped.filter(
-        (swap): swap is Partial<SomeSwap> => swap !== undefined,
-    );
-};
 
 export const getEvmScanTargets = (
     getEtherSwap: (asset: string) => SwapContract,

--- a/src/pages/external-rescue/scan.ts
+++ b/src/pages/external-rescue/scan.ts
@@ -43,8 +43,7 @@ export const normalizeEvmId = (value: string | undefined): string =>
     value?.toLowerCase().replace(/^0x/, "") ?? "";
 
 type RestoredEvmMatchReason =
-    | "metadata-lockup-transaction"
-    | "metadata-commitment-transaction";
+    "metadata-lockup-transaction" | "metadata-commitment-transaction";
 
 type RestoredEvmMatch = {
     restoredSwap: RestoredEvmSwap;

--- a/src/pages/external-rescue/types.ts
+++ b/src/pages/external-rescue/types.ts
@@ -52,8 +52,19 @@ export type RestoredEvmSwap = RestorableSwap & {
     preimageHash: string;
     lockupTx?: string;
     commitmentLockupTxHash?: string;
+    originalDestination?: string;
     dex?: DexDetail;
     bridge?: BridgeDetail;
+};
+
+export type RestorableEvmClaimDetails = {
+    type?: "evm";
+    contractAddress: string;
+    claimAddress: string;
+    transaction?: { id: string };
+    amount?: number;
+    keyIndex?: number;
+    timeoutBlockHeight: number;
 };
 
 export type EvmRescueResult = LogRefundData & {

--- a/src/pages/external-rescue/types.ts
+++ b/src/pages/external-rescue/types.ts
@@ -1,9 +1,11 @@
+import type { RestorableSwap } from "boltz-swaps/client";
 import type { SwapContract } from "boltz-swaps/evm";
 import type { LogRefundData, RskRescueMode } from "boltz-swaps/types";
 
 import type { Swap } from "../../components/SwapList";
 import type { GasAbstractionSweep } from "../../utils/gasAbstractionSweep";
 import type { RescueAction } from "../../utils/rescue";
+import type { BridgeDetail, DexDetail } from "../../utils/swapCreator";
 
 export enum RecoveryMethod {
     Key = "key",
@@ -46,9 +48,20 @@ export type ScanProgress = {
     updateUnmatched: (asset: string, unmatched: number) => void;
 };
 
+export type RestoredEvmSwap = RestorableSwap & {
+    preimageHash: string;
+    lockupTx?: string;
+    commitmentLockupTxHash?: string;
+    dex?: DexDetail;
+    bridge?: BridgeDetail;
+};
+
 export type EvmRescueResult = LogRefundData & {
     action: RskRescueMode;
     currentHeight?: bigint;
+    restoredSwap?: RestoredEvmSwap;
+    dex?: DexDetail;
+    bridge?: BridgeDetail;
 };
 
 export type UnifiedRescueResult =

--- a/src/pages/external-rescue/useExternalRescueSearch.ts
+++ b/src/pages/external-rescue/useExternalRescueSearch.ts
@@ -1,12 +1,14 @@
 import { useNavigate } from "@solidjs/router";
 import {
     type SwapContract,
+    createAssetProvider,
     createProvider,
+    getLogsFromReceipt,
     getTimelockBlockNumber,
     isEmptyPreimageHash,
     scanLockupEvents,
 } from "boltz-swaps/evm";
-import { RskRescueMode } from "boltz-swaps/types";
+import { AssetKind, RskRescueMode } from "boltz-swaps/types";
 import log from "loglevel";
 import {
     createEffect,
@@ -23,7 +25,7 @@ import type {
     RescueFileResult,
 } from "../../components/RescueFileUpload";
 import { config } from "../../config";
-import type { AssetType } from "../../consts/Assets";
+import { type AssetType, RBTC, getKindForAsset } from "../../consts/Assets";
 import { useGlobalContext } from "../../context/Global";
 import { useRescueContext } from "../../context/Rescue";
 import { useWeb3Signer } from "../../context/Web3";
@@ -49,13 +51,17 @@ import { PreimageHashesWorker } from "../../workers/preimageHashes/PreimageHashe
 import {
     arbitrumRescueAssets,
     enrichEvmRescueResults,
+    fetchEvmAddressRestorableSwaps,
     fetchPaginatedRestorableSwaps,
     filterHydratedEvmSwaps,
     getEvmRescueAction,
+    getEvmRestoreAccounts,
     getEvmScanTargets,
     getSwapDate,
     mapHydratedRestorableSwaps,
+    mapRestoredEvmClaimResultFromRescueKey,
     mergeEvmRescueResults,
+    mergeRestorableSwaps,
     mergeRestoredEvmSwaps,
     normalizeEvmId,
     sortUnifiedResults,
@@ -155,18 +161,13 @@ export const isEvmRestoreCandidate = (swap: RestoreSwapAssets) =>
 export const shouldShowEvmRestoreResult = (
     swap: RestoreSwapAssets,
     evmRescuePreimageHashes: Set<string>,
-    claimProgress: string | undefined,
 ) => {
     if (!isEvmRestoreCandidate(swap)) {
         return true;
     }
 
     const preimageHash = getRestorePreimageHash(swap);
-    if (evmRescuePreimageHashes.has(preimageHash)) {
-        return false;
-    }
-
-    return claimProgress === undefined;
+    return !evmRescuePreimageHashes.has(preimageHash);
 };
 
 export const useExternalRescueSearch = () => {
@@ -381,19 +382,7 @@ export const useExternalRescueSearch = () => {
             ),
     );
     const shouldShowRestoreResult = (swap: RestoreSwapAssets) =>
-        shouldShowEvmRestoreResult(
-            swap,
-            evmRescuePreimageHashes(),
-            state.evm.claimProgress,
-        );
-    const pendingRestoreCandidates = createMemo(
-        () =>
-            (btcRescueList() ?? []).filter(
-                (swap) =>
-                    isEvmRestoreCandidate(swap) &&
-                    !shouldShowRestoreResult(swap),
-            ).length,
-    );
+        shouldShowEvmRestoreResult(swap, evmRescuePreimageHashes());
 
     const unifiedResults = createMemo(() => {
         const btcResults: UnifiedRescueResult[] = (btcRescueList() ?? [])
@@ -440,10 +429,7 @@ export const useExternalRescueSearch = () => {
         ]);
     });
     const resultDisplaySlotCount = createMemo(
-        () =>
-            unifiedResults().length +
-            pendingRestoreCandidates() +
-            pendingEvmClaimCandidates(),
+        () => unifiedResults().length + pendingEvmClaimCandidates(),
     );
 
     const resetSearchResults = () => {
@@ -588,15 +574,23 @@ export const useExternalRescueSearch = () => {
         });
 
         try {
-            const restorableSwaps = await fetchPaginatedRestorableSwaps(
-                currentRescueFile,
-                (loadedSwaps) => setBtcState({ loadedSwaps }),
-                signal,
-            );
+            const [xpubRestorableSwaps, evmAddressRestorableSwaps] =
+                await Promise.all([
+                    fetchPaginatedRestorableSwaps(
+                        currentRescueFile,
+                        (loadedSwaps) => setBtcState({ loadedSwaps }),
+                        signal,
+                    ),
+                    fetchEvmAddressRestorableSwaps(currentRescueFile, signal),
+                ]);
             if (signal.aborted) {
                 return;
             }
 
+            const restorableSwaps = mergeRestorableSwaps(
+                xpubRestorableSwaps,
+                evmAddressRestorableSwaps,
+            );
             const hydratedRestorableSwaps =
                 await hydrateRestorableSwapsMetadata(
                     restorableSwaps,
@@ -607,8 +601,115 @@ export const useExternalRescueSearch = () => {
             const restoredEvmSwaps = filterHydratedEvmSwaps(
                 hydratedRestorableSwaps,
             );
+            const evmAddressSwapIds = new Set(
+                evmAddressRestorableSwaps.map((swap) => swap.id),
+            );
+            const restoredEvmAddressClaimSwaps = restoredEvmSwaps
+                .filter((swap) => evmAddressSwapIds.has(swap.id))
+                .map((swap) =>
+                    mapRestoredEvmClaimResultFromRescueKey(
+                        swap,
+                        currentRescueFile,
+                    ),
+                )
+                .filter((swap): swap is EvmRescueResult => swap !== undefined);
+
+            const rescueAddresses = new Set(
+                getEvmRestoreAccounts(currentRescueFile).map(({ account }) =>
+                    account.address.toLowerCase(),
+                ),
+            );
+            const timelockHeights = new Map<
+                string,
+                ReturnType<typeof getTimelockBlockNumber>
+            >();
+            const getCurrentTimelockHeight = (
+                asset: string,
+                provider: Parameters<typeof getTimelockBlockNumber>[0],
+            ) => {
+                let height = timelockHeights.get(asset);
+                if (height === undefined) {
+                    height = getTimelockBlockNumber(
+                        provider,
+                        asset as AssetType,
+                    );
+                    timelockHeights.set(asset, height);
+                }
+                return height;
+            };
+            const restoredEvmAddressRefundSwaps = (
+                await Promise.all(
+                    restoredEvmSwaps
+                        .filter((swap) => evmAddressSwapIds.has(swap.id))
+                        .map(
+                            async (
+                                swap,
+                            ): Promise<EvmRescueResult | undefined> => {
+                                const asset = swap.from;
+                                const transactionHash =
+                                    swap.commitmentLockupTxHash ??
+                                    swap.lockupTx;
+                                if (
+                                    asset === RBTC ||
+                                    transactionHash === undefined ||
+                                    config.assets?.[asset]?.network?.chainId ===
+                                        undefined
+                                ) {
+                                    return undefined;
+                                }
+
+                                try {
+                                    const provider = createAssetProvider(asset);
+                                    const contract =
+                                        getKindForAsset(asset) ===
+                                        AssetKind.ERC20
+                                            ? getErc20Swap(asset)
+                                            : getEtherSwap(asset);
+                                    const [logData, currentHeight] =
+                                        await Promise.all([
+                                            getLogsFromReceipt(
+                                                provider,
+                                                asset as AssetType,
+                                                contract,
+                                                transactionHash,
+                                            ),
+                                            getCurrentTimelockHeight(
+                                                asset,
+                                                provider,
+                                            ),
+                                        ]);
+
+                                    if (
+                                        !rescueAddresses.has(
+                                            logData.refundAddress.toLowerCase(),
+                                        )
+                                    ) {
+                                        return undefined;
+                                    }
+
+                                    return {
+                                        ...logData,
+                                        action: RskRescueMode.Refund,
+                                        currentHeight: BigInt(currentHeight),
+                                        restoredSwap: swap,
+                                        dex: swap.dex,
+                                        bridge: swap.bridge,
+                                    } satisfies EvmRescueResult;
+                                } catch (error) {
+                                    log.warn(
+                                        `failed to restore EVM refund for swap ${swap.id}:`,
+                                        formatError(error),
+                                    );
+                                    return undefined;
+                                }
+                            },
+                        ),
+                )
+            ).filter((swap): swap is EvmRescueResult => swap !== undefined);
 
             appendRestoredEvmSwaps(restoredEvmSwaps);
+            appendEvmSwaps(RskRescueMode.Claim, restoredEvmAddressClaimSwaps);
+            appendEvmSwaps(RskRescueMode.Refund, restoredEvmAddressRefundSwaps);
 
             setBtcState({
                 swaps: mapHydratedRestorableSwaps(hydratedRestorableSwaps),
@@ -629,7 +730,7 @@ export const useExternalRescueSearch = () => {
 
     const runSingleScan = async (
         target: EvmScanTarget,
-        signerAddress: Address,
+        signerAddress: Address | undefined,
         action: RskRescueMode,
         scanProgress: ScanProgress,
         signal: AbortSignal,
@@ -637,6 +738,7 @@ export const useExternalRescueSearch = () => {
         mnemonic?: string,
     ) => {
         const provider = createProvider([target.providerUrl]);
+        let scanAddress = signerAddress;
         const extraAddresses: string[] = [];
         if (mnemonic) {
             const chainId = config.assets?.[target.asset]?.network?.chainId;
@@ -644,10 +746,21 @@ export const useExternalRescueSearch = () => {
                 const gasKey = mnemonicToHDKey(mnemonic).derive(
                     getPathGasAbstraction(chainId),
                 );
-                extraAddresses.push(
-                    evmAccountFromPrivateKey(gasKey.privateKey).address,
-                );
+                const rescueAddress = evmAccountFromPrivateKey(
+                    gasKey.privateKey,
+                ).address;
+                if (scanAddress === undefined) {
+                    scanAddress = rescueAddress;
+                } else if (
+                    scanAddress.toLowerCase() !== rescueAddress.toLowerCase()
+                ) {
+                    extraAddresses.push(rescueAddress);
+                }
             }
+        }
+
+        if (scanAddress === undefined) {
+            return;
         }
 
         let currentHeight: bigint | undefined;
@@ -680,7 +793,7 @@ export const useExternalRescueSearch = () => {
                 providerUrl: target.providerUrl,
                 scanInterval: target.scanInterval,
                 filter: {
-                    address: signerAddress,
+                    address: scanAddress,
                     extraAddresses:
                         extraAddresses.length > 0 ? extraAddresses : undefined,
                 },
@@ -717,7 +830,7 @@ export const useExternalRescueSearch = () => {
 
     const runEvmScan = async (
         action: RskRescueMode,
-        signerAddress: Address,
+        signerAddress: Address | undefined,
         signal: AbortSignal,
         currentRescueFile?: RescueFile,
     ) => {
@@ -726,6 +839,7 @@ export const useExternalRescueSearch = () => {
             getErc20Swap as (a: string) => SwapContract,
             action,
             currentRescueFile !== undefined,
+            signerAddress !== undefined,
         );
 
         if (targets.length === 0) {
@@ -748,7 +862,9 @@ export const useExternalRescueSearch = () => {
         const scanProgress = createScanProgress(setProgress, setUnmatched);
 
         const sweepBalances =
-            action === RskRescueMode.Refund && currentRescueFile !== undefined
+            action === RskRescueMode.Refund &&
+            currentRescueFile !== undefined &&
+            signerAddress !== undefined
                 ? getSweepableGasAbstractionBalances({
                       destination: signerAddress,
                       rescueFile: currentRescueFile,
@@ -811,8 +927,8 @@ export const useExternalRescueSearch = () => {
                 tasks.push(runBtcRestore(currentRescueFile, signal));
             }
 
-            if (currentSigner && evmAvailable) {
-                const signerAddress = currentSigner.address;
+            if (evmAvailable && (currentSigner || currentRescueFile)) {
+                const signerAddress = currentSigner?.address;
 
                 if (signal.aborted) {
                     return;
@@ -914,7 +1030,6 @@ export const useExternalRescueSearch = () => {
             displaySlotCount: resultDisplaySlotCount,
             hasAny: hasAnyResults,
             open: openResult,
-            pendingRestoreCandidates,
             setCurrent: setCurrentResults,
             setCurrentPage: setCurrentResultPage,
         },

--- a/src/pages/external-rescue/useExternalRescueSearch.ts
+++ b/src/pages/external-rescue/useExternalRescueSearch.ts
@@ -3,9 +3,10 @@ import {
     type SwapContract,
     createProvider,
     getTimelockBlockNumber,
+    isEmptyPreimageHash,
     scanLockupEvents,
 } from "boltz-swaps/evm";
-import { type LogRefundData, RskRescueMode } from "boltz-swaps/types";
+import { RskRescueMode } from "boltz-swaps/types";
 import log from "loglevel";
 import {
     createEffect,
@@ -43,14 +44,20 @@ import {
 } from "../../utils/rescueDerivation";
 import { type RescueFile, getPathGasAbstraction } from "../../utils/rescueFile";
 import type { SomeSwap } from "../../utils/swapCreator";
+import { hydrateRestorableSwapsMetadata } from "../../utils/swapMetadata";
 import { PreimageHashesWorker } from "../../workers/preimageHashes/PreimageHashesWorker";
 import {
     arbitrumRescueAssets,
+    enrichEvmRescueResults,
     fetchPaginatedRestorableSwaps,
+    filterHydratedEvmSwaps,
     getEvmRescueAction,
     getEvmScanTargets,
     getSwapDate,
-    mapRestorableSwaps,
+    mapHydratedRestorableSwaps,
+    mergeEvmRescueResults,
+    mergeRestoredEvmSwaps,
+    normalizeEvmId,
     sortUnifiedResults,
 } from "./scan";
 import {
@@ -60,6 +67,7 @@ import {
     RecoveryMethod,
     type RecoveryOption,
     RescueResultSource,
+    type RestoredEvmSwap,
     type ScanProgress,
     type UnifiedRescueResult,
 } from "./types";
@@ -93,6 +101,7 @@ type EvmState = {
     unmatchedRefundSwaps: number;
     unmatchedClaimSwaps: number;
     sweepableBalances: GasAbstractionSweep[];
+    restoredSwaps: RestoredEvmSwap[];
 };
 
 type ExternalRescueState = {
@@ -120,8 +129,45 @@ const initialExternalRescueState = (): ExternalRescueState => ({
         unmatchedRefundSwaps: 0,
         unmatchedClaimSwaps: 0,
         sweepableBalances: [],
+        restoredSwaps: [],
     },
 });
+
+type RestoreSwapAssets = {
+    assetSend?: string;
+    assetReceive?: string;
+    from?: string;
+    preimageHash?: string;
+    to?: string;
+};
+
+export const getRestorePreimageHash = (swap: { preimageHash?: string }) =>
+    normalizeEvmId(swap.preimageHash);
+
+export const isEvmRestoreCandidate = (swap: RestoreSwapAssets) =>
+    getRestorePreimageHash(swap) !== "" &&
+    [swap.assetReceive, swap.to, swap.assetSend, swap.from].some(
+        (asset) =>
+            asset !== undefined &&
+            config.assets?.[asset]?.network?.chainId !== undefined,
+    );
+
+export const shouldShowEvmRestoreResult = (
+    swap: RestoreSwapAssets,
+    evmRescuePreimageHashes: Set<string>,
+    claimProgress: string | undefined,
+) => {
+    if (!isEvmRestoreCandidate(swap)) {
+        return true;
+    }
+
+    const preimageHash = getRestorePreimageHash(swap);
+    if (evmRescuePreimageHashes.has(preimageHash)) {
+        return false;
+    }
+
+    return claimProgress === undefined;
+};
 
 export const useExternalRescueSearch = () => {
     const { t } = useGlobalContext();
@@ -198,12 +244,30 @@ export const useExternalRescueSearch = () => {
                 action === RskRescueMode.Refund
                     ? {
                           ...current.evm,
-                          refundSwaps: current.evm.refundSwaps.concat(events),
+                          refundSwaps: mergeEvmRescueResults(
+                              current.evm.refundSwaps,
+                              events,
+                          ),
                       }
                     : {
                           ...current.evm,
-                          claimSwaps: current.evm.claimSwaps.concat(events),
+                          claimSwaps: mergeEvmRescueResults(
+                              current.evm.claimSwaps,
+                              events,
+                          ),
                       },
+        }));
+    };
+    const appendRestoredEvmSwaps = (swaps: RestoredEvmSwap[]) => {
+        setState((current) => ({
+            ...current,
+            evm: {
+                ...current.evm,
+                restoredSwaps: mergeRestoredEvmSwaps(
+                    current.evm.restoredSwaps,
+                    swaps,
+                ),
+            },
         }));
     };
     const [currentResultPage, setCurrentResultPage] = createSignal(1);
@@ -223,11 +287,29 @@ export const useExternalRescueSearch = () => {
         },
     );
 
+    const enrichedEvmRefundSwaps = createMemo(() =>
+        enrichEvmRescueResults(state.evm.refundSwaps, state.evm.restoredSwaps),
+    );
+    const enrichedEvmClaimSwaps = createMemo(() =>
+        enrichEvmRescueResults(state.evm.claimSwaps, state.evm.restoredSwaps),
+    );
+
+    const allEvmSwaps = createMemo(() => [
+        ...enrichedEvmRefundSwaps(),
+        ...enrichedEvmClaimSwaps(),
+    ]);
+    const shouldDeferEvmResult = (swap: EvmRescueResult) =>
+        state.btc.searchState === BtcSearchState.Loading &&
+        swap.restoredSwap === undefined;
+    const visibleEvmSwaps = createMemo(() =>
+        allEvmSwaps().filter((swap) => !shouldDeferEvmResult(swap)),
+    );
+    const pendingEvmClaimCandidates = createMemo(
+        () => allEvmSwaps().filter(shouldDeferEvmResult).length,
+    );
+
     createEffect(() => {
-        setEvmRescuableSwaps([
-            ...state.evm.refundSwaps,
-            ...state.evm.claimSwaps,
-        ]);
+        setEvmRescuableSwaps(allEvmSwaps());
     });
 
     const activeMethods = createMemo<RecoveryMethod[]>(() => {
@@ -282,10 +364,41 @@ export const useExternalRescueSearch = () => {
     const currentEvmProgress = createMemo(
         () => state.evm.claimProgress ?? state.evm.refundProgress,
     );
+    const evmRescuePreimageHashes = createMemo(
+        () =>
+            new Set(
+                visibleEvmSwaps()
+                    .flatMap((swap) => [
+                        swap.preimageHash,
+                        swap.restoredSwap?.preimageHash,
+                    ])
+                    .filter(
+                        (preimageHash): preimageHash is string =>
+                            normalizeEvmId(preimageHash) !== "" &&
+                            !isEmptyPreimageHash(preimageHash),
+                    )
+                    .map(normalizeEvmId),
+            ),
+    );
+    const shouldShowRestoreResult = (swap: RestoreSwapAssets) =>
+        shouldShowEvmRestoreResult(
+            swap,
+            evmRescuePreimageHashes(),
+            state.evm.claimProgress,
+        );
+    const pendingRestoreCandidates = createMemo(
+        () =>
+            (btcRescueList() ?? []).filter(
+                (swap) =>
+                    isEvmRestoreCandidate(swap) &&
+                    !shouldShowRestoreResult(swap),
+            ).length,
+    );
 
     const unifiedResults = createMemo(() => {
-        const btcResults: UnifiedRescueResult[] = (btcRescueList() ?? []).map(
-            (swap) => {
+        const btcResults: UnifiedRescueResult[] = (btcRescueList() ?? [])
+            .filter(shouldShowRestoreResult)
+            .map((swap): UnifiedRescueResult => {
                 const action = swap.action ?? RescueAction.Pending;
                 return {
                     source: RescueResultSource.Restore,
@@ -295,23 +408,21 @@ export const useExternalRescueSearch = () => {
                     sortValue: getSwapDate(swap),
                     swap,
                 };
+            });
+        const evmResults: UnifiedRescueResult[] = visibleEvmSwaps().map(
+            (swap) => {
+                const action = getEvmRescueAction(swap);
+                return {
+                    source: RescueResultSource.Evm,
+                    key: `evm:${swap.action}:${swap.asset}:${swap.transactionHash}`,
+                    action,
+                    evmAction: swap.action,
+                    actionable: !RescueNoAction.includes(action),
+                    sortValue: swap.blockNumber,
+                    swap,
+                };
             },
         );
-        const evmResults: UnifiedRescueResult[] = [
-            ...state.evm.refundSwaps,
-            ...state.evm.claimSwaps,
-        ].map((swap) => {
-            const action = getEvmRescueAction(swap);
-            return {
-                source: RescueResultSource.Evm,
-                key: `evm:${swap.action}:${swap.asset}:${swap.transactionHash}`,
-                action,
-                evmAction: swap.action,
-                actionable: !RescueNoAction.includes(action),
-                sortValue: swap.blockNumber,
-                swap,
-            };
-        });
         const sweepResults: UnifiedRescueResult[] =
             state.evm.sweepableBalances.map((swap) => ({
                 source: RescueResultSource.Sweep,
@@ -328,6 +439,12 @@ export const useExternalRescueSearch = () => {
             ...sweepResults,
         ]);
     });
+    const resultDisplaySlotCount = createMemo(
+        () =>
+            unifiedResults().length +
+            pendingRestoreCandidates() +
+            pendingEvmClaimCandidates(),
+    );
 
     const resetSearchResults = () => {
         setSearchState({ hasSearched: false, error: undefined });
@@ -347,6 +464,7 @@ export const useExternalRescueSearch = () => {
             unmatchedRefundSwaps: 0,
             unmatchedClaimSwaps: 0,
             sweepableBalances: [],
+            restoredSwaps: [],
         });
         setRescuableSwaps([]);
     };
@@ -478,13 +596,22 @@ export const useExternalRescueSearch = () => {
             if (signal.aborted) {
                 return;
             }
-            setRescuableSwaps(restorableSwaps);
 
-            setBtcState({
-                swaps: await mapRestorableSwaps(
+            const hydratedRestorableSwaps =
+                await hydrateRestorableSwapsMetadata(
                     restorableSwaps,
                     currentRescueFile.mnemonic,
-                ),
+                );
+            setRescuableSwaps(hydratedRestorableSwaps);
+
+            const restoredEvmSwaps = filterHydratedEvmSwaps(
+                hydratedRestorableSwaps,
+            );
+
+            appendRestoredEvmSwaps(restoredEvmSwaps);
+
+            setBtcState({
+                swaps: mapHydratedRestorableSwaps(hydratedRestorableSwaps),
                 searchState: BtcSearchState.Ready,
             });
         } catch (e) {
@@ -509,6 +636,7 @@ export const useExternalRescueSearch = () => {
         onEvents: (events: EvmRescueResult[]) => void,
         mnemonic?: string,
     ) => {
+        const provider = createProvider([target.providerUrl]);
         const extraAddresses: string[] = [];
         if (mnemonic) {
             const chainId = config.assets?.[target.asset]?.network?.chainId;
@@ -527,7 +655,7 @@ export const useExternalRescueSearch = () => {
             try {
                 currentHeight = BigInt(
                     await getTimelockBlockNumber(
-                        createProvider([target.providerUrl]),
+                        provider,
                         target.asset as AssetType,
                     ),
                 );
@@ -575,13 +703,13 @@ export const useExternalRescueSearch = () => {
             scanProgress.update(target.asset, progress, derivedKeys);
 
             if (events.length > 0) {
-                onEvents(
-                    events.map((event: LogRefundData) => ({
-                        ...event,
-                        action,
-                        currentHeight,
-                    })),
-                );
+                const evmEvents = events.map((event) => ({
+                    ...event,
+                    action,
+                    currentHeight,
+                }));
+
+                onEvents(evmEvents);
             }
             scanProgress.updateUnmatched(target.asset, unmatchedSwaps);
         }
@@ -783,8 +911,10 @@ export const useExternalRescueSearch = () => {
             current: currentResults,
             currentEvmProgress,
             currentPage: currentResultPage,
+            displaySlotCount: resultDisplaySlotCount,
             hasAny: hasAnyResults,
             open: openResult,
+            pendingRestoreCandidates,
             setCurrent: setCurrentResults,
             setCurrentPage: setCurrentResultPage,
         },

--- a/src/status/TransactionConfirmed.tsx
+++ b/src/status/TransactionConfirmed.tsx
@@ -159,7 +159,7 @@ const getPostBridgeQuoteOptions = async (
         .buildQuoteOptions(bridge.destinationAsset, destination, getGasToken);
 
 const getAcceptedQuoteAmount = async (
-    amount: number,
+    amount: number | bigint,
     claimAsset: string,
     hop: EncodedHop,
     quote: ClaimQuote,
@@ -267,7 +267,7 @@ const claimErc20ViaRouter = async (
     gasAbstraction: GasAbstractionType,
     asset: string,
     preimage: string,
-    amount: number,
+    amount: number | bigint,
     refundAddress: string,
     timeoutBlockHeight: number,
     destination: string,
@@ -332,7 +332,7 @@ const claimErc20ViaRouterBridge = async (
     gasAbstraction: GasAbstractionType,
     asset: string,
     preimage: string,
-    amount: number,
+    amount: number | bigint,
     refundAddress: string,
     timeoutBlockHeight: number,
     destination: string,
@@ -529,7 +529,7 @@ const getHopRouterClaimExecution = (
 
 const getGasTokenRouterClaimExecution = async (
     asset: string,
-    amount: number,
+    amount: number | bigint,
     destination: string,
 ): Promise<RouterClaimExecution> => {
     const assetAmount = satsToAssetAmount(amount, asset);
@@ -562,12 +562,12 @@ const getGasTokenRouterClaimExecution = async (
     };
 };
 
-const claimHops = async (
+export const claimHops = async (
     hops: EncodedHop[],
     gasAbstraction: GasAbstractionType,
     asset: string,
     preimage: string,
-    amount: number,
+    amount: number | bigint,
     refundAddress: string,
     timeoutBlockHeight: number,
     destination: string,

--- a/src/style/loadingSpinner.scss
+++ b/src/style/loadingSpinner.scss
@@ -34,6 +34,19 @@
     }
 }
 
+.inline-spinner {
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.rescue-evm-refund-amount {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35em;
+    margin: 1em 0;
+}
+
 .restore-loading-spinner {
     margin-top: 0;
 }

--- a/src/utils/Pair.ts
+++ b/src/utils/Pair.ts
@@ -78,7 +78,7 @@ export const toDexAmount = (
         : satsToAssetAmount(toIntegerAmount(amount), asset);
 
 /** Convert an EVM base unit amount from the DEX API back to internal representation. */
-const fromDexAmount = (amount: bigint, asset: string): BigNumber =>
+export const fromDexAmount = (amount: bigint, asset: string): BigNumber =>
     isRoutedAsset(asset)
         ? BigNumber(amount.toString())
         : BigNumber(assetAmountToSats(amount, asset).toString());

--- a/src/utils/evmLockup.ts
+++ b/src/utils/evmLockup.ts
@@ -1,3 +1,15 @@
+import { createAssetProvider } from "boltz-swaps/evm";
+import {
+    type Hash,
+    type Log,
+    erc20Abi,
+    getAddress,
+    isAddressEqual,
+    parseEventLogs,
+} from "viem";
+
+import { requireRouterAddress } from "../consts/Assets";
+
 export const lockupGasUsage = 46_000n;
 
 export const getNativeEvmLockupSpendableBalance = (
@@ -6,4 +18,45 @@ export const getNativeEvmLockupSpendableBalance = (
 ) => {
     const reserve = gasPrice * lockupGasUsage;
     return balance > reserve ? balance - reserve : 0n;
+};
+
+// Gas-abstraction lockups are sent by the gas key, so the funding EOA can
+// only be recovered from the Permit2 pull (tokenIn -> router) in the receipt.
+export const findLockupTokenFunder = (
+    logs: Log[],
+    tokenIn: string,
+    routerAddress: string,
+): string | undefined => {
+    const token = getAddress(tokenIn);
+    const router = getAddress(routerAddress);
+
+    return parseEventLogs({
+        abi: erc20Abi,
+        eventName: "Transfer",
+        logs,
+    }).find(
+        (transfer) =>
+            isAddressEqual(getAddress(transfer.address), token) &&
+            isAddressEqual(transfer.args.to, router) &&
+            !isAddressEqual(transfer.args.from, router),
+    )?.args.from;
+};
+
+export const resolveLockupTokenFunder = async (
+    asset: string,
+    tokenIn: string,
+    lockupTxHash: string,
+): Promise<string | undefined> => {
+    const receipt = await createAssetProvider(asset).getTransactionReceipt({
+        hash: lockupTxHash as Hash,
+    });
+    if (receipt === null) {
+        return undefined;
+    }
+
+    return findLockupTokenFunder(
+        receipt.logs,
+        tokenIn,
+        requireRouterAddress(asset),
+    );
 };

--- a/src/utils/swapCreator.ts
+++ b/src/utils/swapCreator.ts
@@ -70,6 +70,7 @@ export type BridgeDetail = BridgeRoute & {
     details?: BridgeDetails;
     pendingSend?: PendingBridgeSend;
     evmSendCandidate?: PendingEvmBridgeSend;
+    refundAddress?: string;
 
     // Recovery state when a pre-bridge DEX quote falls short and the bridged
     // funds must be retried or refunded back to the original sender.

--- a/src/utils/swapMetadata.ts
+++ b/src/utils/swapMetadata.ts
@@ -1,9 +1,10 @@
 import { hex } from "@scure/base";
-import { patchSwapMetadata } from "boltz-swaps/client";
+import { type RestorableSwap, patchSwapMetadata } from "boltz-swaps/client";
 import { BridgeKind, SwapPosition, SwapType } from "boltz-swaps/types";
 import log from "loglevel";
 
 import type { EncodedHop } from "./Pair";
+import { formatError } from "./errors";
 import type { RescueFile } from "./rescueFile";
 import type {
     BridgeDetail,
@@ -14,7 +15,7 @@ import type {
 
 type SwapMetadataBridge = Pick<
     BridgeDetail,
-    "sourceAsset" | "destinationAsset" | "kind" | "position"
+    "sourceAsset" | "destinationAsset" | "kind" | "position" | "refundAddress"
 >;
 type SwapMetadataDex = Pick<DexDetail, "hops" | "position" | "quoteAmount">;
 type SwapMetadataTxIdentity = Pick<
@@ -32,6 +33,10 @@ export type SwapMetadataSource = SwapMetadataTxIdentity & {
 };
 
 export type SwapMetadataPayload = SwapMetadataTxIdentity & SwapMetadataRoute;
+export type SwapMetadataLocalFields = Pick<
+    SwapMetadataPayload,
+    "dex" | "bridge" | "lockupTx" | "commitmentLockupTxHash"
+>;
 
 // The payload plus the id of the swap it belongs to, sealed in so that
 // the backend cannot serve one swap's metadata for another. Optional only
@@ -169,6 +174,7 @@ const parseSwapMetadataPlaintext = parseObject<SwapMetadataPlaintext>({
             destinationAsset: parseString,
             kind: parseEnum(BridgeKind),
             position: parseEnum(SwapPosition),
+            refundAddress: parseOptional(parseString),
         }),
     ),
     lockupTx: parseOptional(parseString),
@@ -315,6 +321,7 @@ export const buildSwapMetadataPayload = (
             destinationAsset: fields.bridge.destinationAsset,
             kind: fields.bridge.kind,
             position: fields.bridge.position,
+            refundAddress: fields.bridge.refundAddress,
         };
     }
 
@@ -375,3 +382,59 @@ export const patchEncryptedSwapMetadata = async (
         });
     }
 };
+
+export const swapMetadataToLocalFields = (
+    payload: SwapMetadataPayload,
+): SwapMetadataLocalFields => {
+    const fields: SwapMetadataLocalFields = {};
+
+    if (payload.dex !== undefined) {
+        fields.dex = payload.dex;
+    }
+
+    if (payload.bridge !== undefined) {
+        fields.bridge = payload.bridge;
+    }
+
+    if (payload.lockupTx !== undefined) {
+        fields.lockupTx = payload.lockupTx;
+    }
+
+    if (payload.commitmentLockupTxHash !== undefined) {
+        fields.commitmentLockupTxHash = payload.commitmentLockupTxHash;
+    }
+
+    return fields;
+};
+
+export const hydrateRestorableSwapMetadata = async <T extends RestorableSwap>(
+    swap: T,
+    mnemonic: string,
+): Promise<T & SwapMetadataLocalFields> => {
+    if (swap.metadata === undefined) {
+        return swap;
+    }
+
+    try {
+        return {
+            ...swap,
+            ...swapMetadataToLocalFields(
+                await decryptSwapMetadata(mnemonic, swap.id, swap.metadata),
+            ),
+        };
+    } catch (e) {
+        log.warn(
+            `failed to decrypt metadata for swap ${swap.id}, falling back to on-chain assets:`,
+            formatError(e),
+        );
+        return swap;
+    }
+};
+
+export const hydrateRestorableSwapsMetadata = <T extends RestorableSwap>(
+    swaps: T[],
+    mnemonic: string,
+): Promise<(T & SwapMetadataLocalFields)[]> =>
+    Promise.all(
+        swaps.map((swap) => hydrateRestorableSwapMetadata(swap, mnemonic)),
+    );

--- a/src/utils/swapMetadata.ts
+++ b/src/utils/swapMetadata.ts
@@ -20,7 +20,7 @@ type SwapMetadataBridge = Pick<
 type SwapMetadataDex = Pick<DexDetail, "hops" | "position" | "quoteAmount">;
 type SwapMetadataTxIdentity = Pick<
     SwapBase,
-    "lockupTx" | "commitmentLockupTxHash"
+    "lockupTx" | "commitmentLockupTxHash" | "originalDestination"
 >;
 type SwapMetadataDexDetails = NonNullable<EncodedHop["dexDetails"]>;
 type SwapMetadataRoute = {
@@ -35,7 +35,11 @@ export type SwapMetadataSource = SwapMetadataTxIdentity & {
 export type SwapMetadataPayload = SwapMetadataTxIdentity & SwapMetadataRoute;
 export type SwapMetadataLocalFields = Pick<
     SwapMetadataPayload,
-    "dex" | "bridge" | "lockupTx" | "commitmentLockupTxHash"
+    | "dex"
+    | "bridge"
+    | "lockupTx"
+    | "commitmentLockupTxHash"
+    | "originalDestination"
 >;
 
 // The payload plus the id of the swap it belongs to, sealed in so that
@@ -179,6 +183,7 @@ const parseSwapMetadataPlaintext = parseObject<SwapMetadataPlaintext>({
     ),
     lockupTx: parseOptional(parseString),
     commitmentLockupTxHash: parseOptional(parseString),
+    originalDestination: parseOptional(parseString),
     swapId: parseOptional(parseString),
 });
 
@@ -333,6 +338,10 @@ export const buildSwapMetadataPayload = (
         payload.commitmentLockupTxHash = fields.commitmentLockupTxHash;
     }
 
+    if (fields.originalDestination !== undefined) {
+        payload.originalDestination = fields.originalDestination;
+    }
+
     return Object.keys(payload).length > 0 ? payload : undefined;
 };
 
@@ -344,6 +353,7 @@ export const buildSwapMetadataPayloadFromSwap = (
         commitmentLockupTxHash: swap.commitmentLockupTxHash,
         dex: swap.dex,
         lockupTx: swap.lockupTx,
+        originalDestination: swap.originalDestination,
     });
 
 export const patchEncryptedSwapMetadata = async (
@@ -402,6 +412,10 @@ export const swapMetadataToLocalFields = (
 
     if (payload.commitmentLockupTxHash !== undefined) {
         fields.commitmentLockupTxHash = payload.commitmentLockupTxHash;
+    }
+
+    if (payload.originalDestination !== undefined) {
+        fields.originalDestination = payload.originalDestination;
     }
 
     return fields;

--- a/tests/pages/RescueEvm.spec.tsx
+++ b/tests/pages/RescueEvm.spec.tsx
@@ -29,11 +29,13 @@ const preimage =
 
 const {
     mockGetLogsFromReceipt,
+    mockQuoteDexAmountIn,
     mockResolveLockupTokenFunder,
     paramsMock,
     rescueSwaps,
 } = vi.hoisted(() => ({
     mockGetLogsFromReceipt: vi.fn(),
+    mockQuoteDexAmountIn: vi.fn(),
     mockResolveLockupTokenFunder: vi.fn(),
     paramsMock: {
         current: {
@@ -44,6 +46,14 @@ const {
     },
     rescueSwaps: { current: [] as EvmRescueResult[] },
 }));
+
+vi.mock("boltz-swaps/client", async () => {
+    const actual = await vi.importActual("boltz-swaps/client");
+    return {
+        ...actual,
+        quoteDexAmountIn: mockQuoteDexAmountIn,
+    };
+});
 
 vi.mock("@solidjs/router", async () => {
     const actual = await vi.importActual<typeof SolidRouter>("@solidjs/router");
@@ -110,6 +120,16 @@ vi.mock("../../src/context/Rescue", async () => {
     const actual = await vi.importActual<typeof RescueContextModule>(
         "../../src/context/Rescue",
     );
+    // Back rescueSwaps.current with a signal so writes after render are
+    // reactive, like the real context
+    const { createSignal } = await import("solid-js");
+    const [swaps, setSwaps] = createSignal<EvmRescueResult[]>(
+        rescueSwaps.current,
+    );
+    Object.defineProperty(rescueSwaps, "current", {
+        get: () => swaps(),
+        set: setSwaps,
+    });
     return {
         ...actual,
         RescueProvider: (props: { children: JSX.Element }) => (
@@ -136,7 +156,8 @@ vi.mock("../../src/components/RefundButton", () => ({
     ),
 }));
 
-const { default: RescueEvm } = await import("../../src/pages/RescueEvm");
+const { default: RescueEvm, fetchEvmRefundDisplayQuote } =
+    await import("../../src/pages/RescueEvm");
 
 const logData = {
     asset: TBTC,
@@ -211,6 +232,7 @@ describe("RescueEvm", () => {
             action: RskRescueMode.Claim,
         };
         mockGetLogsFromReceipt.mockResolvedValue(logData);
+        mockQuoteDexAmountIn.mockResolvedValue([]);
         mockResolveLockupTokenFunder.mockResolvedValue(originalFunder);
         rescueSwaps.current = [
             {
@@ -396,5 +418,86 @@ describe("RescueEvm", () => {
             screen.queryByRole("button", { name: "Connect wallet" }),
         ).toBeNull();
         expect(screen.queryByRole("button", { name: "Claim" })).toBeNull();
+    });
+
+    test("attaches routed claim metadata when the scan populates the context after load", async () => {
+        rescueSwaps.current = [];
+
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        expect(
+            await screen.findByText(i18n.en.claim_scan_required),
+        ).toBeInTheDocument();
+
+        rescueSwaps.current = [
+            {
+                ...logData,
+                action: RskRescueMode.Claim,
+                preimage,
+                restoredSwap: {
+                    ...restoredSwap,
+                    originalDestination,
+                    dex: postDex,
+                },
+            },
+        ];
+
+        expect(
+            await screen.findByRole("button", { name: i18n.en.continue }),
+        ).toBeInTheDocument();
+        expect(screen.queryByText(i18n.en.claim_scan_required)).toBeNull();
+    });
+
+    test("shows the live DEX quote for a pre-DEX refund in the original asset", async () => {
+        const lockupTokenAddress = "0x0000000000000000000000000000000000000011";
+        paramsMock.current.action = RskRescueMode.Refund;
+        mockGetLogsFromReceipt.mockResolvedValue({
+            ...logData,
+            tokenAddress: lockupTokenAddress,
+        });
+        mockQuoteDexAmountIn.mockResolvedValue([{ quote: "1100000" }]);
+        rescueSwaps.current = [
+            {
+                ...logData,
+                action: RskRescueMode.Refund,
+                currentHeight: 1_000n,
+                tokenAddress: lockupTokenAddress,
+                restoredSwap: {
+                    ...restoredSwap,
+                    type: SwapType.Chain,
+                    from: TBTC,
+                    to: "L-BTC",
+                    dex: preDex,
+                },
+            },
+        ];
+
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        expect(await screen.findByText("1.1 USDT")).toBeInTheDocument();
+        expect(mockQuoteDexAmountIn).toHaveBeenCalledWith(
+            preDex.hops[0].dexDetails!.chain,
+            lockupTokenAddress,
+            preDex.hops[0].dexDetails!.tokenIn,
+            logData.amount,
+        );
+    });
+
+    test("converts DEX quote base units for non-routed display assets", async () => {
+        mockQuoteDexAmountIn.mockResolvedValue([
+            { quote: (10n ** 12n).toString() },
+        ]);
+
+        const result = await fetchEvmRefundDisplayQuote({
+            amount: 1n,
+            asset: TBTC,
+            chain: "ARB",
+            tokenIn: "0x0000000000000000000000000000000000000010",
+            tokenOut: "0x0000000000000000000000000000000000000011",
+        });
+
+        // 10^12 base units of an 18-decimal asset are 100 sats
+        expect(result?.asset).toBe(TBTC);
+        expect(result?.amount.toString()).toBe("100");
     });
 });

--- a/tests/pages/RescueEvm.spec.tsx
+++ b/tests/pages/RescueEvm.spec.tsx
@@ -1,0 +1,400 @@
+import type * as SolidRouter from "@solidjs/router";
+import { render, screen, waitFor } from "@solidjs/testing-library";
+import {
+    BridgeKind,
+    type LogRefundData,
+    RskRescueMode,
+    SwapPosition,
+    SwapType,
+} from "boltz-swaps/types";
+import type { JSX } from "solid-js";
+import { vi } from "vitest";
+
+import { config } from "../../src/config";
+import { TBTC } from "../../src/consts/Assets";
+import type * as RescueContextModule from "../../src/context/Rescue";
+import type * as Web3Module from "../../src/context/Web3";
+import i18n from "../../src/i18n/i18n";
+import type { EvmRescueResult } from "../../src/pages/external-rescue/types";
+import type { RescueFile } from "../../src/utils/rescueFile";
+import type { DexDetail } from "../../src/utils/swapCreator";
+import { contextWrapper } from "../helper";
+
+const transactionHash =
+    "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const preimageHash =
+    "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const preimage =
+    "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+
+const {
+    mockGetLogsFromReceipt,
+    mockResolveLockupTokenFunder,
+    paramsMock,
+    rescueSwaps,
+} = vi.hoisted(() => ({
+    mockGetLogsFromReceipt: vi.fn(),
+    mockResolveLockupTokenFunder: vi.fn(),
+    paramsMock: {
+        current: {
+            asset: "TBTC",
+            txHash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            action: "claim",
+        },
+    },
+    rescueSwaps: { current: [] as EvmRescueResult[] },
+}));
+
+vi.mock("@solidjs/router", async () => {
+    const actual = await vi.importActual<typeof SolidRouter>("@solidjs/router");
+    return {
+        ...actual,
+        useNavigate: () => vi.fn(),
+        useParams: () => paramsMock.current,
+    };
+});
+
+vi.mock("boltz-swaps/evm", async () => {
+    const actual = await vi.importActual("boltz-swaps/evm");
+    return {
+        ...actual,
+        createAssetProvider: vi.fn(() => ({})),
+    };
+});
+
+vi.mock("boltz-swaps/evm/logs", async () => {
+    const actual = await vi.importActual("boltz-swaps/evm/logs");
+    return {
+        ...actual,
+        getLogsFromReceipt: mockGetLogsFromReceipt,
+        getTimelockBlockNumber: vi.fn(() => Promise.resolve(1_000)),
+    };
+});
+
+vi.mock("../../src/utils/evmLockup", async () => {
+    const actual = await vi.importActual("../../src/utils/evmLockup");
+    return {
+        ...actual,
+        resolveLockupTokenFunder: mockResolveLockupTokenFunder,
+    };
+});
+
+const gasSigner = {
+    address: "0x0000000000000000000000000000000000000004",
+    provider: {
+        getChainId: () =>
+            Promise.resolve(config.assets?.TBTC?.network?.chainId ?? 1),
+    },
+};
+
+vi.mock("../../src/context/Web3", async () => {
+    const actual = await vi.importActual<typeof Web3Module>(
+        "../../src/context/Web3",
+    );
+    return {
+        ...actual,
+        Web3SignerProvider: (props: { children: JSX.Element }) => (
+            <>{props.children}</>
+        ),
+        useWeb3Signer: () => ({
+            connectedWallet: () => undefined,
+            getErc20Swap: vi.fn(() => ({})),
+            getEtherSwap: vi.fn(() => ({})),
+            getGasAbstractionSigner: vi.fn(() => gasSigner),
+            signer: () => undefined,
+        }),
+    };
+});
+
+vi.mock("../../src/context/Rescue", async () => {
+    const actual = await vi.importActual<typeof RescueContextModule>(
+        "../../src/context/Rescue",
+    );
+    return {
+        ...actual,
+        RescueProvider: (props: { children: JSX.Element }) => (
+            <>{props.children}</>
+        ),
+        useRescueContext: () => ({
+            evmRescuableSwaps: () => rescueSwaps.current,
+            rescueFile: () => ({ mnemonic: "test" }) as RescueFile,
+        }),
+    };
+});
+
+vi.mock("../../src/components/ConnectWallet", () => ({
+    default: () => <button type="button">Connect wallet</button>,
+    ConnectAddress: () => <button type="button">Connect address</button>,
+    SwitchNetwork: () => <button type="button">Switch network</button>,
+}));
+
+vi.mock("../../src/components/RefundButton", () => ({
+    RefundEvm: (props: { disabled?: boolean }) => (
+        <button type="button" disabled={props.disabled}>
+            Refund
+        </button>
+    ),
+}));
+
+const { default: RescueEvm } = await import("../../src/pages/RescueEvm");
+
+const logData = {
+    asset: TBTC,
+    blockNumber: 100,
+    transactionHash,
+    preimageHash,
+    amount: 1_000_000_000_000n,
+    claimAddress: "0x0000000000000000000000000000000000000001",
+    refundAddress: "0x0000000000000000000000000000000000000002",
+    timelock: 500n,
+} satisfies LogRefundData;
+
+const restoredSwap = {
+    id: "restored-dex",
+    type: SwapType.Reverse,
+    status: "transaction.confirmed",
+    createdAt: 1,
+    from: "L-BTC",
+    to: TBTC,
+    preimageHash,
+    evmClaimDetails: {
+        contractAddress: "0x0000000000000000000000000000000000000003",
+        claimAddress: logData.claimAddress,
+        transaction: { id: transactionHash },
+        timeoutBlockHeight: 500,
+    },
+};
+
+const originalFunder = "0x0000000000000000000000000000000000000005";
+const originalDestination = "0x0000000000000000000000000000000000000006";
+
+const preDex: DexDetail = {
+    position: SwapPosition.Pre,
+    quoteAmount: "1000",
+    hops: [
+        {
+            type: SwapType.Dex,
+            from: "USDT0",
+            to: TBTC,
+            dexDetails: {
+                chain: "ARB",
+                tokenIn: "0x0000000000000000000000000000000000000010",
+                tokenOut: "0x0000000000000000000000000000000000000011",
+            },
+        },
+    ],
+};
+
+const postDex: DexDetail = {
+    position: SwapPosition.Post,
+    quoteAmount: "1000",
+    hops: [
+        {
+            type: SwapType.Dex,
+            from: TBTC,
+            to: "USDT0",
+            dexDetails: {
+                chain: "ARB",
+                tokenIn: "0x0000000000000000000000000000000000000010",
+                tokenOut: "0x0000000000000000000000000000000000000011",
+            },
+        },
+    ],
+};
+
+describe("RescueEvm", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        paramsMock.current = {
+            asset: TBTC,
+            txHash: transactionHash,
+            action: RskRescueMode.Claim,
+        };
+        mockGetLogsFromReceipt.mockResolvedValue(logData);
+        mockResolveLockupTokenFunder.mockResolvedValue(originalFunder);
+        rescueSwaps.current = [
+            {
+                ...logData,
+                action: RskRescueMode.Claim,
+                preimage,
+                restoredSwap,
+            },
+        ];
+    });
+
+    test("loads a restored DEX claim before the wallet is connected", async () => {
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        expect(
+            await screen.findByRole("button", { name: "Connect wallet" }),
+        ).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Claim" })).toBeDisabled();
+        expect(screen.queryByText("No wallet connected")).toBeNull();
+        expect(mockGetLogsFromReceipt).toHaveBeenCalled();
+    });
+
+    test("enables a plain restored refund without a connected wallet", async () => {
+        paramsMock.current.action = RskRescueMode.Refund;
+        rescueSwaps.current = [
+            {
+                ...logData,
+                action: RskRescueMode.Refund,
+                currentHeight: 1_000n,
+                restoredSwap: {
+                    ...restoredSwap,
+                    type: SwapType.Chain,
+                    from: TBTC,
+                    to: "L-BTC",
+                },
+            },
+        ];
+
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        expect(
+            await screen.findByRole("button", { name: "Refund" }),
+        ).not.toBeDisabled();
+        expect(
+            screen.queryByRole("button", { name: "Connect wallet" }),
+        ).toBeNull();
+        expect(mockResolveLockupTokenFunder).not.toHaveBeenCalled();
+        expect(mockGetLogsFromReceipt).toHaveBeenCalled();
+    });
+
+    test("resolves the original funder for a pre-DEX refund without a wallet", async () => {
+        paramsMock.current.action = RskRescueMode.Refund;
+        rescueSwaps.current = [
+            {
+                ...logData,
+                action: RskRescueMode.Refund,
+                currentHeight: 1_000n,
+                restoredSwap: {
+                    ...restoredSwap,
+                    type: SwapType.Chain,
+                    from: TBTC,
+                    to: "L-BTC",
+                    dex: preDex,
+                },
+            },
+        ];
+
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        const refund = await screen.findByRole("button", { name: "Refund" });
+        await waitFor(() => expect(refund).not.toBeDisabled());
+        expect(
+            screen.queryByRole("button", { name: "Connect wallet" }),
+        ).toBeNull();
+        expect(mockResolveLockupTokenFunder).toHaveBeenCalledWith(
+            TBTC,
+            preDex.hops[0].dexDetails!.tokenIn,
+            transactionHash,
+        );
+    });
+
+    test("does not resolve a funder for pre-bridge refunds", async () => {
+        paramsMock.current.action = RskRescueMode.Refund;
+        rescueSwaps.current = [
+            {
+                ...logData,
+                action: RskRescueMode.Refund,
+                currentHeight: 1_000n,
+                restoredSwap: {
+                    ...restoredSwap,
+                    type: SwapType.Chain,
+                    from: TBTC,
+                    to: "L-BTC",
+                    dex: preDex,
+                    bridge: {
+                        kind: BridgeKind.Oft,
+                        position: SwapPosition.Pre,
+                        sourceAsset: "USDT0-ETH",
+                        destinationAsset: "USDT0",
+                    },
+                },
+            },
+        ];
+
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        expect(
+            await screen.findByRole("button", { name: "Refund" }),
+        ).not.toBeDisabled();
+        expect(
+            screen.queryByRole("button", { name: "Connect wallet" }),
+        ).toBeNull();
+        expect(mockResolveLockupTokenFunder).not.toHaveBeenCalled();
+    });
+
+    test("asks for a wallet when the pre-DEX refund destination cannot be resolved", async () => {
+        paramsMock.current.action = RskRescueMode.Refund;
+        mockResolveLockupTokenFunder.mockResolvedValue(undefined);
+        rescueSwaps.current = [
+            {
+                ...logData,
+                action: RskRescueMode.Refund,
+                currentHeight: 1_000n,
+                restoredSwap: {
+                    ...restoredSwap,
+                    type: SwapType.Chain,
+                    from: TBTC,
+                    to: "L-BTC",
+                    dex: preDex,
+                },
+            },
+        ];
+
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        expect(
+            await screen.findByRole("button", { name: "Connect wallet" }),
+        ).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Refund" })).toBeDisabled();
+    });
+
+    test("keeps a routed DEX claim gated when the original destination is missing", async () => {
+        rescueSwaps.current = [
+            {
+                ...logData,
+                action: RskRescueMode.Claim,
+                preimage,
+                restoredSwap: {
+                    ...restoredSwap,
+                    dex: postDex,
+                },
+            },
+        ];
+
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        expect(
+            await screen.findByRole("button", { name: "Connect wallet" }),
+        ).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Claim" })).toBeDisabled();
+    });
+
+    test("claims a restored routed DEX swap without a connected wallet", async () => {
+        rescueSwaps.current = [
+            {
+                ...logData,
+                action: RskRescueMode.Claim,
+                preimage,
+                restoredSwap: {
+                    ...restoredSwap,
+                    originalDestination,
+                    dex: postDex,
+                },
+            },
+        ];
+
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        expect(
+            await screen.findByRole("button", { name: i18n.en.continue }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: "Connect wallet" }),
+        ).toBeNull();
+        expect(screen.queryByRole("button", { name: "Claim" })).toBeNull();
+    });
+});

--- a/tests/pages/RescueEvm.spec.tsx
+++ b/tests/pages/RescueEvm.spec.tsx
@@ -500,4 +500,28 @@ describe("RescueEvm", () => {
         expect(result?.asset).toBe(TBTC);
         expect(result?.amount.toString()).toBe("100");
     });
+
+    test("titles a restored swap with its swap id", async () => {
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        await waitFor(() => {
+            expect(document.querySelector(".frame-title")).toHaveTextContent(
+                "restored-dex",
+            );
+        });
+    });
+
+    test("titles an unmatched lockup with the cropped transaction hash", async () => {
+        rescueSwaps.current = [
+            { ...logData, action: RskRescueMode.Claim, preimage },
+        ];
+
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        await waitFor(() => {
+            expect(document.querySelector(".frame-title")).toHaveTextContent(
+                "0xaaa...aaaaa",
+            );
+        });
+    });
 });

--- a/tests/pages/RescueExternal.spec.tsx
+++ b/tests/pages/RescueExternal.spec.tsx
@@ -4,10 +4,16 @@ import { type RestorableSwap, getRestorableSwaps } from "boltz-swaps/client";
 import { BridgeKind, SwapPosition, SwapType } from "boltz-swaps/types";
 import { vi } from "vitest";
 
-import { WBTC, getAssetDisplaySymbol } from "../../src/consts/Assets";
+import { WBTC } from "../../src/consts/Assets";
 import i18n from "../../src/i18n/i18n";
 import RescueExternal from "../../src/pages/external-rescue/RescueExternal";
+import { Results } from "../../src/pages/external-rescue/Results";
 import { mapRestorableSwaps } from "../../src/pages/external-rescue/scan";
+import {
+    BtcSearchState,
+    RescueResultSource,
+} from "../../src/pages/external-rescue/types";
+import { RescueAction } from "../../src/utils/rescue";
 import {
     type SomeSwap,
     getFinalAssetReceive,
@@ -563,9 +569,95 @@ describe("RescueExternal", () => {
         const assets = row.querySelectorAll(".asset");
         expect(assets).toHaveLength(2);
         expect(assets[0]).toHaveAttribute("data-asset", "LBTC");
-        expect(assets[1]).toHaveAttribute(
-            "data-asset",
-            getAssetDisplaySymbol(finalAssetReceive),
+        expect(assets[1]).toHaveAttribute("data-asset", "USDT");
+        expect(assets[1]).toHaveAttribute("data-network", "solana");
+    });
+
+    test("should display metadata swap assets for routed restored refund rows", () => {
+        const result = {
+            source: RescueResultSource.Restore,
+            key: "restore:metadata-refund-swap",
+            action: RescueAction.Refund,
+            actionable: true,
+            sortValue: 1,
+            swap: {
+                id: "metadata-refund-swap",
+                type: SwapType.Chain,
+                status: "transaction.lockupFailed",
+                date: 1,
+                assetSend: "TBTC",
+                assetReceive: "L-BTC",
+                dex: {
+                    hops: [
+                        {
+                            type: SwapType.Dex,
+                            from: "USDT0",
+                            to: "TBTC",
+                        },
+                    ],
+                    position: SwapPosition.Pre,
+                    quoteAmount: 13334,
+                },
+                bridge: {
+                    sourceAsset: "USDT0-SOL",
+                    destinationAsset: "USDT0",
+                    kind: BridgeKind.Oft,
+                    position: SwapPosition.Pre,
+                },
+            },
+        };
+
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Results
+                        state={
+                            {
+                                btc: {
+                                    loadedSwaps: 0,
+                                    searchState: BtcSearchState.Ready,
+                                    listLoading: false,
+                                },
+                                evm: {
+                                    unmatchedRefundSwaps: 0,
+                                    unmatchedClaimSwaps: 0,
+                                },
+                                search: {
+                                    hasSearched: true,
+                                    isSearching: false,
+                                },
+                            } as any
+                        }
+                        results={
+                            {
+                                all: () => [result],
+                                current: () => [result],
+                                currentEvmProgress: () => undefined,
+                                currentPage: () => 1,
+                                displaySlotCount: () => 1,
+                                hasAny: () => true,
+                                open: vi.fn(),
+                                setCurrent: vi.fn(),
+                                setCurrentPage: vi.fn(),
+                            } as any
+                        }
+                    />
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
         );
+
+        const row = screen.getByTestId("swaplist-item-metadata-refund-swap");
+        const assets = row.querySelectorAll(".asset");
+
+        expect(row).toHaveTextContent(i18n.en.refund);
+        expect(assets).toHaveLength(2);
+        expect(assets[0]).toHaveAttribute("data-asset", "USDT");
+        expect(assets[0]).toHaveAttribute("data-network", "solana");
+        expect(assets[1]).toHaveAttribute("data-asset", "LBTC");
+        expect(row.querySelector('[data-asset="TBTC"]')).toBeNull();
     });
 });

--- a/tests/pages/RescueExternal.spec.tsx
+++ b/tests/pages/RescueExternal.spec.tsx
@@ -1,7 +1,12 @@
 import { render, screen, waitFor, within } from "@solidjs/testing-library";
 import { userEvent } from "@testing-library/user-event";
 import { type RestorableSwap, getRestorableSwaps } from "boltz-swaps/client";
-import { BridgeKind, SwapPosition, SwapType } from "boltz-swaps/types";
+import {
+    BridgeKind,
+    RskRescueMode,
+    SwapPosition,
+    SwapType,
+} from "boltz-swaps/types";
 import { vi } from "vitest";
 
 import { LN, WBTC } from "../../src/consts/Assets";
@@ -661,5 +666,101 @@ describe("RescueExternal", () => {
         expect(assets[0]).toHaveAttribute("data-network", "solana");
         expect(assets[1]).toHaveAttribute("data-asset", "LBTC");
         expect(row.querySelector('[data-asset="TBTC"]')).toBeNull();
+    });
+
+    test("should show the restored swap id for enriched EVM rows and the tx hash otherwise", () => {
+        const enrichedTxHash = `0x${"a".repeat(64)}`;
+        const scannedTxHash = `0x${"b".repeat(64)}`;
+        const enriched = {
+            source: RescueResultSource.Evm,
+            key: `evm:claim:TBTC:${enrichedTxHash}`,
+            action: RescueAction.Claim,
+            evmAction: RskRescueMode.Claim,
+            actionable: true,
+            sortValue: 100,
+            swap: {
+                action: RskRescueMode.Claim,
+                asset: "TBTC",
+                blockNumber: 100,
+                transactionHash: enrichedTxHash,
+                restoredSwap: {
+                    id: "restored-evm-swap",
+                    type: SwapType.Reverse,
+                    status: "transaction.confirmed",
+                    createdAt: 1,
+                    from: "L-BTC",
+                    to: "TBTC",
+                    preimageHash: "bb",
+                },
+            },
+        };
+        const scanned = {
+            source: RescueResultSource.Evm,
+            key: `evm:refund:TBTC:${scannedTxHash}`,
+            action: RescueAction.Refund,
+            evmAction: RskRescueMode.Refund,
+            actionable: true,
+            sortValue: 99,
+            swap: {
+                action: RskRescueMode.Refund,
+                asset: "TBTC",
+                blockNumber: 99,
+                transactionHash: scannedTxHash,
+            },
+        };
+        const results = [enriched, scanned];
+
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Results
+                        state={
+                            {
+                                btc: {
+                                    loadedSwaps: 0,
+                                    searchState: BtcSearchState.Ready,
+                                    listLoading: false,
+                                },
+                                evm: {
+                                    unmatchedRefundSwaps: 0,
+                                    unmatchedClaimSwaps: 0,
+                                },
+                                search: {
+                                    hasSearched: true,
+                                    isSearching: false,
+                                },
+                            } as any
+                        }
+                        results={
+                            {
+                                all: () => results,
+                                current: () => results,
+                                currentEvmProgress: () => undefined,
+                                currentPage: () => 1,
+                                displaySlotCount: () => results.length,
+                                hasAny: () => true,
+                                open: vi.fn(),
+                                setCurrent: vi.fn(),
+                                setCurrentPage: vi.fn(),
+                            } as any
+                        }
+                    />
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+
+        const enrichedRow = screen.getByTestId(`swaplist-item-${enriched.key}`);
+        expect(
+            within(enrichedRow).getByText("restored-evm-swap"),
+        ).toBeInTheDocument();
+
+        const scannedRow = screen.getByTestId(`swaplist-item-${scanned.key}`);
+        expect(
+            within(scannedRow).getByText("0xbbb...bbbbb"),
+        ).toBeInTheDocument();
     });
 });

--- a/tests/pages/RescueExternal.spec.tsx
+++ b/tests/pages/RescueExternal.spec.tsx
@@ -199,7 +199,7 @@ describe("RescueExternal", () => {
         expect(tbtcChip).toHaveAttribute("data-active", "false");
         expect(tbtcChip).toHaveAttribute(
             "data-tooltip",
-            i18n.en.rescue_external_requires_rescue_key,
+            i18n.en.rescue_external_requires_rescue_key_wallet,
         );
         expect(wbtcChip).toHaveAttribute("data-active", "false");
         expect(wbtcChip).toHaveAttribute(
@@ -232,14 +232,17 @@ describe("RescueExternal", () => {
             within(rbtcRefundChip).getByLabelText("Wallet required"),
         ).toHaveAttribute("data-active", "false");
 
-        expect(tbtcChip).toHaveAttribute("data-active", "true");
-        expect(tbtcChip).not.toHaveAttribute("data-tooltip");
+        expect(tbtcChip).toHaveAttribute("data-active", "false");
+        expect(tbtcChip).toHaveAttribute(
+            "data-tooltip",
+            i18n.en.rescue_external_requires_rescue_key_wallet,
+        );
         expect(
             within(tbtcChip).getByLabelText("Rescue key required"),
         ).toHaveAttribute("data-active", "true");
         expect(
-            within(tbtcChip).queryByLabelText("Wallet required"),
-        ).not.toBeInTheDocument();
+            within(tbtcChip).getByLabelText("Wallet required"),
+        ).toHaveAttribute("data-active", "false");
 
         expect(wbtcChip).toHaveAttribute("data-active", "true");
         expect(wbtcChip).not.toHaveAttribute("data-tooltip");

--- a/tests/pages/RescueExternal.spec.tsx
+++ b/tests/pages/RescueExternal.spec.tsx
@@ -4,7 +4,7 @@ import { type RestorableSwap, getRestorableSwaps } from "boltz-swaps/client";
 import { BridgeKind, SwapPosition, SwapType } from "boltz-swaps/types";
 import { vi } from "vitest";
 
-import { WBTC } from "../../src/consts/Assets";
+import { LN, WBTC } from "../../src/consts/Assets";
 import i18n from "../../src/i18n/i18n";
 import RescueExternal from "../../src/pages/external-rescue/RescueExternal";
 import { Results } from "../../src/pages/external-rescue/Results";
@@ -175,6 +175,9 @@ describe("RescueExternal", () => {
         const btcChip = (await screen.findByText("BTC")).closest(
             ".rescue-external-chip",
         ) as HTMLElement;
+        const lightningChip = screen
+            .getByText(LN)
+            .closest(".rescue-external-chip") as HTMLElement;
         const tbtcChip = screen
             .getByText("TBTC")
             .closest(".rescue-external-chip") as HTMLElement;
@@ -196,12 +199,12 @@ describe("RescueExternal", () => {
         expect(tbtcChip).toHaveAttribute("data-active", "false");
         expect(tbtcChip).toHaveAttribute(
             "data-tooltip",
-            i18n.en.rescue_external_requires_rescue_key_wallet,
+            i18n.en.rescue_external_requires_rescue_key,
         );
         expect(wbtcChip).toHaveAttribute("data-active", "false");
         expect(wbtcChip).toHaveAttribute(
             "data-tooltip",
-            i18n.en.rescue_external_requires_rescue_key_wallet,
+            i18n.en.rescue_external_requires_rescue_key,
         );
 
         const uploadInput = screen.getByTestId("refundUpload");
@@ -217,6 +220,8 @@ describe("RescueExternal", () => {
 
         expect(btcChip).toHaveAttribute("data-active", "true");
         expect(btcChip).not.toHaveAttribute("data-tooltip");
+        expect(lightningChip).toHaveAttribute("data-active", "true");
+        expect(lightningChip).not.toHaveAttribute("data-tooltip");
 
         expect(rbtcRefundChip).toHaveAttribute("data-active", "false");
         expect(rbtcRefundChip).toHaveAttribute(
@@ -227,29 +232,23 @@ describe("RescueExternal", () => {
             within(rbtcRefundChip).getByLabelText("Wallet required"),
         ).toHaveAttribute("data-active", "false");
 
-        expect(tbtcChip).toHaveAttribute("data-active", "false");
-        expect(tbtcChip).toHaveAttribute(
-            "data-tooltip",
-            i18n.en.rescue_external_requires_rescue_key_wallet,
-        );
+        expect(tbtcChip).toHaveAttribute("data-active", "true");
+        expect(tbtcChip).not.toHaveAttribute("data-tooltip");
         expect(
             within(tbtcChip).getByLabelText("Rescue key required"),
         ).toHaveAttribute("data-active", "true");
         expect(
-            within(tbtcChip).getByLabelText("Wallet required"),
-        ).toHaveAttribute("data-active", "false");
+            within(tbtcChip).queryByLabelText("Wallet required"),
+        ).not.toBeInTheDocument();
 
-        expect(wbtcChip).toHaveAttribute("data-active", "false");
-        expect(wbtcChip).toHaveAttribute(
-            "data-tooltip",
-            i18n.en.rescue_external_requires_rescue_key_wallet,
-        );
+        expect(wbtcChip).toHaveAttribute("data-active", "true");
+        expect(wbtcChip).not.toHaveAttribute("data-tooltip");
         expect(
             within(wbtcChip).getByLabelText("Rescue key required"),
         ).toHaveAttribute("data-active", "true");
         expect(
-            within(wbtcChip).getByLabelText("Wallet required"),
-        ).toHaveAttribute("data-active", "false");
+            within(wbtcChip).queryByLabelText("Wallet required"),
+        ).not.toBeInTheDocument();
 
         expect(rbtcResumeChip).toHaveAttribute("data-active", "false");
         expect(rbtcResumeChip).toHaveAttribute(

--- a/tests/pages/RescueExternalEvmScan.spec.tsx
+++ b/tests/pages/RescueExternalEvmScan.spec.tsx
@@ -1,27 +1,58 @@
 import { render, screen, waitFor } from "@solidjs/testing-library";
 import { userEvent } from "@testing-library/user-event";
-import { getRestorableSwaps } from "boltz-swaps/client";
-import { RskRescueMode } from "boltz-swaps/types";
+import { type RestorableSwap, getRestorableSwaps } from "boltz-swaps/client";
+import {
+    BridgeKind,
+    RskRescueMode,
+    SwapPosition,
+    SwapType,
+} from "boltz-swaps/types";
 import type { JSX } from "solid-js";
 import { vi } from "vitest";
 
 import { TBTC, WBTC } from "../../src/consts/Assets";
 import i18n from "../../src/i18n/i18n";
 import RescueExternal from "../../src/pages/external-rescue/RescueExternal";
+import type * as RescueUtils from "../../src/utils/rescue";
+import { encryptSwapMetadata } from "../../src/utils/swapMetadata";
 import { TestComponent, contextWrapper } from "../helper";
 
 const {
+    mockCreateRescueList,
     mockGetErc20Swap,
+    mockGetTransaction,
     mockGetSweepableGasAbstractionBalances,
     mockPreimageHashesWorker,
     mockScanLockupEvents,
 } = vi.hoisted(() => ({
+    mockCreateRescueList: vi.fn(),
     mockGetErc20Swap: vi.fn(() => ({})),
+    mockGetTransaction: vi.fn(() => Promise.resolve({ input: "0x" })),
     mockGetSweepableGasAbstractionBalances: vi.fn(),
     mockPreimageHashesWorker: vi.fn(function PreimageHashesWorker() {
-        return {};
+        return {
+            isDone: true,
+            map: new Map([
+                [
+                    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    {
+                        index: 0,
+                        preimage:
+                            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                    },
+                ],
+            ]),
+            start: vi.fn(),
+            terminate: vi.fn(),
+            waitForNextBatch: vi.fn(),
+        };
     }),
-    mockScanLockupEvents: vi.fn(async function* () {
+    mockScanLockupEvents: vi.fn(async function* (): AsyncGenerator<{
+        derivedKeys?: number;
+        events: unknown[];
+        progress: number;
+        unmatchedSwaps: number;
+    }> {
         await Promise.resolve();
         yield {
             derivedKeys: undefined,
@@ -37,8 +68,13 @@ vi.mock("boltz-swaps/client", () => ({
 }));
 
 vi.mock("boltz-swaps/evm", () => ({
-    createProvider: vi.fn(() => ({})),
+    assetAmountToSats: (amount: bigint, asset?: string) =>
+        asset === "TBTC" ? amount / 10n ** 10n : amount,
+    createAssetProvider: vi.fn(() => ({})),
+    createProvider: vi.fn(() => ({ getTransaction: mockGetTransaction })),
     getTimelockBlockNumber: vi.fn(() => Promise.resolve(0)),
+    isEmptyPreimageHash: (preimageHash: string | undefined) =>
+        preimageHash?.replace(/^0x/i, "").toLowerCase() === "00".repeat(32),
     scanLockupEvents: mockScanLockupEvents,
 }));
 
@@ -81,6 +117,14 @@ vi.mock("../../src/utils/gasAbstractionSweep", () => ({
     getSweepableGasAbstractionBalances: mockGetSweepableGasAbstractionBalances,
 }));
 
+vi.mock("../../src/utils/rescue", async (importOriginal) => {
+    const actual = await importOriginal<typeof RescueUtils>();
+    return {
+        ...actual,
+        createRescueList: mockCreateRescueList,
+    };
+});
+
 vi.mock("../../src/workers/preimageHashes/PreimageHashesWorker", () => ({
     PreimageHashesWorker: mockPreimageHashesWorker,
 }));
@@ -93,6 +137,13 @@ describe("RescueExternal EVM scan", () => {
         vi.stubEnv("VITE_RSK_LOG_SCAN_ENDPOINT", "http://localhost:8545");
         vi.stubEnv("VITE_ARBITRUM_LOG_SCAN_ENDPOINT", "");
         mockGetRestorableSwaps.mockResolvedValue([]);
+        mockCreateRescueList.mockImplementation(
+            (swaps: Record<string, unknown>[]) =>
+                Promise.resolve(
+                    swaps.map((swap) => ({ ...swap, action: "pending" })),
+                ),
+        );
+        mockGetTransaction.mockResolvedValue({ input: "0x" });
         mockGetSweepableGasAbstractionBalances.mockResolvedValue([]);
     });
 
@@ -142,6 +193,449 @@ describe("RescueExternal EVM scan", () => {
             );
         });
         expect(mockPreimageHashesWorker).toHaveBeenCalledTimes(1);
+    });
+
+    test("queries backend restore with rescue xpub", async () => {
+        const user = userEvent.setup();
+
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <RescueExternal />
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+
+        const uploadInput = await screen.findByTestId("refundUpload");
+        const rescueFile = new File(["{}"], "rescue.json", {
+            type: "application/json",
+        });
+        (rescueFile as File & { text: () => Promise<string> }).text = () =>
+            Promise.resolve(
+                JSON.stringify({
+                    mnemonic:
+                        "horse olympic laundry marriage material private arch civil theory crew alone thank",
+                }),
+            );
+
+        await user.upload(uploadInput, rescueFile);
+        await user.click(screen.getByRole("button", { name: i18n.en.rescue }));
+
+        await waitFor(() => {
+            expect(mockGetRestorableSwaps).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.objectContaining({ startIndex: 0 }),
+                expect.any(AbortSignal),
+            );
+        });
+        expect(mockGetRestorableSwaps).toHaveBeenCalledTimes(1);
+    });
+
+    test("renders restored EVM claim metadata as original swap assets", async () => {
+        const user = userEvent.setup();
+        const mnemonic =
+            "horse olympic laundry marriage material private arch civil theory crew alone thank";
+        const transactionHash =
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        vi.stubEnv("VITE_ARBITRUM_LOG_SCAN_ENDPOINT", "http://localhost:8547");
+
+        const restoredSwap: RestorableSwap = {
+            id: "restored-evm",
+            type: SwapType.Chain,
+            status: "transaction.server.confirmed",
+            createdAt: 1,
+            from: "L-BTC",
+            to: TBTC,
+            preimageHash:
+                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            evmClaimDetails: {
+                amount: 1_000,
+                claimAddress: "0x0000000000000000000000000000000000000001",
+                contractAddress: "0x0000000000000000000000000000000000000003",
+                timeoutBlockHeight: 123,
+                transaction: { id: transactionHash },
+            },
+            metadata: await encryptSwapMetadata(mnemonic, {
+                swapId: "restored-evm",
+                lockupTx: transactionHash,
+                dex: {
+                    hops: [
+                        {
+                            type: SwapType.Dex,
+                            from: TBTC,
+                            to: "USDT0",
+                            dexDetails: {
+                                chain: "ARB",
+                                tokenIn:
+                                    "0x0000000000000000000000000000000000000004",
+                                tokenOut:
+                                    "0x0000000000000000000000000000000000000005",
+                            },
+                        },
+                    ],
+                    position: SwapPosition.Post,
+                    quoteAmount: 1_000,
+                },
+                bridge: {
+                    sourceAsset: "USDT0",
+                    destinationAsset: "USDT0-SOL",
+                    kind: BridgeKind.Oft,
+                    position: SwapPosition.Post,
+                },
+            }),
+        };
+        mockGetRestorableSwaps.mockResolvedValueOnce([restoredSwap]);
+        mockScanLockupEvents.mockImplementation(async function* (
+            ...args: unknown[]
+        ) {
+            await Promise.resolve();
+            const config = args[2] as {
+                action?: RskRescueMode;
+                asset?: string;
+            };
+            yield {
+                derivedKeys: undefined,
+                events:
+                    config.action === RskRescueMode.Claim &&
+                    config.asset === TBTC
+                        ? [
+                              {
+                                  asset: TBTC,
+                                  blockNumber: 100,
+                                  transactionHash,
+                                  preimageHash:
+                                      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                                  amount: 1_000n,
+                                  claimAddress:
+                                      "0x0000000000000000000000000000000000000001",
+                                  refundAddress:
+                                      "0x0000000000000000000000000000000000000002",
+                                  timelock: 123n,
+                              },
+                          ]
+                        : [],
+                progress: 1,
+                unmatchedSwaps: 0,
+            };
+        });
+
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <RescueExternal />
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+
+        const uploadInput = await screen.findByTestId("refundUpload");
+        const rescueFile = new File(["{}"], "rescue.json", {
+            type: "application/json",
+        });
+        (rescueFile as File & { text: () => Promise<string> }).text = () =>
+            Promise.resolve(JSON.stringify({ mnemonic }));
+
+        await user.upload(uploadInput, rescueFile);
+        await user.click(screen.getByRole("button", { name: i18n.en.rescue }));
+
+        const row = await screen.findByTestId(
+            `swaplist-item-evm:${RskRescueMode.Claim}:${TBTC}:${transactionHash}`,
+        );
+        const assets = row.querySelectorAll(".asset");
+
+        expect(assets).toHaveLength(2);
+        expect(assets[0]).toHaveAttribute("data-asset", "LBTC");
+        expect(assets[1]).toHaveAttribute("data-asset", "USDT");
+        expect(assets[1]).toHaveAttribute("data-network", "solana");
+    });
+
+    test("deduplicates regular restore metadata with chain-scanned EVM claim", async () => {
+        const user = userEvent.setup();
+        const mnemonic =
+            "horse olympic laundry marriage material private arch civil theory crew alone thank";
+        const preimageHash =
+            "1511378baf1ce4b03edeeb340c6f4f456629674846e96b1912944971605827a6";
+        const transactionHash =
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        vi.stubEnv("VITE_ARBITRUM_LOG_SCAN_ENDPOINT", "http://localhost:8547");
+
+        const restoredSwap: RestorableSwap = {
+            id: "GpfGQX5voYWC",
+            type: SwapType.Chain,
+            status: "transaction.server.confirmed",
+            createdAt: 1780894795,
+            from: "L-BTC",
+            to: TBTC,
+            preimageHash,
+            refundDetails: {
+                amount: 1105,
+                blindingKey:
+                    "340c4b1433ad946e134e46a2593696ec43364a1b6dfe7e7cddb029e6d2127229",
+                keyIndex: 1,
+                lockupAddress:
+                    "lq1pq2vj4xa85w2yu9sahuauk2c3w3cdynqv54vv4z3z2ukeu5ah09tymaag3udz9d4x3ux04juyscnsjjpda0w9dytrtrlf2epj9skr3jdyq5433g3qj7yv",
+                serverPublicKey:
+                    "038028b1547af7ca73b3cf46b9fbdc4d95ebb9c3abfadbff4e03ff79e13c0eb751",
+                timeoutBlockHeight: 3922386,
+                transaction: {
+                    id: "a4798e0e5d0e84c18025a4d96dca57abdf633d5760d1550c94cece1e41ce5cd9",
+                    vout: 0,
+                },
+                tree: {
+                    claimLeaf: {
+                        version: 196,
+                        output: "82012088a914099ad1bfe70691a567c6efc94547c5108aca7bbf88208028b1547af7ca73b3cf46b9fbdc4d95ebb9c3abfadbff4e03ff79e13c0eb751ac",
+                    },
+                    refundLeaf: {
+                        version: 196,
+                        output: "203cb0e1738c72c2fe40e30d79c728a5a5200b58c422675f474c9d5af31aa4bd30ad03d2d93bb1",
+                    },
+                },
+            },
+            metadata: await encryptSwapMetadata(mnemonic, {
+                swapId: "GpfGQX5voYWC",
+                lockupTx: transactionHash,
+                dex: {
+                    hops: [
+                        {
+                            type: SwapType.Dex,
+                            from: TBTC,
+                            to: "USDT0",
+                            dexDetails: {
+                                chain: "ARB",
+                                tokenIn:
+                                    "0x6c84a8f1c29108F47a79964b5Fe888D4f4D0dE40",
+                                tokenOut:
+                                    "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+                            },
+                        },
+                    ],
+                    position: SwapPosition.Post,
+                    quoteAmount: 0,
+                },
+                bridge: {
+                    sourceAsset: "USDT0",
+                    destinationAsset: "USDT0-SOL",
+                    kind: BridgeKind.Oft,
+                    position: SwapPosition.Post,
+                },
+            }),
+        };
+        mockGetRestorableSwaps
+            .mockResolvedValueOnce([restoredSwap])
+            .mockResolvedValueOnce([]);
+        mockScanLockupEvents.mockImplementation(async function* (
+            ...args: unknown[]
+        ) {
+            await Promise.resolve();
+            const config = args[2] as {
+                action?: RskRescueMode;
+                asset?: string;
+            };
+            yield {
+                derivedKeys: undefined,
+                events:
+                    config.action === RskRescueMode.Claim &&
+                    config.asset === TBTC
+                        ? [
+                              {
+                                  asset: TBTC,
+                                  blockNumber: 100,
+                                  transactionHash,
+                                  preimage:
+                                      "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                                  preimageHash: `0x${preimageHash}`,
+                                  amount: 1105n,
+                                  claimAddress:
+                                      "0x0000000000000000000000000000000000000001",
+                                  refundAddress:
+                                      "0x0000000000000000000000000000000000000002",
+                                  timelock: 123n,
+                              },
+                          ]
+                        : [],
+                progress: 1,
+                unmatchedSwaps: 0,
+            };
+        });
+
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <RescueExternal />
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+
+        const uploadInput = await screen.findByTestId("refundUpload");
+        const rescueFile = new File(["{}"], "rescue.json", {
+            type: "application/json",
+        });
+        (rescueFile as File & { text: () => Promise<string> }).text = () =>
+            Promise.resolve(JSON.stringify({ mnemonic }));
+
+        await user.upload(uploadInput, rescueFile);
+        await user.click(screen.getByRole("button", { name: i18n.en.rescue }));
+
+        const row = await screen.findByTestId(
+            `swaplist-item-evm:${RskRescueMode.Claim}:${TBTC}:${transactionHash}`,
+        );
+        const assets = row.querySelectorAll(".asset");
+
+        expect(row).not.toHaveClass("disabled");
+        expect(row).toHaveTextContent(i18n.en.claim);
+        expect(screen.queryByTestId("swaplist-item-GpfGQX5voYWC")).toBeNull();
+        expect(assets).toHaveLength(2);
+        expect(assets[0]).toHaveAttribute("data-asset", "LBTC");
+        expect(assets[1]).toHaveAttribute("data-asset", "USDT");
+        expect(assets[1]).toHaveAttribute("data-network", "solana");
+    });
+
+    test("keeps zero-preimage EVM refund rows separate from restored routed metadata", async () => {
+        const user = userEvent.setup();
+        const mnemonic =
+            "awake father sword slab matrix myth cargo lock river thumb inspire speed";
+        const transactionHash =
+            "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        vi.stubEnv("VITE_ARBITRUM_LOG_SCAN_ENDPOINT", "http://localhost:8547");
+
+        const restoredSwap: RestorableSwap = {
+            id: "QzNPe7rckJCp",
+            type: SwapType.Chain,
+            status: "transaction.server.confirmed",
+            createdAt: 1782787562,
+            from: TBTC,
+            to: "L-BTC",
+            preimageHash:
+                "c75a1b92ece410e13823372edceb1fc148c37d36586c2ccd8b2c78dac1556a8e",
+            claimDetails: {
+                amount: 13_341,
+                blindingKey:
+                    "c43345f5cbf63cd5be4044c0eb7b0991cc2465599fcf2e8d6127ec3847943dc4",
+                keyIndex: 71,
+                lockupAddress: "lockup",
+                serverPublicKey:
+                    "03bb779740ad43c9337bf89a23062a8564b2cf5a75fd7e317a352965ee1b4a51b2",
+                timeoutBlockHeight: 3953207,
+                transaction: {
+                    id: "6ba69b919aaf28f5ec746f97cde06da136c77390082de0b52674954b58a51aa1",
+                    vout: 1,
+                },
+                tree: {
+                    claimLeaf: { version: 196, output: "51" },
+                    refundLeaf: { version: 196, output: "51" },
+                },
+            },
+            metadata: await encryptSwapMetadata(mnemonic, {
+                dex: {
+                    hops: [
+                        {
+                            type: SwapType.Dex,
+                            from: "USDT0",
+                            to: TBTC,
+                            dexDetails: {
+                                chain: "ARB",
+                                tokenIn:
+                                    "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+                                tokenOut:
+                                    "0x6c84a8f1c29108F47a79964b5Fe888D4f4D0dE40",
+                            },
+                        },
+                    ],
+                    position: SwapPosition.Pre,
+                    quoteAmount: 13_334,
+                },
+                bridge: {
+                    sourceAsset: "USDT0-SOL",
+                    destinationAsset: "USDT0",
+                    kind: BridgeKind.Oft,
+                    position: SwapPosition.Pre,
+                },
+            }),
+        };
+        mockGetRestorableSwaps.mockResolvedValueOnce([restoredSwap]);
+        mockScanLockupEvents.mockImplementation(async function* (
+            ...args: unknown[]
+        ) {
+            await Promise.resolve();
+            const config = args[2] as {
+                action?: RskRescueMode;
+                asset?: string;
+            };
+            const events =
+                config.action === RskRescueMode.Refund && config.asset === TBTC
+                    ? [
+                          {
+                              asset: TBTC,
+                              blockNumber: 100,
+                              transactionHash,
+                              preimageHash: `0x${"00".repeat(32)}`,
+                              amount: 99_039_478_307_028n,
+                              claimAddress:
+                                  "0x0000000000000000000000000000000000000001",
+                              refundAddress:
+                                  "0x0000000000000000000000000000000000000002",
+                              timelock: 123n,
+                          },
+                      ]
+                    : [];
+            yield {
+                derivedKeys: undefined,
+                events,
+                progress: 1,
+                unmatchedSwaps: 0,
+            };
+        });
+
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <RescueExternal />
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+
+        const uploadInput = await screen.findByTestId("refundUpload");
+        const rescueFile = new File(["{}"], "rescue.json", {
+            type: "application/json",
+        });
+        (rescueFile as File & { text: () => Promise<string> }).text = () =>
+            Promise.resolve(JSON.stringify({ mnemonic }));
+
+        await user.upload(uploadInput, rescueFile);
+        await user.click(screen.getByRole("button", { name: i18n.en.rescue }));
+
+        const row = await screen.findByTestId(
+            `swaplist-item-evm:${RskRescueMode.Refund}:${TBTC}:${transactionHash}`,
+            undefined,
+            { timeout: 5_000 },
+        );
+
+        expect(row).not.toHaveClass("disabled");
+        expect(row).toHaveTextContent(i18n.en.refund);
+        await waitFor(() => {
+            const currentRow = screen.getByTestId(
+                `swaplist-item-evm:${RskRescueMode.Refund}:${TBTC}:${transactionHash}`,
+            );
+            const assets = currentRow.querySelectorAll(".asset");
+            expect(assets).toHaveLength(1);
+            expect(assets[0]).toHaveAttribute("data-asset", "TBTC");
+        });
     });
 
     test("scans WBTC and TBTC on Arbitrum", async () => {

--- a/tests/pages/RescueExternalEvmScan.spec.tsx
+++ b/tests/pages/RescueExternalEvmScan.spec.tsx
@@ -1,3 +1,5 @@
+import { sha256 } from "@noble/hashes/sha2.js";
+import { hex } from "@scure/base";
 import { render, screen, waitFor } from "@solidjs/testing-library";
 import { userEvent } from "@testing-library/user-event";
 import { type RestorableSwap, getRestorableSwaps } from "boltz-swaps/client";
@@ -14,21 +16,27 @@ import { TBTC, WBTC } from "../../src/consts/Assets";
 import i18n from "../../src/i18n/i18n";
 import RescueExternal from "../../src/pages/external-rescue/RescueExternal";
 import type * as RescueUtils from "../../src/utils/rescue";
+import { derivePreimageFromRescueKey } from "../../src/utils/rescueFile";
 import { encryptSwapMetadata } from "../../src/utils/swapMetadata";
 import { TestComponent, contextWrapper } from "../helper";
 
 const {
     mockCreateRescueList,
     mockGetErc20Swap,
+    mockGetLogsFromReceipt,
     mockGetTransaction,
     mockGetSweepableGasAbstractionBalances,
     mockPreimageHashesWorker,
+    mockRestoreByAddressFetch,
     mockScanLockupEvents,
+    mockSigner,
 } = vi.hoisted(() => ({
     mockCreateRescueList: vi.fn(),
     mockGetErc20Swap: vi.fn(() => ({})),
+    mockGetLogsFromReceipt: vi.fn(),
     mockGetTransaction: vi.fn(() => Promise.resolve({ input: "0x" })),
     mockGetSweepableGasAbstractionBalances: vi.fn(),
+    mockRestoreByAddressFetch: vi.fn(),
     mockPreimageHashesWorker: vi.fn(function PreimageHashesWorker() {
         return {
             isDone: true,
@@ -61,6 +69,11 @@ const {
             unmatchedSwaps: 0,
         };
     }),
+    mockSigner: {
+        current: {
+            address: "0x0000000000000000000000000000000000000001",
+        } as { address: string } | undefined,
+    },
 }));
 
 vi.mock("boltz-swaps/client", () => ({
@@ -72,9 +85,12 @@ vi.mock("boltz-swaps/evm", () => ({
         asset === "TBTC" ? amount / 10n ** 10n : amount,
     createAssetProvider: vi.fn(() => ({})),
     createProvider: vi.fn(() => ({ getTransaction: mockGetTransaction })),
+    getLogsFromReceipt: mockGetLogsFromReceipt,
     getTimelockBlockNumber: vi.fn(() => Promise.resolve(0)),
     isEmptyPreimageHash: (preimageHash: string | undefined) =>
         preimageHash?.replace(/^0x/i, "").toLowerCase() === "00".repeat(32),
+    satsToAssetAmount: (amount: number | bigint, asset?: string) =>
+        asset === "TBTC" ? BigInt(amount) * 10n ** 10n : BigInt(amount),
     scanLockupEvents: mockScanLockupEvents,
 }));
 
@@ -105,9 +121,7 @@ vi.mock("../../src/context/Web3", () => ({
         providers: () => ({}),
         setOpenWalletConnectModal: vi.fn(),
         setWalletConnected: vi.fn(),
-        signer: () => ({
-            address: "0x0000000000000000000000000000000000000001",
-        }),
+        signer: () => mockSigner.current,
         switchNetwork: vi.fn(),
         walletConnected: () => true,
     }),
@@ -137,6 +151,13 @@ describe("RescueExternal EVM scan", () => {
         vi.stubEnv("VITE_RSK_LOG_SCAN_ENDPOINT", "http://localhost:8545");
         vi.stubEnv("VITE_ARBITRUM_LOG_SCAN_ENDPOINT", "");
         mockGetRestorableSwaps.mockResolvedValue([]);
+        mockRestoreByAddressFetch.mockResolvedValue(
+            new Response(JSON.stringify([]), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+            }),
+        );
+        vi.stubGlobal("fetch", mockRestoreByAddressFetch);
         mockCreateRescueList.mockImplementation(
             (swaps: Record<string, unknown>[]) =>
                 Promise.resolve(
@@ -145,10 +166,14 @@ describe("RescueExternal EVM scan", () => {
         );
         mockGetTransaction.mockResolvedValue({ input: "0x" });
         mockGetSweepableGasAbstractionBalances.mockResolvedValue([]);
+        mockSigner.current = {
+            address: "0x0000000000000000000000000000000000000001",
+        };
     });
 
     afterEach(() => {
         vi.unstubAllEnvs();
+        vi.unstubAllGlobals();
     });
 
     test("passes a preimage derivation worker to claim scans", async () => {
@@ -233,6 +258,359 @@ describe("RescueExternal EVM scan", () => {
             );
         });
         expect(mockGetRestorableSwaps).toHaveBeenCalledTimes(1);
+    });
+
+    test("restores DEX refunds with only the rescue key", async () => {
+        const user = userEvent.setup();
+        const mnemonic =
+            "awake father sword slab matrix myth cargo lock river thumb inspire speed";
+        const transactionHash =
+            "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        vi.stubEnv("VITE_ARBITRUM_LOG_SCAN_ENDPOINT", "http://localhost:8547");
+        const { getEvmRestoreAccounts } =
+            await import("../../src/pages/external-rescue/scan");
+        const refundAddress = getEvmRestoreAccounts({ mnemonic })[0].account
+            .address;
+        const restoredSwap: RestorableSwap = {
+            id: "restored-refund",
+            type: SwapType.Chain,
+            status: "transaction.server.confirmed",
+            createdAt: 1,
+            from: TBTC,
+            to: "L-BTC",
+            preimageHash:
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            metadata: await encryptSwapMetadata(mnemonic, {
+                swapId: "restored-refund",
+                lockupTx: transactionHash,
+                dex: {
+                    hops: [
+                        {
+                            type: SwapType.Dex,
+                            from: "USDT0",
+                            to: TBTC,
+                        },
+                    ],
+                    position: SwapPosition.Pre,
+                    quoteAmount: 1_000,
+                },
+            }),
+        };
+        mockSigner.current = undefined;
+        mockRestoreByAddressFetch.mockResolvedValue(
+            new Response(JSON.stringify([restoredSwap]), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+            }),
+        );
+        mockGetLogsFromReceipt.mockResolvedValue({
+            asset: TBTC,
+            blockNumber: 100,
+            transactionHash,
+            preimageHash: restoredSwap.preimageHash,
+            amount: 1_000_000_000_000n,
+            claimAddress: "0x0000000000000000000000000000000000000002",
+            refundAddress,
+            timelock: 0n,
+        });
+
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <RescueExternal />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        const uploadInput = await screen.findByTestId("refundUpload");
+        const rescueFile = new File(["{}"], "rescue.json", {
+            type: "application/json",
+        });
+        (rescueFile as File & { text: () => Promise<string> }).text = () =>
+            Promise.resolve(JSON.stringify({ mnemonic }));
+
+        await user.upload(uploadInput, rescueFile);
+        await user.click(screen.getByRole("button", { name: i18n.en.rescue }));
+
+        const row = await screen.findByTestId(
+            `swaplist-item-evm:${RskRescueMode.Refund}:${TBTC}:${transactionHash}`,
+        );
+        expect(row).toHaveTextContent(i18n.en.refund);
+        expect(row).not.toHaveClass("disabled");
+        await waitFor(() => {
+            expect(mockScanLockupEvents).toHaveBeenCalledWith(
+                expect.any(AbortSignal),
+                expect.anything(),
+                expect.objectContaining({
+                    action: RskRescueMode.Refund,
+                    filter: expect.objectContaining({
+                        address: refundAddress,
+                    }),
+                }),
+                undefined,
+            );
+            expect(mockScanLockupEvents).toHaveBeenCalledWith(
+                expect.any(AbortSignal),
+                expect.anything(),
+                expect.objectContaining({
+                    action: RskRescueMode.Claim,
+                    filter: expect.objectContaining({
+                        address: refundAddress,
+                    }),
+                }),
+                expect.any(Object),
+            );
+        });
+        const scannedAssets = (
+            mockScanLockupEvents.mock.calls as unknown[][]
+        ).map((call) => (call[2] as { asset: string }).asset);
+        expect(scannedAssets).not.toContain("RBTC");
+    });
+
+    test("rejects restored refunds whose refund address is not a rescue key", async () => {
+        const user = userEvent.setup();
+        const mnemonic =
+            "awake father sword slab matrix myth cargo lock river thumb inspire speed";
+        const transactionHash =
+            "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        vi.stubEnv("VITE_ARBITRUM_LOG_SCAN_ENDPOINT", "http://localhost:8547");
+        const restoredSwap: RestorableSwap = {
+            id: "restored-refund",
+            type: SwapType.Chain,
+            status: "transaction.server.confirmed",
+            createdAt: 1,
+            from: TBTC,
+            to: "L-BTC",
+            preimageHash:
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            metadata: await encryptSwapMetadata(mnemonic, {
+                swapId: "restored-refund",
+                lockupTx: transactionHash,
+                dex: {
+                    hops: [
+                        {
+                            type: SwapType.Dex,
+                            from: "USDT0",
+                            to: TBTC,
+                        },
+                    ],
+                    position: SwapPosition.Pre,
+                    quoteAmount: 1_000,
+                },
+            }),
+        };
+        mockSigner.current = undefined;
+        mockRestoreByAddressFetch.mockResolvedValue(
+            new Response(JSON.stringify([restoredSwap]), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+            }),
+        );
+        mockGetLogsFromReceipt.mockResolvedValue({
+            asset: TBTC,
+            blockNumber: 100,
+            transactionHash,
+            preimageHash: restoredSwap.preimageHash,
+            amount: 1_000_000_000_000n,
+            claimAddress: "0x0000000000000000000000000000000000000002",
+            refundAddress: "0x00000000000000000000000000000000000000ff",
+            timelock: 0n,
+        });
+
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <RescueExternal />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        const uploadInput = await screen.findByTestId("refundUpload");
+        const rescueFile = new File(["{}"], "rescue.json", {
+            type: "application/json",
+        });
+        (rescueFile as File & { text: () => Promise<string> }).text = () =>
+            Promise.resolve(JSON.stringify({ mnemonic }));
+
+        await user.upload(uploadInput, rescueFile);
+        await user.click(screen.getByRole("button", { name: i18n.en.rescue }));
+
+        await waitFor(() => {
+            expect(mockGetLogsFromReceipt).toHaveBeenCalled();
+        });
+        await expect(
+            screen.findByTestId(
+                `swaplist-item-evm:${RskRescueMode.Refund}:${TBTC}:${transactionHash}`,
+                {},
+                { timeout: 1_500 },
+            ),
+        ).rejects.toThrow();
+    });
+
+    test("renders signed EVM address restore results as claim rows", async () => {
+        const user = userEvent.setup();
+        const mnemonic =
+            "awake father sword slab matrix myth cargo lock river thumb inspire speed";
+        const transactionHash =
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        const preimage = derivePreimageFromRescueKey({ mnemonic }, 0, TBTC);
+        const restoredSwap: RestorableSwap = {
+            id: "evm-address-restored",
+            type: SwapType.Reverse,
+            status: "transaction.confirmed",
+            createdAt: 1,
+            from: "BTC",
+            to: TBTC,
+            preimageHash: hex.encode(sha256(preimage)),
+            evmClaimDetails: {
+                amount: 1_000,
+                claimAddress: "0x0000000000000000000000000000000000000001",
+                contractAddress: "0x0000000000000000000000000000000000000003",
+                keyIndex: 0,
+                timeoutBlockHeight: 123,
+                transaction: { id: transactionHash },
+            } as RestorableSwap["evmClaimDetails"],
+            metadata: await encryptSwapMetadata(mnemonic, {
+                swapId: "evm-address-restored",
+                dex: {
+                    hops: [
+                        {
+                            type: SwapType.Dex,
+                            from: TBTC,
+                            to: "USDT0",
+                            dexDetails: {
+                                chain: "ARB",
+                                tokenIn:
+                                    "0x0000000000000000000000000000000000000004",
+                                tokenOut:
+                                    "0x0000000000000000000000000000000000000005",
+                            },
+                        },
+                    ],
+                    position: SwapPosition.Post,
+                    quoteAmount: 1_000,
+                },
+                bridge: {
+                    sourceAsset: "USDT0",
+                    destinationAsset: "USDT0-SOL",
+                    kind: BridgeKind.Oft,
+                    position: SwapPosition.Post,
+                },
+            }),
+        };
+        mockRestoreByAddressFetch.mockResolvedValue(
+            new Response(JSON.stringify([restoredSwap]), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+            }),
+        );
+
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <RescueExternal />
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+
+        const uploadInput = await screen.findByTestId("refundUpload");
+        const rescueFile = new File(["{}"], "rescue.json", {
+            type: "application/json",
+        });
+        (rescueFile as File & { text: () => Promise<string> }).text = () =>
+            Promise.resolve(JSON.stringify({ mnemonic }));
+
+        await user.upload(uploadInput, rescueFile);
+        await user.click(screen.getByRole("button", { name: i18n.en.rescue }));
+
+        const row = await screen.findByTestId(
+            `swaplist-item-evm:${RskRescueMode.Claim}:${TBTC}:${transactionHash}`,
+        );
+        const assets = row.querySelectorAll(".asset");
+
+        expect(row).not.toHaveClass("disabled");
+        expect(row).toHaveTextContent(i18n.en.claim);
+        expect(
+            screen.queryByTestId("swaplist-item-evm-address-restored"),
+        ).toBeNull();
+        expect(assets).toHaveLength(2);
+        expect(assets[0]).toHaveAttribute("data-asset", "LN");
+        expect(assets[1]).toHaveAttribute("data-asset", "USDT");
+        expect(assets[1]).toHaveAttribute("data-network", "solana");
+    });
+
+    test("does not render restored EVM claims without a scanner-confirmed lockup", async () => {
+        const user = userEvent.setup();
+        const mnemonic =
+            "horse olympic laundry marriage material private arch civil theory crew alone thank";
+        const transactionHash =
+            "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+
+        mockGetRestorableSwaps.mockResolvedValueOnce([
+            {
+                id: "restored-claim-only",
+                type: SwapType.Chain,
+                status: "transaction.server.confirmed",
+                createdAt: 1,
+                from: "L-BTC",
+                to: TBTC,
+                preimageHash:
+                    "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                evmClaimDetails: {
+                    amount: 1_000,
+                    claimAddress: "0x0000000000000000000000000000000000000001",
+                    contractAddress:
+                        "0x0000000000000000000000000000000000000003",
+                    timeoutBlockHeight: 123,
+                    transaction: { id: transactionHash },
+                },
+            } as RestorableSwap,
+        ]);
+
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <RescueExternal />
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+
+        const uploadInput = await screen.findByTestId("refundUpload");
+        const rescueFile = new File(["{}"], "rescue.json", {
+            type: "application/json",
+        });
+        (rescueFile as File & { text: () => Promise<string> }).text = () =>
+            Promise.resolve(JSON.stringify({ mnemonic }));
+
+        await user.upload(uploadInput, rescueFile);
+        await user.click(screen.getByRole("button", { name: i18n.en.rescue }));
+
+        await waitFor(() =>
+            expect(mockGetRestorableSwaps).toHaveBeenCalledTimes(2),
+        );
+        await waitFor(() => expect(mockScanLockupEvents).toHaveBeenCalled());
+        await waitFor(() =>
+            expect(screen.queryByText(/Scan progress/)).toBeNull(),
+        );
+
+        expect(
+            screen.queryByTestId(
+                `swaplist-item-evm:${RskRescueMode.Claim}:${TBTC}:${transactionHash}`,
+            ),
+        ).toBeNull();
+        expect(screen.queryByText("block: 0")).toBeNull();
     });
 
     test("renders restored EVM claim metadata as original swap assets", async () => {

--- a/tests/pages/externalRescueScan.spec.ts
+++ b/tests/pages/externalRescueScan.spec.ts
@@ -5,10 +5,7 @@ import {
     SwapType,
 } from "boltz-swaps/types";
 
-import {
-    getEvmDisplayAssets,
-    getEvmFinalAsset,
-} from "../../src/pages/external-rescue/Results";
+import { getEvmDisplayAssets } from "../../src/pages/external-rescue/Results";
 import {
     enrichEvmRescueResults,
     mapRestoredEvmSwaps,
@@ -254,7 +251,6 @@ describe("external EVM rescue scan helpers", () => {
             },
         };
 
-        expect(getEvmFinalAsset(refund)).toBe("USDT0-SOL");
         expect(getEvmDisplayAssets(refund)).toEqual(["USDT0-SOL"]);
     });
 
@@ -269,7 +265,6 @@ describe("external EVM rescue scan helpers", () => {
             },
         };
 
-        expect(getEvmFinalAsset(refund)).toBe("TBTC");
         expect(getEvmDisplayAssets(refund)).toEqual(["TBTC"]);
     });
 

--- a/tests/pages/externalRescueScan.spec.ts
+++ b/tests/pages/externalRescueScan.spec.ts
@@ -235,7 +235,7 @@ describe("external EVM rescue scan helpers", () => {
     });
 
     test("falls back to the original source asset for unmatched pre-bridge refund rows", () => {
-        const refund = {
+        const refund: EvmRescueResult = {
             ...baseEvent,
             action: RskRescueMode.Refund,
             bridge: {
@@ -255,7 +255,7 @@ describe("external EVM rescue scan helpers", () => {
     });
 
     test("does not infer source asset from unmatched pre-dex refund rows", () => {
-        const refund = {
+        const refund: EvmRescueResult = {
             ...baseEvent,
             action: RskRescueMode.Refund,
             dex: {

--- a/tests/pages/externalRescueScan.spec.ts
+++ b/tests/pages/externalRescueScan.spec.ts
@@ -808,6 +808,37 @@ describe("external EVM rescue scan helpers", () => {
         expect(merged[0].metadata).toBe("address-metadata");
     });
 
+    test("keeps the preimage hash and claim key when a later group omits them", () => {
+        const base: RestorableSwap = {
+            id: "swap-a",
+            type: SwapType.Reverse,
+            status: "swap.created",
+            createdAt: 1,
+            from: "BTC",
+            to: "TBTC",
+        };
+
+        const merged = mergeRestorableSwaps(
+            [
+                {
+                    ...base,
+                    preimageHash:
+                        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    claimPrivateKey: "claim-key",
+                },
+            ],
+            // Spreading a swap that carries these fields as explicit
+            // undefined must not clobber the values of the earlier group
+            [{ ...base, preimageHash: undefined, claimPrivateKey: undefined }],
+        );
+
+        expect(merged).toHaveLength(1);
+        expect(merged[0].preimageHash).toBe(
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        );
+        expect(merged[0].claimPrivateKey).toBe("claim-key");
+    });
+
     test("merges scan and restore-derived claims despite hash format differences", () => {
         // Scan results carry 0x-prefixed identifiers while restore-derived
         // results are unprefixed; both must collapse into one entry.

--- a/tests/pages/externalRescueScan.spec.ts
+++ b/tests/pages/externalRescueScan.spec.ts
@@ -1,15 +1,32 @@
+import { sha256 } from "@noble/hashes/sha2.js";
+import { hex } from "@scure/base";
+import type { RestorableSwap } from "boltz-swaps/client";
 import {
     BridgeKind,
     RskRescueMode,
     SwapPosition,
     SwapType,
 } from "boltz-swaps/types";
+import { type Hex, getAddress, recoverMessageAddress } from "viem";
 
+import { config } from "../../src/config";
+import {
+    getEvmRefundDisplayAmount,
+    getEvmRefundDisplayQuoteParams,
+} from "../../src/pages/RescueEvm";
 import { getEvmDisplayAssets } from "../../src/pages/external-rescue/Results";
 import {
     enrichEvmRescueResults,
+    filterHydratedEvmSwaps,
+    getEvmRestoreAccounts,
+    getEvmRestoreChainIds,
+    getEvmRestoreMessage,
+    getRestorableSwapsByEvmAddress,
+    mapRestoredEvmClaimResult,
+    mapRestoredEvmClaimResultFromRescueKey,
     mapRestoredEvmSwaps,
     mergeEvmRescueResults,
+    mergeRestorableSwaps,
 } from "../../src/pages/external-rescue/scan";
 import type {
     EvmRescueResult,
@@ -19,6 +36,10 @@ import {
     isEvmRestoreCandidate,
     shouldShowEvmRestoreResult,
 } from "../../src/pages/external-rescue/useExternalRescueSearch";
+import {
+    type RescueFile,
+    derivePreimageFromRescueKey,
+} from "../../src/utils/rescueFile";
 import { encryptSwapMetadata } from "../../src/utils/swapMetadata";
 
 const baseEvent: EvmRescueResult = {
@@ -64,6 +85,12 @@ const restoredSwap: RestoredEvmSwap = {
 };
 
 describe("external EVM rescue scan helpers", () => {
+    test("excludes the RBTC chain from rescue-key address restores", () => {
+        expect(getEvmRestoreChainIds()).not.toContain(
+            config.assets?.RBTC?.network?.chainId,
+        );
+    });
+
     test("deduplicates chain scan and backend restore events", () => {
         const merged = mergeEvmRescueResults(
             [baseEvent],
@@ -355,6 +382,59 @@ describe("external EVM rescue scan helpers", () => {
         ).toEqual(["USDT0-SOL", "L-BTC"]);
     });
 
+    test("displays pre-bridge refund amounts in the original source asset", () => {
+        const refund = {
+            ...baseEvent,
+            action: RskRescueMode.Refund,
+            asset: "TBTC",
+            amount: 1_102_000_000_000n,
+            tokenAddress: "0x0000000000000000000000000000000000000004",
+            restoredSwap: {
+                ...restoredSwap,
+                from: "TBTC",
+                to: "L-BTC",
+                bridge: {
+                    sourceAsset: "USDT0-SOL",
+                    destinationAsset: "USDT0",
+                    kind: BridgeKind.Oft,
+                    position: SwapPosition.Pre,
+                },
+                dex: {
+                    hops: [
+                        {
+                            type: SwapType.Dex,
+                            from: "USDT0",
+                            to: "TBTC",
+                            dexDetails: {
+                                chain: "ARB",
+                                tokenIn:
+                                    "0x0000000000000000000000000000000000000005",
+                                tokenOut:
+                                    "0x0000000000000000000000000000000000000004",
+                            },
+                        },
+                    ],
+                    position: SwapPosition.Pre,
+                    quoteAmount: 1_100_000,
+                },
+            },
+        } as EvmRescueResult;
+
+        expect(getEvmRefundDisplayAmount(refund, "TBTC")).toMatchObject({
+            asset: "USDT0-SOL",
+        });
+        expect(
+            getEvmRefundDisplayAmount(refund, "TBTC").amount.toString(),
+        ).toBe("1100000");
+        expect(getEvmRefundDisplayQuoteParams(refund, "TBTC")).toEqual({
+            amount: 1_102_000_000_000n,
+            asset: "USDT0-SOL",
+            chain: "ARB",
+            tokenIn: "0x0000000000000000000000000000000000000004",
+            tokenOut: "0x0000000000000000000000000000000000000005",
+        });
+    });
+
     test("does not attach QzNPe7rckJCp metadata to a zero-preimage refund row by amount", async () => {
         const mnemonic =
             "awake father sword slab matrix myth cargo lock river thumb inspire speed";
@@ -450,13 +530,25 @@ describe("external EVM rescue scan helpers", () => {
         ]);
 
         expect(isEvmRestoreCandidate(restoreRow)).toBe(true);
-        expect(
-            shouldShowEvmRestoreResult(
-                restoreRow,
-                evmPreimageHashes,
-                undefined,
-            ),
-        ).toBe(false);
+        expect(shouldShowEvmRestoreResult(restoreRow, evmPreimageHashes)).toBe(
+            false,
+        );
+    });
+
+    test("shows unmatched EVM restore rows while the chain scan is still running", () => {
+        const restoreRow = {
+            id: "restore-only",
+            type: SwapType.Chain,
+            status: "transaction.server.confirmed",
+            createdAt: 1782787562,
+            from: "TBTC",
+            to: "L-BTC",
+            preimageHash:
+                "c75a1b92ece410e13823372edceb1fc148c37d36586c2ccd8b2c78dac1556a8e",
+        };
+
+        expect(isEvmRestoreCandidate(restoreRow)).toBe(true);
+        expect(shouldShowEvmRestoreResult(restoreRow, new Set())).toBe(true);
     });
 
     test("falls back to the routed EVM asset pair for unmatched claim rows", () => {
@@ -485,6 +577,402 @@ describe("external EVM rescue scan helpers", () => {
                 restoredSwap,
             }),
         ).toEqual(["L-BTC", "USDT0-SOL"]);
+    });
+
+    test("maps restored post-dex claims from restore transaction metadata only", () => {
+        const transactionHash =
+            "0x1111111111111111111111111111111111111111111111111111111111111111";
+        const result = mapRestoredEvmClaimResult(
+            {
+                ...restoredSwap,
+                lockupTx: undefined,
+                commitmentLockupTxHash: undefined,
+                bridge: undefined,
+                evmClaimDetails: {
+                    ...restoredSwap.evmClaimDetails!,
+                    amount: 70_000,
+                    transaction: { id: transactionHash },
+                },
+            },
+            "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        );
+
+        if (result === undefined) {
+            throw new Error("missing restored EVM claim result");
+        }
+
+        expect(result.action).toBe(RskRescueMode.Claim);
+        expect(result.asset).toBe("TBTC");
+        expect(result.transactionHash).toBe(transactionHash);
+        expect(result.bridge).toBeUndefined();
+        expect(result.dex?.position).toBe(SwapPosition.Post);
+        expect(getEvmDisplayAssets(result)).toEqual(["L-BTC", "USDT0"]);
+    });
+
+    test("maps restored EVM claim amount to token units", () => {
+        const result = mapRestoredEvmClaimResult(
+            {
+                ...restoredSwap,
+                evmClaimDetails: {
+                    ...restoredSwap.evmClaimDetails!,
+                    amount: 70_000,
+                },
+            },
+            "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        );
+
+        expect(result?.asset).toBe("TBTC");
+        expect(result?.amount).toBe(700_000_000_000_000n);
+    });
+
+    test("maps signed EVM address restore claims with the rescue key index", () => {
+        const rescueFile: RescueFile = {
+            mnemonic:
+                "awake father sword slab matrix myth cargo lock river thumb inspire speed",
+        };
+        const preimage = derivePreimageFromRescueKey(rescueFile, 0, "TBTC");
+        const preimageHash = hex.encode(sha256(preimage));
+        const result = mapRestoredEvmClaimResultFromRescueKey(
+            {
+                ...restoredSwap,
+                preimageHash,
+                evmClaimDetails: {
+                    ...restoredSwap.evmClaimDetails!,
+                    keyIndex: 0,
+                } as RestoredEvmSwap["evmClaimDetails"] & { keyIndex: number },
+            },
+            rescueFile,
+        );
+
+        expect(Buffer.from(preimage).toString("hex")).toBe(result?.preimage);
+        expect(result?.restoredSwap?.id).toBe("swap-id");
+    });
+
+    test("builds EVM address restore proof messages", () => {
+        expect(
+            getEvmRestoreMessage(
+                "0x0000000000000000000000000000000000000001",
+                1_234,
+            ),
+        ).toBe(
+            "Boltz swap restore\naddress: 0x0000000000000000000000000000000000000001\ntimestamp: 1234",
+        );
+    });
+
+    test("sends a verifiable EVM address restore request payload", async () => {
+        const rescueFile: RescueFile = {
+            mnemonic:
+                "awake father sword slab matrix myth cargo lock river thumb inspire speed",
+        };
+        const [{ account }] = getEvmRestoreAccounts(rescueFile);
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify([]), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+            }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        try {
+            const before = Math.floor(Date.now() / 1_000);
+            await getRestorableSwapsByEvmAddress(
+                account,
+                new AbortController().signal,
+            );
+            const after = Math.floor(Date.now() / 1_000);
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            const [url, options] = fetchMock.mock.calls[0] as [
+                string,
+                RequestInit,
+            ];
+            expect(url).toContain("/v2/swap/restore");
+            expect(options.method).toBe("POST");
+
+            const body = JSON.parse(options.body as string) as {
+                address: string;
+                timestamp: number;
+                signature: Hex;
+            };
+            expect(body.address).toBe(getAddress(account.address));
+            expect(body.timestamp).toBeGreaterThanOrEqual(before);
+            expect(body.timestamp).toBeLessThanOrEqual(after);
+            expect(
+                await recoverMessageAddress({
+                    message: getEvmRestoreMessage(body.address, body.timestamp),
+                    signature: body.signature,
+                }),
+            ).toBe(getAddress(account.address));
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
+    test("rejects rescue key claims when the derived preimage does not match", () => {
+        const rescueFile: RescueFile = {
+            mnemonic:
+                "awake father sword slab matrix myth cargo lock river thumb inspire speed",
+        };
+        const preimage = derivePreimageFromRescueKey(rescueFile, 0, "TBTC");
+        const preimageHash = hex.encode(sha256(preimage));
+        const withClaimDetails = (keyIndex: number, hash: string) => ({
+            ...restoredSwap,
+            preimageHash: hash,
+            evmClaimDetails: {
+                ...restoredSwap.evmClaimDetails!,
+                keyIndex,
+            } as RestoredEvmSwap["evmClaimDetails"] & { keyIndex: number },
+        });
+
+        // Wrong key index: the derived preimage hashes to something else.
+        expect(
+            mapRestoredEvmClaimResultFromRescueKey(
+                withClaimDetails(1, preimageHash),
+                rescueFile,
+            ),
+        ).toBeUndefined();
+        // Missing preimage hash: nothing to verify against.
+        expect(
+            mapRestoredEvmClaimResultFromRescueKey(
+                withClaimDetails(0, ""),
+                rescueFile,
+            ),
+        ).toBeUndefined();
+    });
+
+    test("merges restorable swap groups by id and keeps existing details", () => {
+        const evmClaimDetails = {
+            contractAddress: "0x0000000000000000000000000000000000000003",
+            claimAddress: "0x0000000000000000000000000000000000000001",
+            keyIndex: 0,
+            timeoutBlockHeight: 123,
+        } as RestorableSwap["evmClaimDetails"];
+        const xpubSwap: RestorableSwap = {
+            id: "swap-a",
+            type: SwapType.Reverse,
+            status: "swap.created",
+            createdAt: 1,
+            from: "BTC",
+            to: "TBTC",
+            metadata: "xpub-metadata",
+            evmClaimDetails,
+        };
+        const addressSwap: RestorableSwap = {
+            id: "swap-a",
+            type: SwapType.Reverse,
+            status: "transaction.confirmed",
+            createdAt: 1,
+            from: "BTC",
+            to: "TBTC",
+        };
+        const otherSwap: RestorableSwap = {
+            id: "swap-b",
+            type: SwapType.Chain,
+            status: "swap.created",
+            createdAt: 2,
+            from: "L-BTC",
+            to: "TBTC",
+        };
+
+        const merged = mergeRestorableSwaps(
+            [xpubSwap, otherSwap],
+            [addressSwap],
+        );
+
+        expect(merged).toHaveLength(2);
+        const swapA = merged.find((swap) => swap.id === "swap-a");
+        // Later groups win for fields they define...
+        expect(swapA?.status).toBe("transaction.confirmed");
+        // ...but must not drop details only the earlier group carried.
+        expect(swapA?.metadata).toBe("xpub-metadata");
+        expect(swapA?.evmClaimDetails).toEqual(evmClaimDetails);
+        expect(merged.find((swap) => swap.id === "swap-b")).toBeDefined();
+    });
+
+    test("prefers later restorable swap details when both groups define them", () => {
+        const base: RestorableSwap = {
+            id: "swap-a",
+            type: SwapType.Reverse,
+            status: "swap.created",
+            createdAt: 1,
+            from: "BTC",
+            to: "TBTC",
+        };
+
+        const merged = mergeRestorableSwaps(
+            [{ ...base, metadata: "xpub-metadata" }],
+            [{ ...base, metadata: "address-metadata" }],
+        );
+
+        expect(merged).toHaveLength(1);
+        expect(merged[0].metadata).toBe("address-metadata");
+    });
+
+    test("merges scan and restore-derived claims despite hash format differences", () => {
+        // Scan results carry 0x-prefixed identifiers while restore-derived
+        // results are unprefixed; both must collapse into one entry.
+        const restoreDerived = mapRestoredEvmClaimResult(
+            {
+                ...restoredSwap,
+                lockupTx: undefined,
+                commitmentLockupTxHash: undefined,
+            },
+            "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        );
+
+        if (restoreDerived === undefined) {
+            throw new Error("missing restored EVM claim result");
+        }
+
+        for (const [current, next] of [
+            [[baseEvent], [restoreDerived]],
+            [[restoreDerived], [baseEvent]],
+        ]) {
+            const merged = mergeEvmRescueResults(current, next);
+            expect(merged).toHaveLength(1);
+            expect(merged[0].preimage).toBeDefined();
+            expect(merged[0].restoredSwap?.id).toBe("swap-id");
+        }
+    });
+
+    test("keeps scan lockup fields when restore-derived claims merge in either order", () => {
+        // Restore-derived results carry placeholder blockNumber/amount/
+        // refundAddress; the scan values must survive regardless of which
+        // side arrives first.
+        const restoreDerived = mapRestoredEvmClaimResult(
+            {
+                ...restoredSwap,
+                lockupTx: undefined,
+                commitmentLockupTxHash: undefined,
+            },
+            "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        );
+
+        if (restoreDerived === undefined) {
+            throw new Error("missing restored EVM claim result");
+        }
+
+        for (const [current, next] of [
+            [[baseEvent], [restoreDerived]],
+            [[restoreDerived], [baseEvent]],
+        ]) {
+            const merged = mergeEvmRescueResults(current, next);
+            expect(merged).toHaveLength(1);
+            expect(merged[0].blockNumber).toBe(baseEvent.blockNumber);
+            expect(merged[0].amount).toBe(baseEvent.amount);
+            expect(merged[0].refundAddress).toBe(baseEvent.refundAddress);
+        }
+    });
+
+    test("enriches scanner claims with the restored claim transaction hash", () => {
+        const [enriched] = enrichEvmRescueResults(
+            [baseEvent],
+            [
+                {
+                    ...restoredSwap,
+                    lockupTx: undefined,
+                    commitmentLockupTxHash: undefined,
+                    evmClaimDetails: {
+                        ...restoredSwap.evmClaimDetails!,
+                        transaction: {
+                            id: baseEvent.transactionHash
+                                .toUpperCase()
+                                .replace(/^0X/, ""),
+                        },
+                    },
+                },
+            ],
+        );
+
+        expect(enriched.restoredSwap?.id).toBe("swap-id");
+        expect(enriched.dex?.hops[0].to).toBe("USDT0");
+    });
+
+    test("normalizes identifiers in restored claim results", () => {
+        const result = mapRestoredEvmClaimResult(
+            {
+                ...restoredSwap,
+                preimageHash: baseEvent.preimageHash.toUpperCase(),
+                evmClaimDetails: {
+                    ...restoredSwap.evmClaimDetails!,
+                    transaction: {
+                        id: baseEvent.transactionHash.replace(/^0x/, ""),
+                    },
+                },
+            },
+            "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+        );
+
+        expect(result?.transactionHash).toBe(baseEvent.transactionHash);
+        expect(result?.preimageHash).toBe(
+            baseEvent.preimageHash.replace(/^0x/, ""),
+        );
+        expect(result?.preimage).toBe("c".repeat(64));
+    });
+
+    test("does not map restored claims with missing or unknown details", () => {
+        const preimage =
+            "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+
+        expect(
+            mapRestoredEvmClaimResult(
+                { ...restoredSwap, evmClaimDetails: undefined },
+                preimage,
+            ),
+        ).toBeUndefined();
+        expect(
+            mapRestoredEvmClaimResult(
+                {
+                    ...restoredSwap,
+                    evmClaimDetails: {
+                        ...restoredSwap.evmClaimDetails!,
+                        transaction: undefined,
+                    },
+                },
+                preimage,
+            ),
+        ).toBeUndefined();
+        expect(
+            mapRestoredEvmClaimResult(
+                { ...restoredSwap, preimageHash: "0x" },
+                preimage,
+            ),
+        ).toBeUndefined();
+        expect(
+            mapRestoredEvmClaimResult(
+                {
+                    ...restoredSwap,
+                    dex: {
+                        ...restoredSwap.dex!,
+                        hops: [
+                            { type: SwapType.Dex, from: "DOGE", to: "USDT0" },
+                        ],
+                    },
+                },
+                preimage,
+            ),
+        ).toBeUndefined();
+    });
+
+    test("keeps swaps with only a claim transaction when filtering hydrated EVM swaps", () => {
+        const claimOnly = {
+            ...restoredSwap,
+            lockupTx: undefined,
+            commitmentLockupTxHash: undefined,
+        };
+
+        expect(filterHydratedEvmSwaps([claimOnly])).toEqual([claimOnly]);
+        expect(
+            filterHydratedEvmSwaps([
+                {
+                    ...claimOnly,
+                    evmClaimDetails: {
+                        ...restoredSwap.evmClaimDetails!,
+                        transaction: undefined,
+                    },
+                },
+            ]),
+        ).toEqual([]);
     });
 
     test("does not match restored metadata on empty identifiers", () => {

--- a/tests/pages/externalRescueScan.spec.ts
+++ b/tests/pages/externalRescueScan.spec.ts
@@ -1,0 +1,520 @@
+import {
+    BridgeKind,
+    RskRescueMode,
+    SwapPosition,
+    SwapType,
+} from "boltz-swaps/types";
+
+import {
+    getEvmDisplayAssets,
+    getEvmFinalAsset,
+} from "../../src/pages/external-rescue/Results";
+import {
+    enrichEvmRescueResults,
+    mapRestoredEvmSwaps,
+    mergeEvmRescueResults,
+} from "../../src/pages/external-rescue/scan";
+import type {
+    EvmRescueResult,
+    RestoredEvmSwap,
+} from "../../src/pages/external-rescue/types";
+import {
+    isEvmRestoreCandidate,
+    shouldShowEvmRestoreResult,
+} from "../../src/pages/external-rescue/useExternalRescueSearch";
+import { encryptSwapMetadata } from "../../src/utils/swapMetadata";
+
+const baseEvent: EvmRescueResult = {
+    action: RskRescueMode.Claim,
+    asset: "TBTC",
+    blockNumber: 100,
+    transactionHash:
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    preimageHash:
+        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    amount: 1000n,
+    claimAddress: "0x0000000000000000000000000000000000000001",
+    refundAddress: "0x0000000000000000000000000000000000000002",
+    timelock: 123n,
+};
+
+const restoredSwap: RestoredEvmSwap = {
+    id: "swap-id",
+    type: SwapType.Chain,
+    status: "transaction.server.confirmed",
+    createdAt: 1,
+    from: "L-BTC",
+    to: "TBTC",
+    preimageHash: baseEvent.preimageHash,
+    commitmentLockupTxHash: baseEvent.transactionHash,
+    evmClaimDetails: {
+        contractAddress: "0x0000000000000000000000000000000000000003",
+        claimAddress: baseEvent.claimAddress,
+        transaction: { id: baseEvent.transactionHash },
+        timeoutBlockHeight: 123,
+    },
+    dex: {
+        hops: [{ type: SwapType.Dex, from: "TBTC", to: "USDT0" }],
+        position: SwapPosition.Post,
+        quoteAmount: 1000,
+    },
+    bridge: {
+        sourceAsset: "USDT0",
+        destinationAsset: "USDT0-SOL",
+        kind: BridgeKind.Oft,
+        position: SwapPosition.Post,
+    },
+};
+
+describe("external EVM rescue scan helpers", () => {
+    test("deduplicates chain scan and backend restore events", () => {
+        const merged = mergeEvmRescueResults(
+            [baseEvent],
+            [
+                {
+                    ...baseEvent,
+                    preimage:
+                        "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                    restoredSwap,
+                    dex: restoredSwap.dex,
+                    bridge: restoredSwap.bridge,
+                },
+            ],
+        );
+
+        expect(merged).toHaveLength(1);
+        expect(merged[0].preimage).toBe(
+            "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        );
+        expect(merged[0].restoredSwap?.id).toBe("swap-id");
+        expect(merged[0].bridge?.destinationAsset).toBe("USDT0-SOL");
+    });
+
+    test("enriches scanner results with encrypted metadata transaction hash", () => {
+        const [enriched] = enrichEvmRescueResults([baseEvent], [restoredSwap]);
+
+        expect(enriched.restoredSwap?.id).toBe("swap-id");
+        expect(enriched.dex?.hops[0].to).toBe("USDT0");
+        expect(enriched.bridge?.destinationAsset).toBe("USDT0-SOL");
+    });
+
+    test("hydrates encrypted metadata transaction hash for matching", async () => {
+        const mnemonic =
+            "awake father sword slab matrix myth cargo lock river thumb inspire speed";
+        const [restored] = await mapRestoredEvmSwaps(
+            [
+                {
+                    id: "metadata-tx-swap",
+                    type: SwapType.Chain,
+                    status: "transaction.server.confirmed",
+                    createdAt: 1,
+                    from: "L-BTC",
+                    to: "TBTC",
+                    preimageHash:
+                        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    metadata: await encryptSwapMetadata(mnemonic, {
+                        swapId: "metadata-tx-swap",
+                        lockupTx: baseEvent.transactionHash,
+                        dex: restoredSwap.dex,
+                        bridge: restoredSwap.bridge,
+                    }),
+                },
+            ],
+            mnemonic,
+        );
+
+        if (restored === undefined) {
+            throw new Error("missing restored swap");
+        }
+
+        expect(restored.lockupTx).toBe(baseEvent.transactionHash);
+        const [enriched] = enrichEvmRescueResults([baseEvent], [restored]);
+        expect(enriched.restoredSwap?.id).toBe("metadata-tx-swap");
+    });
+
+    test("enriches scanner refund results with encrypted metadata refund transaction", () => {
+        const refundTx =
+            "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+        const [enriched] = enrichEvmRescueResults(
+            [
+                {
+                    ...baseEvent,
+                    action: RskRescueMode.Refund,
+                    transactionHash: refundTx,
+                    preimageHash: "0x",
+                },
+            ],
+            [
+                {
+                    ...restoredSwap,
+                    preimageHash: "",
+                    commitmentLockupTxHash: refundTx,
+                    refundDetails: {
+                        tree: {
+                            claimLeaf: { version: 192, output: "51" },
+                            refundLeaf: { version: 192, output: "51" },
+                        },
+                        keyIndex: 0,
+                        lockupAddress: "lockup",
+                        serverPublicKey:
+                            "020000000000000000000000000000000000000000000000000000000000000000",
+                        timeoutBlockHeight: 1,
+                        transaction: { id: refundTx, vout: 0 },
+                    },
+                },
+            ],
+        );
+
+        expect(enriched.restoredSwap?.id).toBe("swap-id");
+        expect(enriched.bridge?.destinationAsset).toBe("USDT0-SOL");
+    });
+
+    test("does not enrich scanner results by unambiguous claim address", () => {
+        const [enriched] = enrichEvmRescueResults(
+            [
+                {
+                    ...baseEvent,
+                    action: RskRescueMode.Refund,
+                    transactionHash:
+                        "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                    preimageHash: "0x",
+                },
+            ],
+            [
+                {
+                    ...restoredSwap,
+                    preimageHash: "",
+                    evmClaimDetails: {
+                        ...restoredSwap.evmClaimDetails!,
+                        transaction: {
+                            id: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                        },
+                    },
+                },
+            ],
+        );
+
+        expect(enriched.restoredSwap).toBeUndefined();
+        expect(enriched.bridge).toBeUndefined();
+    });
+
+    test("does not enrich scanner results by claim address when ambiguous", () => {
+        const [enriched] = enrichEvmRescueResults(
+            [
+                {
+                    ...baseEvent,
+                    action: RskRescueMode.Refund,
+                    transactionHash:
+                        "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                    preimageHash: "0x",
+                },
+            ],
+            [
+                {
+                    ...restoredSwap,
+                    preimageHash: "",
+                    evmClaimDetails: {
+                        ...restoredSwap.evmClaimDetails!,
+                        transaction: {
+                            id: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                        },
+                    },
+                },
+                {
+                    ...restoredSwap,
+                    id: "other-swap-id",
+                    preimageHash: "",
+                    evmClaimDetails: {
+                        ...restoredSwap.evmClaimDetails!,
+                        transaction: {
+                            id: "0x1111111111111111111111111111111111111111111111111111111111111111",
+                        },
+                    },
+                },
+            ],
+        );
+
+        expect(enriched.restoredSwap).toBeUndefined();
+    });
+
+    test("falls back to the original source asset for unmatched pre-bridge refund rows", () => {
+        const refund = {
+            ...baseEvent,
+            action: RskRescueMode.Refund,
+            bridge: {
+                sourceAsset: "USDT0-SOL",
+                destinationAsset: "USDT0",
+                kind: BridgeKind.Oft,
+                position: SwapPosition.Pre,
+            },
+            dex: {
+                hops: [{ type: SwapType.Dex, from: "USDT0", to: "TBTC" }],
+                position: SwapPosition.Pre,
+                quoteAmount: 1000,
+            },
+        };
+
+        expect(getEvmFinalAsset(refund)).toBe("USDT0-SOL");
+        expect(getEvmDisplayAssets(refund)).toEqual(["USDT0-SOL"]);
+    });
+
+    test("does not infer source asset from unmatched pre-dex refund rows", () => {
+        const refund = {
+            ...baseEvent,
+            action: RskRescueMode.Refund,
+            dex: {
+                hops: [{ type: SwapType.Dex, from: "USDT0", to: "TBTC" }],
+                position: SwapPosition.Pre,
+                quoteAmount: 1000,
+            },
+        };
+
+        expect(getEvmFinalAsset(refund)).toBe("TBTC");
+        expect(getEvmDisplayAssets(refund)).toEqual(["TBTC"]);
+    });
+
+    test("does not infer source metadata for unmatched routed pre-bridge refund rows", () => {
+        const preRoutedSwap: RestoredEvmSwap = {
+            ...restoredSwap,
+            id: "pre-routed-swap",
+            from: "TBTC",
+            to: "L-BTC",
+            preimageHash:
+                "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            claimDetails: {
+                tree: {
+                    claimLeaf: { version: 192, output: "51" },
+                    refundLeaf: { version: 192, output: "51" },
+                },
+                amount: 13341,
+                keyIndex: 0,
+                lockupAddress: "lockup",
+                serverPublicKey: "server",
+                timeoutBlockHeight: 100,
+                blindingKey: "blind",
+                preimageHash:
+                    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            },
+            evmClaimDetails: undefined,
+            dex: {
+                hops: [{ type: SwapType.Dex, from: "USDT0", to: "TBTC" }],
+                position: SwapPosition.Pre,
+                quoteAmount: 13334,
+            },
+            bridge: {
+                sourceAsset: "USDT0-SOL",
+                destinationAsset: "USDT0",
+                kind: BridgeKind.Oft,
+                position: SwapPosition.Pre,
+            },
+        };
+        const [enriched] = enrichEvmRescueResults(
+            [
+                {
+                    ...baseEvent,
+                    action: RskRescueMode.Refund,
+                    asset: "TBTC",
+                    amount: 42n,
+                    transactionHash:
+                        "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+                    preimageHash: `0x${"00".repeat(32)}`,
+                },
+            ],
+            [preRoutedSwap],
+        );
+
+        expect(enriched.restoredSwap).toBeUndefined();
+        expect(enriched.bridge).toBeUndefined();
+        expect(getEvmDisplayAssets(enriched)).toEqual(["TBTC"]);
+    });
+
+    test("uses restored swap endpoints for pre-bridge refund rows", () => {
+        expect(
+            getEvmDisplayAssets({
+                ...baseEvent,
+                action: RskRescueMode.Refund,
+                asset: "TBTC",
+                restoredSwap: {
+                    ...restoredSwap,
+                    from: "TBTC",
+                    to: "L-BTC",
+                    bridge: {
+                        sourceAsset: "USDT0-SOL",
+                        destinationAsset: "USDT0",
+                        kind: BridgeKind.Oft,
+                        position: SwapPosition.Pre,
+                    },
+                    dex: {
+                        hops: [
+                            {
+                                type: SwapType.Dex,
+                                from: "USDT0",
+                                to: "TBTC",
+                            },
+                        ],
+                        position: SwapPosition.Pre,
+                        quoteAmount: 13334,
+                    },
+                },
+            }),
+        ).toEqual(["USDT0-SOL", "L-BTC"]);
+    });
+
+    test("does not attach QzNPe7rckJCp metadata to a zero-preimage refund row by amount", async () => {
+        const mnemonic =
+            "awake father sword slab matrix myth cargo lock river thumb inspire speed";
+        const restored = await mapRestoredEvmSwaps(
+            [
+                {
+                    id: "QzNPe7rckJCp",
+                    type: SwapType.Chain,
+                    status: "transaction.server.confirmed",
+                    createdAt: 1782787562,
+                    from: "TBTC",
+                    to: "L-BTC",
+                    preimageHash:
+                        "c75a1b92ece410e13823372edceb1fc148c37d36586c2ccd8b2c78dac1556a8e",
+                    claimDetails: {
+                        tree: {
+                            claimLeaf: { version: 196, output: "51" },
+                            refundLeaf: { version: 196, output: "51" },
+                        },
+                        amount: 13341,
+                        keyIndex: 71,
+                        transaction: {
+                            id: "6ba69b919aaf28f5ec746f97cde06da136c77390082de0b52674954b58a51aa1",
+                            vout: 1,
+                        },
+                        lockupAddress: "lockup",
+                        serverPublicKey:
+                            "03bb779740ad43c9337bf89a23062a8564b2cf5a75fd7e317a352965ee1b4a51b2",
+                        timeoutBlockHeight: 3953207,
+                        blindingKey:
+                            "c43345f5cbf63cd5be4044c0eb7b0991cc2465599fcf2e8d6127ec3847943dc4",
+                        preimageHash:
+                            "c75a1b92ece410e13823372edceb1fc148c37d36586c2ccd8b2c78dac1556a8e",
+                    },
+                    metadata: await encryptSwapMetadata(mnemonic, {
+                        dex: {
+                            hops: [
+                                {
+                                    type: SwapType.Dex,
+                                    from: "USDT0",
+                                    to: "TBTC",
+                                },
+                            ],
+                            position: SwapPosition.Pre,
+                            quoteAmount: 13334,
+                        },
+                        bridge: {
+                            sourceAsset: "USDT0-SOL",
+                            destinationAsset: "USDT0",
+                            kind: BridgeKind.Oft,
+                            position: SwapPosition.Pre,
+                        },
+                    }),
+                },
+            ],
+            mnemonic,
+        );
+
+        const [enriched] = enrichEvmRescueResults(
+            [
+                {
+                    ...baseEvent,
+                    action: RskRescueMode.Refund,
+                    asset: "TBTC",
+                    transactionHash:
+                        "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                    preimageHash: `0x${"00".repeat(32)}`,
+                    amount: 99_039_478_307_028n,
+                },
+            ],
+            restored,
+        );
+
+        expect(restored).toHaveLength(0);
+        expect(enriched.restoredSwap).toBeUndefined();
+        expect(enriched.bridge).toBeUndefined();
+        expect(getEvmDisplayAssets(enriched)).toEqual(["TBTC"]);
+    });
+
+    test("hides the QzNPe7rckJCp generic restore row when the EVM refund row exists", () => {
+        const restoreRow = {
+            id: "QzNPe7rckJCp",
+            type: SwapType.Chain,
+            status: "transaction.server.confirmed",
+            createdAt: 1782787562,
+            from: "TBTC",
+            to: "L-BTC",
+            preimageHash:
+                "c75a1b92ece410e13823372edceb1fc148c37d36586c2ccd8b2c78dac1556a8e",
+        };
+        const evmPreimageHashes = new Set([
+            "c75a1b92ece410e13823372edceb1fc148c37d36586c2ccd8b2c78dac1556a8e",
+        ]);
+
+        expect(isEvmRestoreCandidate(restoreRow)).toBe(true);
+        expect(
+            shouldShowEvmRestoreResult(
+                restoreRow,
+                evmPreimageHashes,
+                undefined,
+            ),
+        ).toBe(false);
+    });
+
+    test("falls back to the routed EVM asset pair for unmatched claim rows", () => {
+        expect(
+            getEvmDisplayAssets({
+                ...baseEvent,
+                bridge: {
+                    sourceAsset: "USDT0",
+                    destinationAsset: "USDT0-SOL",
+                    kind: BridgeKind.Oft,
+                    position: SwapPosition.Post,
+                },
+                dex: {
+                    hops: [{ type: SwapType.Dex, from: "TBTC", to: "USDT0" }],
+                    position: SwapPosition.Post,
+                    quoteAmount: 1000,
+                },
+            }),
+        ).toEqual(["TBTC", "USDT0-SOL"]);
+    });
+
+    test("uses restored swap endpoints for post-bridge claim rows", () => {
+        expect(
+            getEvmDisplayAssets({
+                ...baseEvent,
+                restoredSwap,
+            }),
+        ).toEqual(["L-BTC", "USDT0-SOL"]);
+    });
+
+    test("does not match restored metadata on empty identifiers", () => {
+        const [enriched] = enrichEvmRescueResults(
+            [
+                {
+                    ...baseEvent,
+                    transactionHash: "0x",
+                    preimageHash: "0x",
+                    claimAddress: "0x",
+                },
+            ],
+            [
+                {
+                    ...restoredSwap,
+                    preimageHash: "",
+                    evmClaimDetails: {
+                        ...restoredSwap.evmClaimDetails!,
+                        claimAddress: "0x",
+                        transaction: { id: "" },
+                    },
+                },
+            ],
+        );
+
+        expect(enriched.restoredSwap).toBeUndefined();
+    });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -47,6 +47,7 @@ if (runtimeConfig.assets && mainnetConfig.assets) {
     runtimeConfig.assets.TBTC ??= mainnetConfig.assets.TBTC;
     runtimeConfig.assets.WBTC ??= mainnetConfig.assets.WBTC;
     runtimeConfig.assets.USDT0 ??= mainnetConfig.assets.USDT0;
+    runtimeConfig.assets["USDT0-SOL"] ??= mainnetConfig.assets["USDT0-SOL"];
     runtimeConfig.assets.USDC ??= mainnetConfig.assets.USDC;
 }
 

--- a/tests/utils/evmLockup.spec.ts
+++ b/tests/utils/evmLockup.spec.ts
@@ -1,4 +1,62 @@
-import { getNativeEvmLockupSpendableBalance } from "../../src/utils/evmLockup";
+import {
+    type Log,
+    encodeAbiParameters,
+    encodeEventTopics,
+    erc20Abi,
+    getAddress,
+} from "viem";
+import { vi } from "vitest";
+
+import {
+    findLockupTokenFunder,
+    getNativeEvmLockupSpendableBalance,
+    resolveLockupTokenFunder,
+} from "../../src/utils/evmLockup";
+
+const tokenIn = "0x0000000000000000000000000000000000000010";
+const tokenOut = "0x0000000000000000000000000000000000000011";
+const router = "0x0000000000000000000000000000000000000020";
+const funder = "0x0000000000000000000000000000000000000030";
+const pool = "0x0000000000000000000000000000000000000040";
+const lockupTxHash =
+    "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+
+const { mockGetTransactionReceipt } = vi.hoisted(() => ({
+    mockGetTransactionReceipt: vi.fn(),
+}));
+
+vi.mock("boltz-swaps/evm", async () => {
+    const actual = await vi.importActual("boltz-swaps/evm");
+    return {
+        ...actual,
+        createAssetProvider: () => ({
+            getTransactionReceipt: mockGetTransactionReceipt,
+        }),
+    };
+});
+
+vi.mock("../../src/consts/Assets", async () => {
+    const actual = await vi.importActual("../../src/consts/Assets");
+    return {
+        ...actual,
+        requireRouterAddress: () =>
+            "0x0000000000000000000000000000000000000020",
+    };
+});
+
+const transferLog = (token: string, from: string, to: string): Log =>
+    ({
+        address: token,
+        topics: encodeEventTopics({
+            abi: erc20Abi,
+            eventName: "Transfer",
+            args: {
+                from: from as `0x${string}`,
+                to: to as `0x${string}`,
+            },
+        }),
+        data: encodeAbiParameters([{ type: "uint256" }], [1_000n]),
+    }) as unknown as Log;
 
 describe("getNativeEvmLockupSpendableBalance", () => {
     test("reserves lockup gas from the native balance", () => {
@@ -7,5 +65,59 @@ describe("getNativeEvmLockupSpendableBalance", () => {
 
     test("returns zero when the gas reserve exceeds the balance", () => {
         expect(getNativeEvmLockupSpendableBalance(10_000n, 2n)).toBe(0n);
+    });
+});
+
+describe("findLockupTokenFunder", () => {
+    test("returns the sender of the Permit2 pull into the router", () => {
+        const logs = [
+            transferLog(tokenIn, funder, router),
+            transferLog(tokenIn, router, pool),
+            transferLog(tokenOut, pool, router),
+        ];
+
+        expect(findLockupTokenFunder(logs, tokenIn, router)).toBe(
+            getAddress(funder),
+        );
+    });
+
+    test("ignores transfers of other tokens into the router", () => {
+        const logs = [
+            transferLog(tokenOut, pool, router),
+            transferLog(tokenIn, router, pool),
+        ];
+
+        expect(findLockupTokenFunder(logs, tokenIn, router)).toBeUndefined();
+    });
+
+    test("returns undefined when the receipt has no transfers", () => {
+        expect(findLockupTokenFunder([], tokenIn, router)).toBeUndefined();
+    });
+});
+
+describe("resolveLockupTokenFunder", () => {
+    beforeEach(() => {
+        mockGetTransactionReceipt.mockReset();
+    });
+
+    test("returns undefined when the receipt is missing", async () => {
+        mockGetTransactionReceipt.mockResolvedValue(null);
+
+        expect(
+            await resolveLockupTokenFunder("TBTC", tokenIn, lockupTxHash),
+        ).toBeUndefined();
+        expect(mockGetTransactionReceipt).toHaveBeenCalledWith({
+            hash: lockupTxHash,
+        });
+    });
+
+    test("resolves the funder from the receipt logs", async () => {
+        mockGetTransactionReceipt.mockResolvedValue({
+            logs: [transferLog(tokenIn, funder, router)],
+        });
+
+        expect(
+            await resolveLockupTokenFunder("TBTC", tokenIn, lockupTxHash),
+        ).toBe(getAddress(funder));
     });
 });

--- a/tests/utils/swapMetadata.spec.ts
+++ b/tests/utils/swapMetadata.spec.ts
@@ -37,12 +37,20 @@ const samplePayload: SwapMetadataPayload = {
     },
     lockupTx: "0xlockup",
     commitmentLockupTxHash: "0xcommitment",
+    originalDestination: "0xdestination",
     bridge: {
         sourceAsset: "USDC",
         destinationAsset: "USDC-BASE",
         kind: BridgeKind.Cctp,
         position: SwapPosition.Post,
     },
+};
+
+const legacyGoldenPayload: SwapMetadataPayload = {
+    dex: samplePayload.dex,
+    lockupTx: samplePayload.lockupTx,
+    commitmentLockupTxHash: samplePayload.commitmentLockupTxHash,
+    bridge: samplePayload.bridge,
 };
 
 // Payloads carrying a lockup transaction must be bound to their swap.
@@ -90,7 +98,7 @@ describe("swapMetadata crypto", () => {
     test("decrypts the golden vector (wire format is frozen)", async () => {
         await expect(
             decryptSwapMetadata(mnemonic, swapId, goldenVector),
-        ).resolves.toEqual(samplePayload);
+        ).resolves.toEqual(legacyGoldenPayload);
     });
 
     test("rejects an unsupported (newer) metadata version", async () => {
@@ -308,6 +316,7 @@ describe("patchEncryptedSwapMetadata", () => {
                 id: "swap-id",
                 lockupTx: "0xtx",
                 dex: samplePayload.dex,
+                originalDestination: samplePayload.originalDestination,
             } as never,
             rescueFile,
         );
@@ -320,6 +329,7 @@ describe("patchEncryptedSwapMetadata", () => {
         ).resolves.toEqual({
             lockupTx: "0xtx",
             dex: samplePayload.dex,
+            originalDestination: samplePayload.originalDestination,
         });
 
         // The blob must not decrypt for any other swap.


### PR DESCRIPTION
Closes #1554 
Closes #1476 

# PR 2 of 3
The three combined PRs will allow using the stored metadata to claim/refund to the user's original asset. 

1. https://github.com/BoltzExchange/boltz-web-app/pull/1524 data storage / retrieve
2. https://github.com/BoltzExchange/boltz-web-app/pull/1525 uses the returned metadata to enrich external rescue list (show the original pairs on the swaps list), also dedups results, preserves previous `main` behavior if metadata is not available / there is no match for it
3. https://github.com/BoltzExchange/boltz-web-app/pull/1549 final step: claim / refund the original asset via the external rescue flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added restored EVM swap metadata hydration for external rescue, including richer claim/timeout and optional preimage details.
  * Enhanced external rescue results to render correct single-asset vs input→final asset pairs using restored-swap context.
  * Improved rescue search and scan flows to merge/enrich restored EVM results for refund and claim cases.
* **Bug Fixes**
  * Improved restored EVM result matching, deduplication, and UI wiring for correct refund/bridge/dex targeting.
  * Bridge refund destination resolution now prefers an explicit refund address when available.
* **Tests**
  * Expanded coverage for restored EVM scan helpers, result rendering, and deduplication/enrichment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->