### PR TITLE
feat: add unix timestamp to rescue file name

### DIFF
--- a/src/utils/backup.ts
+++ b/src/utils/backup.ts
@@ -3,7 +3,10 @@ import type { Accessor } from "solid-js";
 import { downloadJson } from "./download";
 import type { RescueFile } from "./rescueFile";
 
-export const rescueFileName = "boltz-rescue-key-DO-NOT-DELETE";
+const rescueFileNamePrefix = "boltz-rescue-key-DO-NOT-DELETE";
+
+export const getRescueFileName = (date = new Date()) =>
+    `${rescueFileNamePrefix}-${Math.floor(date.getTime() / 1000)}`;
 
 export const downloadRescueFile = (rescueFile: Accessor<RescueFile | null>) => {
     const currentRescueFile = rescueFile();
@@ -11,5 +14,5 @@ export const downloadRescueFile = (rescueFile: Accessor<RescueFile | null>) => {
         throw new Error("rescue file unavailable");
     }
 
-    downloadJson(rescueFileName, currentRescueFile);
+    downloadJson(getRescueFileName(), currentRescueFile);
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backup downloads now use date-based filenames (timestamped) instead of a fixed name, making it easier to identify and manage multiple backup versions.
* **Behavior**
  * Download behavior and error handling remain unchanged; backups still validate presence before downloading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->