### PR TITLE
fix: stranded funds from dex quote shortfall

### DIFF
--- a/src/components/RefundButton.tsx
+++ b/src/components/RefundButton.tsx
@@ -58,7 +58,12 @@ import {
 import { type AlchemyCall, toAlchemyCall } from "../alchemy/Alchemy";
 import RefundEta from "../components/RefundEta";
 import { config } from "../config";
-import { type AssetType, getKindForAsset, isEvmAsset } from "../consts/Assets";
+import {
+    type AssetType,
+    getKindForAsset,
+    getTokenAddress,
+    isEvmAsset,
+} from "../consts/Assets";
 import { type deriveKeyFn, useGlobalContext } from "../context/Global";
 import { usePayContext } from "../context/Pay";
 import { type Signer, useWeb3Signer } from "../context/Web3";
@@ -126,6 +131,197 @@ export const sendRefundTransaction = async (
     return transactionHash;
 };
 
+const resolveBridgeSender = async (bridge: BridgeDetail): Promise<string> => {
+    if (bridge.txHash === undefined) {
+        throw new Error(
+            "missing bridge transaction hash for pre-bridge refund",
+        );
+    }
+
+    const forwardDriver = bridgeRegistry.requireDriverForRoute(bridge);
+    const sender = await forwardDriver.getTransactionSender(
+        bridge.sourceAsset,
+        bridge.txHash,
+    );
+    if (sender === undefined) {
+        throw new Error(
+            `could not resolve original sender from bridge transaction: ${bridge.txHash}`,
+        );
+    }
+
+    return sender;
+};
+
+const buildReverseBridgeCalls = async ({
+    transactionSigner,
+    bridge,
+    recipient,
+    sourceToken,
+    amount,
+    quoteChain,
+    refundAddress,
+    slippage,
+    trade,
+}: {
+    transactionSigner: Signer;
+    bridge: BridgeDetail;
+    recipient: string;
+    sourceToken: string;
+    amount: bigint;
+    quoteChain: string;
+    refundAddress: string;
+    slippage: number;
+    trade?: { desiredToken: string };
+}): Promise<AlchemyCall[]> => {
+    const route = {
+        sourceAsset: bridge.destinationAsset,
+        destinationAsset: bridge.sourceAsset,
+    };
+    const driver = bridgeRegistry.requireDriverForRoute(route);
+    const router = createRouterContract(route.sourceAsset, transactionSigner);
+    const [bridgeContract, quotedBridge] = await Promise.all([
+        driver.getContract(route),
+        driver.getQuotedContract(route),
+    ]);
+
+    const fetchTradeQuote = async (amountIn: bigint, toToken: string) => {
+        const [quote] = await quoteDexAmountIn(
+            quoteChain,
+            sourceToken,
+            toToken,
+            amountIn,
+        );
+        if (quote === undefined) {
+            throw new Error("could not get DEX quote for refund");
+        }
+        return quote;
+    };
+
+    const feeQuoteAmount =
+        trade === undefined
+            ? amount
+            : BigInt((await fetchTradeQuote(amount, trade.desiredToken)).quote);
+    const { msgFee } = await driver.quoteSend(
+        quotedBridge,
+        route,
+        recipient,
+        feeQuoteAmount,
+    );
+
+    let postFeeAmount = amount;
+    let msgFeeCalls: AlchemyCall[] = [];
+    if (msgFee[0] > 0n) {
+        const msgFeeAmountOut = calculateAmountWithSlippage(
+            msgFee[0],
+            slippage,
+        );
+        const [msgFeeQuote] = await quoteDexAmountOut(
+            quoteChain,
+            sourceToken,
+            zeroAddress,
+            msgFeeAmountOut,
+        );
+        if (msgFeeQuote === undefined) {
+            throw new Error("could not get DEX quote for bridge messaging fee");
+        }
+
+        postFeeAmount -= BigInt(msgFeeQuote.quote);
+        if (postFeeAmount <= 0n) {
+            throw new Error("amount too small to cover bridge messaging fee");
+        }
+
+        const msgFeeCalldata = await encodeDexQuote(
+            quoteChain,
+            router.address,
+            BigInt(msgFeeQuote.quote),
+            msgFee[0],
+            msgFeeQuote.data,
+        );
+        msgFeeCalls = msgFeeCalldata.calls.map((call) => ({
+            to: call.to,
+            value: call.value,
+            data: call.data,
+        }));
+    }
+
+    let approvalAmount = postFeeAmount;
+    let bridgeAmount = postFeeAmount;
+    let tradeCalls: AlchemyCall[] = [];
+    if (trade !== undefined) {
+        const tradeQuote = await fetchTradeQuote(
+            postFeeAmount,
+            trade.desiredToken,
+        );
+        approvalAmount = BigInt(tradeQuote.quote);
+        bridgeAmount = calculateAmountOutMin(approvalAmount, slippage);
+        const tradeCalldata = await encodeDexQuote(
+            quoteChain,
+            router.address,
+            postFeeAmount,
+            bridgeAmount,
+            tradeQuote.data,
+        );
+        tradeCalls = tradeCalldata.calls.map((call) => ({
+            to: call.to,
+            value: call.value,
+            data: call.data,
+        }));
+    }
+
+    const routerCalls = [...tradeCalls, ...msgFeeCalls].map((call) => ({
+        target: call.to,
+        value: call.value ?? "0",
+        callData: prefix0x(call.data ?? "0x"),
+    }));
+
+    const approvalCall = await driver.buildApprovalCall(
+        route,
+        router.address,
+        approvalAmount,
+        transactionSigner,
+    );
+    if (approvalCall !== undefined) {
+        routerCalls.push({
+            target: approvalCall.to,
+            value: approvalCall.value ?? "0",
+            callData: prefix0x(approvalCall.data ?? "0x"),
+        });
+    }
+
+    const { sendParam, minAmount } = await driver.quoteSend(
+        quotedBridge,
+        route,
+        recipient,
+        bridgeAmount,
+    );
+    const minAmountLd = calculateAmountOutMin(minAmount, slippage);
+    const executeBridgeData = driver.encodeRouterExecuteData({
+        router,
+        route,
+        bridgeContract,
+        routerCalls,
+        sendParam,
+        minAmountLd,
+        lzTokenFee: msgFee[1],
+        refundAddress,
+    });
+
+    return [
+        {
+            to: getAddress(sourceToken),
+            data: encodeFunctionData({
+                abi: erc20Abi,
+                functionName: "transfer",
+                args: [getAddress(router.address), amount],
+            }),
+        },
+        {
+            to: router.address,
+            data: executeBridgeData,
+        },
+    ];
+};
+
 const buildRefundFollowUpCalls = async (
     transactionSigner: Signer,
     refundData: LockupEvent,
@@ -138,12 +334,6 @@ const buildRefundFollowUpCalls = async (
     const isPreBridge = bridge?.position === SwapPosition.Pre;
 
     if (isPreBridge) {
-        if (bridge.txHash === undefined) {
-            throw new Error(
-                "missing bridge transaction hash for pre-bridge refund",
-            );
-        }
-
         if (
             dexDetails === undefined ||
             dexDetails.position !== SwapPosition.Pre
@@ -153,18 +343,7 @@ const buildRefundFollowUpCalls = async (
             );
         }
 
-        const bridgeDriver = bridgeRegistry.requireDriverForRoute(bridge);
-        const sender = await bridgeDriver.getTransactionSender(
-            bridge.sourceAsset,
-            bridge.txHash,
-        );
-        if (sender === undefined) {
-            throw new Error(
-                `could not resolve original sender from bridge transaction: ${bridge.txHash}`,
-            );
-        }
-
-        resolvedDestination = sender;
+        resolvedDestination = await resolveBridgeSender(bridge);
     }
 
     if (dexDetails === undefined || dexDetails.position !== SwapPosition.Pre) {
@@ -184,37 +363,30 @@ const buildRefundFollowUpCalls = async (
     if (refundData.tokenAddress === undefined) {
         throw new Error("missing token address for refund");
     }
-    const [quote] = await quoteDexAmountIn(
-        quoteChain,
-        refundData.tokenAddress,
-        desiredToken,
-        refundData.amount,
-    );
-    if (quote === undefined) {
-        throw new Error("could not get DEX quote for refund");
-    }
-
-    const quoteAmount = BigInt(quote.quote);
-    const amountOutMin = calculateAmountOutMin(quoteAmount, slippage);
-    const dexRecipient = isPreBridge
-        ? refundData.refundAddress
-        : resolvedDestination;
-
-    log.debug(
-        isPreBridge
-            ? `Refunding via DEX and bridge to ${resolvedDestination}`
-            : `Refunding via DEX to ${desiredToken}`,
-    );
 
     if (!isPreBridge) {
+        const [quote] = await quoteDexAmountIn(
+            quoteChain,
+            refundData.tokenAddress,
+            desiredToken,
+            refundData.amount,
+        );
+        if (quote === undefined) {
+            throw new Error("could not get DEX quote for refund");
+        }
+        const amountOutMin = calculateAmountOutMin(
+            BigInt(quote.quote),
+            slippage,
+        );
+
+        log.debug(`Refunding via DEX to ${desiredToken}`);
         const calldata = await encodeDexQuote(
             quoteChain,
-            dexRecipient,
+            resolvedDestination,
             refundData.amount,
             amountOutMin,
             quote.data,
         );
-
         return calldata.calls.map((call) => ({
             to: call.to,
             value: call.value,
@@ -222,142 +394,54 @@ const buildRefundFollowUpCalls = async (
         }));
     }
 
-    const reverseBridgeRoute = {
-        sourceAsset: bridge.destinationAsset,
-        destinationAsset: bridge.sourceAsset,
-    };
-    const bridgeDriver =
-        bridgeRegistry.requireDriverForRoute(reverseBridgeRoute);
-    const router = createRouterContract(
-        reverseBridgeRoute.sourceAsset,
+    log.debug(`Refunding via DEX and bridge to ${resolvedDestination}`);
+    return buildReverseBridgeCalls({
         transactionSigner,
-    );
-    const [bridgeContract, quotedBridge] = await Promise.all([
-        bridgeDriver.getContract(reverseBridgeRoute),
-        bridgeDriver.getQuotedContract(reverseBridgeRoute),
-    ]);
-    const { msgFee } = await bridgeDriver.quoteSend(
-        quotedBridge,
-        reverseBridgeRoute,
-        resolvedDestination,
-        quoteAmount,
-    );
-
-    let tradeAmountIn = refundData.amount;
-    let msgFeeCalls: AlchemyCall[] = [];
-    if (msgFee[0] > 0n) {
-        const msgFeeAmountOut = calculateAmountWithSlippage(
-            msgFee[0],
-            slippage,
-        );
-        const [msgFeeQuote] = await quoteDexAmountOut(
-            quoteChain,
-            refundData.tokenAddress,
-            zeroAddress,
-            msgFeeAmountOut,
-        );
-        if (msgFeeQuote === undefined) {
-            throw new Error("could not get DEX quote for bridge messaging fee");
-        }
-
-        const msgFeeAmountIn = BigInt(msgFeeQuote.quote);
-        tradeAmountIn -= msgFeeAmountIn;
-        if (tradeAmountIn <= 0n) {
-            throw new Error("amount too small to cover bridge messaging fee");
-        }
-
-        const msgFeeCalldata = await encodeDexQuote(
-            quoteChain,
-            router.address,
-            msgFeeAmountIn,
-            msgFee[0],
-            msgFeeQuote.data,
-        );
-        msgFeeCalls = msgFeeCalldata.calls.map((call) => ({
-            to: call.to,
-            value: call.value,
-            data: call.data,
-        }));
-    }
-
-    const [tradeQuote] = await quoteDexAmountIn(
+        bridge,
+        recipient: resolvedDestination,
+        sourceToken: refundData.tokenAddress,
+        amount: refundData.amount,
         quoteChain,
-        refundData.tokenAddress,
-        desiredToken,
-        tradeAmountIn,
-    );
-    if (tradeQuote === undefined) {
-        throw new Error("could not get DEX quote for refund");
-    }
-
-    const tradeAmountOutMin = calculateAmountOutMin(
-        BigInt(tradeQuote.quote),
-        slippage,
-    );
-    const tradeCalldata = await encodeDexQuote(
-        quoteChain,
-        router.address,
-        tradeAmountIn,
-        tradeAmountOutMin,
-        tradeQuote.data,
-    );
-    const tradeCalls: AlchemyCall[] = tradeCalldata.calls.map((call) => ({
-        to: call.to,
-        value: call.value,
-        data: call.data,
-    }));
-    const routerCalls = [...tradeCalls, ...msgFeeCalls].map((call) => ({
-        target: call.to,
-        value: call.value ?? "0",
-        callData: prefix0x(call.data ?? "0x"),
-    }));
-
-    const approvalCall = await bridgeDriver.buildApprovalCall(
-        reverseBridgeRoute,
-        router.address,
-        BigInt(tradeQuote.quote),
-        transactionSigner,
-    );
-    if (approvalCall !== undefined) {
-        routerCalls.push({
-            target: approvalCall.to,
-            value: approvalCall.value ?? "0",
-            callData: prefix0x(approvalCall.data ?? "0x"),
-        });
-    }
-
-    const { sendParam, minAmount } = await bridgeDriver.quoteSend(
-        quotedBridge,
-        reverseBridgeRoute,
-        resolvedDestination,
-        tradeAmountOutMin,
-    );
-    const minAmountLd = calculateAmountOutMin(minAmount, slippage);
-    const executeBridgeData = bridgeDriver.encodeRouterExecuteData({
-        router,
-        route: reverseBridgeRoute,
-        bridgeContract,
-        routerCalls,
-        sendParam,
-        minAmountLd,
-        lzTokenFee: msgFee[1],
         refundAddress: refundData.refundAddress,
+        slippage,
+        trade: { desiredToken },
     });
+};
 
-    return [
-        {
-            to: refundData.tokenAddress,
-            data: encodeFunctionData({
-                abi: erc20Abi,
-                functionName: "transfer",
-                args: [getAddress(router.address), refundData.amount],
-            }),
-        },
-        {
-            to: router.address,
-            data: executeBridgeData,
-        },
-    ];
+export const buildPreBridgeReverseBridgeRefundCalls = async ({
+    transactionSigner,
+    asset,
+    amount,
+    slippage,
+    dexDetails,
+    bridge,
+}: {
+    transactionSigner: Signer;
+    asset: string;
+    amount: bigint;
+    slippage: number;
+    dexDetails: DexDetail;
+    bridge: BridgeDetail;
+}): Promise<AlchemyCall[]> => {
+    if (bridge.position !== SwapPosition.Pre) {
+        throw new Error("reverse-bridge refund requires a pre-bridge route");
+    }
+
+    const hopDexDetails = dexDetails.hops[0]?.dexDetails;
+    if (hopDexDetails === undefined) {
+        throw new Error("missing DEX details for pre-bridge refund");
+    }
+
+    return buildReverseBridgeCalls({
+        transactionSigner,
+        bridge,
+        recipient: await resolveBridgeSender(bridge),
+        sourceToken: getAddress(getTokenAddress(asset)),
+        amount,
+        quoteChain: hopDexDetails.chain,
+        refundAddress: getAddress(transactionSigner.address),
+        slippage,
+    });
 };
 
 const buildErc20RefundTransaction = async ({

--- a/src/components/RefundButton.tsx
+++ b/src/components/RefundButton.tsx
@@ -58,12 +58,7 @@ import {
 import { type AlchemyCall, toAlchemyCall } from "../alchemy/Alchemy";
 import RefundEta from "../components/RefundEta";
 import { config } from "../config";
-import {
-    type AssetType,
-    getKindForAsset,
-    getTokenAddress,
-    isEvmAsset,
-} from "../consts/Assets";
+import { type AssetType, getKindForAsset, isEvmAsset } from "../consts/Assets";
 import { type deriveKeyFn, useGlobalContext } from "../context/Global";
 import { usePayContext } from "../context/Pay";
 import { type Signer, useWeb3Signer } from "../context/Web3";
@@ -131,7 +126,9 @@ export const sendRefundTransaction = async (
     return transactionHash;
 };
 
-const resolveBridgeSender = async (bridge: BridgeDetail): Promise<string> => {
+export const resolveBridgeSender = async (
+    bridge: BridgeDetail,
+): Promise<string> => {
     if (bridge.txHash === undefined) {
         throw new Error(
             "missing bridge transaction hash for pre-bridge refund",
@@ -152,7 +149,7 @@ const resolveBridgeSender = async (bridge: BridgeDetail): Promise<string> => {
     return sender;
 };
 
-const buildReverseBridgeCalls = async ({
+export const buildReverseBridgeCalls = async ({
     transactionSigner,
     bridge,
     recipient,
@@ -405,42 +402,6 @@ const buildRefundFollowUpCalls = async (
         refundAddress: refundData.refundAddress,
         slippage,
         trade: { desiredToken },
-    });
-};
-
-export const buildPreBridgeReverseBridgeRefundCalls = async ({
-    transactionSigner,
-    asset,
-    amount,
-    slippage,
-    dexDetails,
-    bridge,
-}: {
-    transactionSigner: Signer;
-    asset: string;
-    amount: bigint;
-    slippage: number;
-    dexDetails: DexDetail;
-    bridge: BridgeDetail;
-}): Promise<AlchemyCall[]> => {
-    if (bridge.position !== SwapPosition.Pre) {
-        throw new Error("reverse-bridge refund requires a pre-bridge route");
-    }
-
-    const hopDexDetails = dexDetails.hops[0]?.dexDetails;
-    if (hopDexDetails === undefined) {
-        throw new Error("missing DEX details for pre-bridge refund");
-    }
-
-    return buildReverseBridgeCalls({
-        transactionSigner,
-        bridge,
-        recipient: await resolveBridgeSender(bridge),
-        sourceToken: getAddress(getTokenAddress(asset)),
-        amount,
-        quoteChain: hopDexDetails.chain,
-        refundAddress: getAddress(transactionSigner.address),
-        slippage,
     });
 };
 

--- a/src/components/SwapExecutionWorker.tsx
+++ b/src/components/SwapExecutionWorker.tsx
@@ -306,24 +306,30 @@ export const SwapExecutionWorker = () => {
         await persistSwap(latestSwap);
     };
 
-    // The backend can only renegotiate a chain swap whose locked amount still
-    // clears the pair minimum. When even the slippage-protected DEX output
-    // would fall below it, locking is pointless (renegotiation would be
-    // rejected), so the swap should block for a refund instead.
-    const preBridgeLockupClearsRenegotiationMinimum = async (
-        swap: ChainSwap,
-        lockupAmount: bigint,
+    // A pre-bridge quote below the slippage threshold can still be locked when
+    // the backend is able to renegotiate the shortfall. That is only possible
+    // for chain swaps whose lockup amount still clears the pair minimum;
+    // otherwise locking is pointless and the swap should block for a refund.
+    const shouldLockBelowThresholdQuote = async (
+        swap: SomeSwap,
+        quoteAmountOut: bigint,
     ): Promise<boolean> => {
-        await fetchPairs();
-        const minimal =
-            pairs()?.[SwapType.Chain]?.[swap.assetSend]?.[swap.assetReceive]
-                ?.limits.minimal;
-        if (minimal === undefined) {
-            return true;
+        if (swap.type !== SwapType.Chain) {
+            return false;
         }
 
+        const chainSwap = swap as ChainSwap;
+        const lockupAmount = calculateAmountOutMin(quoteAmountOut, slippage());
+        await fetchPairs();
+        const minimal =
+            pairs()?.[SwapType.Chain]?.[chainSwap.assetSend]?.[
+                chainSwap.assetReceive
+            ]?.limits.minimal;
+
         return (
-            assetAmountToSats(lockupAmount, swap.assetSend) >= BigInt(minimal)
+            minimal === undefined ||
+            assetAmountToSats(lockupAmount, chainSwap.assetSend) >=
+                BigInt(minimal)
         );
     };
 
@@ -383,19 +389,10 @@ export const SwapExecutionWorker = () => {
             });
 
             // Retrying only helps if the quote recovers above the slippage
-            // threshold. When the lockup already clears the chain swap
-            // renegotiation minimum, the backend can renegotiate the shortfall,
-            // so lock immediately instead of burning the remaining attempts.
-            const lockupAmount = calculateAmountOutMin(
-                quote.trade.amountOut,
-                slippage(),
-            );
+            // threshold. If locking the shortfall is still viable, do it now
+            // instead of burning the remaining attempts.
             if (
-                swap.type === SwapType.Chain &&
-                (await preBridgeLockupClearsRenegotiationMinimum(
-                    swap as ChainSwap,
-                    lockupAmount,
-                ))
+                await shouldLockBelowThresholdQuote(swap, quote.trade.amountOut)
             ) {
                 log.info(
                     "Swap execution locking pre-bridge quote below threshold; lockup clears renegotiation minimum",

--- a/src/components/SwapExecutionWorker.tsx
+++ b/src/components/SwapExecutionWorker.tsx
@@ -13,6 +13,7 @@ import {
 } from "boltz-swaps/cctp";
 import { encodeDexQuote, getCommitmentLockupDetails } from "boltz-swaps/client";
 import {
+    assetAmountToSats,
     createAssetProvider,
     prefix0x,
     satsToAssetAmount,
@@ -68,12 +69,13 @@ import { calculateAmountOutMin } from "../utils/calculate";
 import { formatAssetAmountForLog } from "../utils/denomination";
 import { sendPopulatedTransaction } from "../utils/evmTransaction";
 import { decodeInvoice } from "../utils/invoice";
-import { fetchDexQuote } from "../utils/quoter";
+import { type ClaimQuote, fetchDexQuote } from "../utils/quoter";
 import {
     type BridgeDetail,
     type ChainSwap,
     type DexDetail,
     GasAbstractionType,
+    PreBridgeRecoveryStatus,
     type SomeSwap,
     type SubmarineSwap,
     getLockupGasAbstraction,
@@ -81,6 +83,8 @@ import {
 
 const retryIntervalMs = 1_000;
 const taskRetryIntervalMs = 3_000;
+const preBridgeDexQuoteAttempts = 3;
+const preBridgeDexQuoteRetryDelayMs = 5_000;
 
 const sleep = (ms: number) =>
     new Promise((resolve) => window.setTimeout(resolve, ms));
@@ -142,6 +146,9 @@ const needsPreBridgeLockup = (
     swap.bridge?.position === SwapPosition.Pre &&
     swap.bridge.txHash !== undefined &&
     swap.commitmentLockupTxHash === undefined &&
+    (swap.execution?.preBridgeRecovery === undefined ||
+        swap.execution.preBridgeRecovery.status ===
+            PreBridgeRecoveryStatus.Retrying) &&
     isPendingCommitmentStatus(swap.status) &&
     swap.dex !== undefined &&
     swap.dex.position === SwapPosition.Pre &&
@@ -212,7 +219,8 @@ const isTaskRelevant = (
 };
 
 export const SwapExecutionWorker = () => {
-    const { getSwap, getSwaps, setSwapStorage, slippage } = useGlobalContext();
+    const { getSwap, getSwaps, setSwapStorage, slippage, pairs, fetchPairs } =
+        useGlobalContext();
     const { swap, setSwap } = usePayContext();
     const { getErc20Swap, getGasAbstractionSigner, signer } = useWeb3Signer();
 
@@ -249,6 +257,163 @@ export const SwapExecutionWorker = () => {
         );
         queueRelevantTasks(latestSwap);
         return true;
+    };
+
+    const persistPreBridgeDexQuoteBlock = async ({
+        latestSwap,
+        receivedAmount,
+        receiveCall,
+    }: {
+        latestSwap: SomeSwap & {
+            bridge: BridgeDetail & { txHash: string };
+            dex: DexDetail;
+        };
+        receivedAmount: bigint;
+        receiveCall?: AlchemyCall;
+    }) => {
+        log.warn(
+            "Pre-bridge lockup blocked: DEX quote below required amount, " +
+                "awaiting user recovery decision",
+            getSwapExecutionLogContext(latestSwap.id, {
+                asset: latestSwap.bridge.destinationAsset,
+                amount: receivedAmount.toString(),
+            }),
+        );
+        latestSwap.execution = {
+            ...latestSwap.execution,
+            preBridgeRecovery: {
+                status: PreBridgeRecoveryStatus.Blocked,
+                asset: latestSwap.bridge.destinationAsset,
+                amount: receivedAmount.toString(),
+                receiveCall,
+            },
+        };
+        await persistSwap(latestSwap);
+    };
+
+    const clearPreBridgeRecovery = async (latestSwap: SomeSwap) => {
+        if (latestSwap.execution?.preBridgeRecovery === undefined) {
+            return;
+        }
+
+        log.info(
+            "Pre-bridge recovery cleared, proceeding with lockup",
+            getSwapExecutionLogContext(latestSwap.id, {
+                status: latestSwap.execution.preBridgeRecovery.status,
+            }),
+        );
+        latestSwap.execution = undefined;
+        await persistSwap(latestSwap);
+    };
+
+    // The backend can only renegotiate a chain swap whose locked amount still
+    // clears the pair minimum. When even the slippage-protected DEX output
+    // would fall below it, locking is pointless (renegotiation would be
+    // rejected), so the swap should block for a refund instead.
+    const preBridgeLockupClearsRenegotiationMinimum = async (
+        swap: ChainSwap,
+        lockupAmount: bigint,
+    ): Promise<boolean> => {
+        await fetchPairs();
+        const minimal =
+            pairs()?.[SwapType.Chain]?.[swap.assetSend]?.[swap.assetReceive]
+                ?.limits.minimal;
+        if (minimal === undefined) {
+            return true;
+        }
+
+        return (
+            assetAmountToSats(lockupAmount, swap.assetSend) >= BigInt(minimal)
+        );
+    };
+
+    const fetchPreBridgeDexQuote = async ({
+        swap,
+        swapId,
+        guid,
+        hop,
+        receivedAmount,
+        expectedAmount,
+        receivedAsset,
+        requiredAsset,
+    }: {
+        swap: SomeSwap;
+        swapId: string;
+        guid: string;
+        hop: NonNullable<DexDetail["hops"][number]["dexDetails"]>;
+        receivedAmount: bigint;
+        expectedAmount: bigint;
+        receivedAsset: string;
+        requiredAsset: string;
+    }): Promise<{ quote: ClaimQuote; shouldLock: boolean }> => {
+        let lastQuote: ClaimQuote | undefined;
+        const requiredAmount = calculateAmountOutMin(
+            expectedAmount,
+            slippage(),
+        );
+        for (let attempt = 1; attempt <= preBridgeDexQuoteAttempts; attempt++) {
+            const quote = await fetchDexQuote(hop, receivedAmount);
+            lastQuote = quote;
+
+            const logContext = getSwapExecutionLogContext(swapId, {
+                guid,
+                attempt,
+                attempts: preBridgeDexQuoteAttempts,
+                receivedAsset,
+                amountReceived: receivedAmount.toString(),
+                requiredAsset,
+                amountExpected: expectedAmount.toString(),
+                amountRequired: requiredAmount.toString(),
+                quotedAmountOut: quote.trade.amountOut.toString(),
+                slippage: slippage(),
+            });
+
+            log.debug(
+                "Swap execution fetched pre-bridge DEX quote",
+                logContext,
+            );
+
+            if (quote.trade.amountOut >= requiredAmount) {
+                return { quote, shouldLock: true };
+            }
+
+            log.warn("Pre-bridge DEX quote is below slippage threshold", {
+                ...logContext,
+                deficit: (requiredAmount - quote.trade.amountOut).toString(),
+            });
+
+            // Retrying only helps if the quote recovers above the slippage
+            // threshold. When the lockup already clears the chain swap
+            // renegotiation minimum, the backend can renegotiate the shortfall,
+            // so lock immediately instead of burning the remaining attempts.
+            const lockupAmount = calculateAmountOutMin(
+                quote.trade.amountOut,
+                slippage(),
+            );
+            if (
+                swap.type === SwapType.Chain &&
+                (await preBridgeLockupClearsRenegotiationMinimum(
+                    swap as ChainSwap,
+                    lockupAmount,
+                ))
+            ) {
+                log.info(
+                    "Swap execution locking pre-bridge quote below threshold; lockup clears renegotiation minimum",
+                    logContext,
+                );
+                return { quote, shouldLock: true };
+            }
+
+            if (attempt < preBridgeDexQuoteAttempts) {
+                await sleep(preBridgeDexQuoteRetryDelayMs);
+            }
+        }
+
+        if (lastQuote === undefined) {
+            throw new Error("failed to fetch pre-bridge DEX quote");
+        }
+
+        return { quote: lastQuote, shouldLock: false };
     };
 
     const recoverPreBridgeCommitmentLockup = async (
@@ -1007,42 +1172,27 @@ export const SwapExecutionWorker = () => {
             latestSwap.sendAmount,
             latestSwap.assetSend,
         );
-        const quote = await fetchDexQuote(hop.dexDetails, receivedAmount);
+        const { quote, shouldLock } = await fetchPreBridgeDexQuote({
+            swap: latestSwap,
+            swapId: latestSwap.id,
+            guid,
+            hop: hop.dexDetails,
+            receivedAmount,
+            expectedAmount,
+            receivedAsset: latestSwap.bridge.destinationAsset,
+            requiredAsset: latestSwap.assetSend,
+        });
 
-        log.debug(
-            "Swap execution fetched pre-bridge DEX quote",
-            getSwapExecutionLogContext(latestSwap.id, {
-                guid,
-                amountReceived: formatAssetAmountForLog(
-                    receivedAmount,
-                    latestSwap.bridge.destinationAsset,
-                ),
-                amountExpected: formatAssetAmountForLog(
-                    expectedAmount,
-                    latestSwap.assetSend,
-                ),
-                quotedAmountOut: formatAssetAmountForLog(
-                    quote.trade.amountOut,
-                    latestSwap.assetSend,
-                ),
-            }),
-        );
-
-        if (quote.trade.amountOut < expectedAmount) {
-            log.warn("Bridge received amount is less than expected", {
-                swapId: latestSwap.id,
-                guid,
-                amountReceived: formatAssetAmountForLog(
-                    receivedAmount,
-                    latestSwap.bridge.destinationAsset,
-                ),
-                amountExpected: formatAssetAmountForLog(
-                    expectedAmount,
-                    latestSwap.assetSend,
-                ),
+        if (!shouldLock) {
+            await persistPreBridgeDexQuoteBlock({
+                latestSwap,
+                receivedAmount,
+                receiveCall: manualCctpReceive?.receiveCall,
             });
             return;
         }
+
+        await clearPreBridgeRecovery(latestSwap);
 
         const router = createRouterContract(
             latestSwap.assetSend,

--- a/src/components/SwapExecutionWorker.tsx
+++ b/src/components/SwapExecutionWorker.tsx
@@ -146,9 +146,8 @@ const needsPreBridgeLockup = (
     swap.bridge?.position === SwapPosition.Pre &&
     swap.bridge.txHash !== undefined &&
     swap.commitmentLockupTxHash === undefined &&
-    (swap.execution?.preBridgeRecovery === undefined ||
-        swap.execution.preBridgeRecovery.status ===
-            PreBridgeRecoveryStatus.Retrying) &&
+    (swap.bridge.recovery === undefined ||
+        swap.bridge.recovery.status === PreBridgeRecoveryStatus.Retrying) &&
     isPendingCommitmentStatus(swap.status) &&
     swap.dex !== undefined &&
     swap.dex.position === SwapPosition.Pre &&
@@ -279,30 +278,27 @@ export const SwapExecutionWorker = () => {
                 amount: receivedAmount.toString(),
             }),
         );
-        latestSwap.execution = {
-            ...latestSwap.execution,
-            preBridgeRecovery: {
-                status: PreBridgeRecoveryStatus.Blocked,
-                asset: latestSwap.bridge.destinationAsset,
-                amount: receivedAmount.toString(),
-                receiveCall,
-            },
+        latestSwap.bridge.recovery = {
+            status: PreBridgeRecoveryStatus.Blocked,
+            asset: latestSwap.bridge.destinationAsset,
+            amount: receivedAmount.toString(),
+            receiveCall,
         };
         await persistSwap(latestSwap);
     };
 
     const clearPreBridgeRecovery = async (latestSwap: SomeSwap) => {
-        if (latestSwap.execution?.preBridgeRecovery === undefined) {
+        if (latestSwap.bridge?.recovery === undefined) {
             return;
         }
 
         log.info(
             "Pre-bridge recovery cleared, proceeding with lockup",
             getSwapExecutionLogContext(latestSwap.id, {
-                status: latestSwap.execution.preBridgeRecovery.status,
+                status: latestSwap.bridge.recovery.status,
             }),
         );
-        latestSwap.execution = undefined;
+        latestSwap.bridge.recovery = undefined;
         await persistSwap(latestSwap);
     };
 

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -142,6 +142,8 @@ const dict = {
         tx_confirmed: "Transaction confirmed",
         tx_ready_to_claim: "Claiming transaction now...",
         refunded: "Swap has been refunded successfully!",
+        refunded_bridge_pending:
+            "Swap has been refunded. Your {{ denomination }} is being bridged back to {{ network }} and may take some time to arrive.",
         locktime_not_satisfied: "Locktime requirement not satisfied",
         already_refunded: "Swap already refunded",
         api_offline: "API is offline",
@@ -236,6 +238,14 @@ const dict = {
         oft_transfer_in_progress: "Transfer in progress",
         waiting_for_bridge: "Waiting for {{ symbol }} bridge",
         dex_quote_changed: "DEX quote has changed",
+        pre_bridge_dex_quote_blocked: "Quote has changed",
+        pre_bridge_dex_quote_blocked_line:
+            "Prices changed while your funds were bridging, so the quote is no longer enough to complete the swap. Please try again or refund your funds.",
+        recovering_bridged_funds: "Refunding...",
+        pre_bridge_refund_initiated:
+            "Your funds are being bridged back to your original address and will arrive shortly.",
+        retry_quote: "Retry",
+        retrying_quote: "Checking quote...",
         zero_conf: "Zero-Conf",
         zero_conf_tooltip:
             "Accept transactions that are not yet confirmed in a block",
@@ -667,6 +677,8 @@ const dict = {
         tx_confirmed: "Transaktion bestätigt!",
         tx_ready_to_claim: "Claime die Transaktion jetzt...",
         refunded: "Swap wurde erfolgreich erstattet!",
+        refunded_bridge_pending:
+            "Swap wurde erstattet. Dein {{ denomination }} wird zurück nach {{ network }} gebridged und kann einige Zeit dauern.",
         locktime_not_satisfied: "Locktime-Anforderung nicht erfüllt.",
         already_refunded: "Swap wurde bereits erstattet!",
         api_offline: "API ist offline",
@@ -765,6 +777,14 @@ const dict = {
         oft_transfer_in_progress: "Übertragung läuft",
         waiting_for_bridge: "Warte auf {{ symbol }}-Bridge",
         dex_quote_changed: "DEX-Kurs hat sich geändert",
+        pre_bridge_dex_quote_blocked: "Der Kurs hat sich geändert",
+        pre_bridge_dex_quote_blocked_line:
+            "Die Preise haben sich während der Bridge-Übertragung geändert, daher reicht der Kurs nicht mehr aus, um den Swap abzuschließen. Bitte versuche es erneut oder lass dir dein Guthaben erstatten.",
+        recovering_bridged_funds: "Rückerstattung läuft...",
+        pre_bridge_refund_initiated:
+            "Deine Gelder werden über die Bridge an deine ursprüngliche Adresse zurückgesendet und treffen in Kürze ein.",
+        retry_quote: "Erneut versuchen",
+        retrying_quote: "Angebot wird geprüft...",
         zero_conf: "Zero-Conf",
         zero_conf_tooltip:
             "Akzeptiere Transaktionen, die noch nicht in einem Block bestätigt sind",
@@ -1207,6 +1227,8 @@ const dict = {
         tx_confirmed: "Transacción confirmada!",
         tx_ready_to_claim: "Reclamando la transacción ahora...",
         refunded: "El intercambio ha sido reembolsado!",
+        refunded_bridge_pending:
+            "El intercambio ha sido reembolsado. Tu {{ denomination }} se está puenteando de vuelta a {{ network }} y puede tardar algún tiempo en llegar.",
         locktime_not_satisfied:
             "No se cumple el requisito de tiempo de bloqueo!",
         already_refunded: "El intercambio ya ha sido reembolsado!",
@@ -1305,6 +1327,14 @@ const dict = {
         oft_transfer_in_progress: "Transferencia en curso",
         waiting_for_bridge: "Esperando el puente {{ symbol }}",
         dex_quote_changed: "La cotización de DEX ha cambiado",
+        pre_bridge_dex_quote_blocked: "La cotización ha cambiado",
+        pre_bridge_dex_quote_blocked_line:
+            "Los precios cambiaron mientras tus fondos se transferían por el puente, por lo que la cotización ya no es suficiente para completar el swap. Inténtalo de nuevo o reembolsa tus fondos.",
+        recovering_bridged_funds: "Reembolsando...",
+        pre_bridge_refund_initiated:
+            "Tus fondos se están enviando de vuelta a tu dirección original a través del puente y llegarán en breve.",
+        retry_quote: "Reintentar",
+        retrying_quote: "Comprobando cotización...",
         zero_conf: "Zero-Conf",
         zero_conf_tooltip:
             "Aceptar transacciones que aún no están confirmadas en un bloque",
@@ -1743,6 +1773,8 @@ const dict = {
         tx_confirmed: "Transação confirmada",
         tx_ready_to_claim: "Reivindicando transação agora...",
         refunded: "Troca reembolsada com sucesso!",
+        refunded_bridge_pending:
+            "Troca reembolsada. Seu {{ denomination }} está sendo enviado de volta pela ponte para {{ network }} e pode levar algum tempo para chegar.",
         locktime_not_satisfied: "O prazo de lockup não foi cumprido",
         already_refunded: "A troca já foi reembolsada",
         api_offline: "A API está offline",
@@ -1838,6 +1870,14 @@ const dict = {
         oft_transfer_in_progress: "Transferência em andamento",
         waiting_for_bridge: "Aguardando a ponte {{ symbol }}",
         dex_quote_changed: "A cotação da DEX mudou",
+        pre_bridge_dex_quote_blocked: "A cotação mudou",
+        pre_bridge_dex_quote_blocked_line:
+            "Os preços mudaram enquanto seus fundos eram transferidos pela ponte, então a cotação não é mais suficiente para completar o swap. Tente novamente ou reembolse seus fundos.",
+        recovering_bridged_funds: "Reembolsando...",
+        pre_bridge_refund_initiated:
+            "Os seus fundos estão a ser enviados de volta para o seu endereço original através da ponte e chegarão em breve.",
+        retry_quote: "Tentar novamente",
+        retrying_quote: "Verificando cotação...",
         zero_conf: "Zero-Conf",
         zero_conf_tooltip:
             "Aceitar transações que ainda não foram confirmadas num bloco",
@@ -2099,7 +2139,7 @@ const dict = {
         refund_scan_required:
             "Para reembolsar este saldo, volte e escaneie com o arquivo de resgate carregado.",
         refund_destination_hint:
-            "Os fundos serão reembolsados como {{ symbol }} no {{ network }} para sua carteira EVM conectada.",
+            "Os fundos serão reembolsados como {{ symbol }} via {{ network }} para sua carteira EVM conectada.",
         invalid_rescue_key_evm:
             "Esta chave de resgate não está associada a esta troca. Por favor, tente novamente usando uma chave de resgate diferente.",
         error_occurred: "Ocorreu um erro: {{ error }}",
@@ -2260,6 +2300,8 @@ const dict = {
         tx_confirmed: "交易已确认",
         tx_ready_to_claim: "现在要求交换……",
         refunded: "交换已退还",
+        refunded_bridge_pending:
+            "交换已退还。您的 {{ denomination }} 正在桥接回 {{ network }}，可能还需一些时间到账。",
         locktime_not_satisfied: "未满足锁定时间要求",
         already_refunded: "交换已经退还",
         api_offline: "API离线",
@@ -2346,6 +2388,14 @@ const dict = {
         oft_transfer_in_progress: "转账进行中",
         waiting_for_bridge: "等待 {{ symbol }} 桥接",
         dex_quote_changed: "DEX 报价已变更",
+        pre_bridge_dex_quote_blocked: "报价已变更",
+        pre_bridge_dex_quote_blocked_line:
+            "您的资金在桥接期间价格发生了变动，因此报价已不足以完成兑换。请重试，或退还您的资金。",
+        recovering_bridged_funds: "正在退款...",
+        pre_bridge_refund_initiated:
+            "您的资金正在通过跨链桥退回到您的原始地址，将很快到账。",
+        retry_quote: "重试",
+        retrying_quote: "正在检查报价...",
         zero_conf: "零确认",
         zero_conf_tooltip: "接受尚未被区块确认的交易",
         on: "开",
@@ -2753,6 +2803,8 @@ const dict = {
         tx_confirmed: "トランザクションが確認されました",
         tx_ready_to_claim: "トランザクションを実行中...",
         refunded: "このスワップを返金しました",
+        refunded_bridge_pending:
+            "スワップを返金しました。{{ denomination }} は {{ network }} へブリッジで返金中で、到着まで時間がかかる場合があります。",
         locktime_not_satisfied: "ロックタイムの条件を満たしていません",
         already_refunded: "スワップはすでに返金されています",
         api_offline: "APIがオフラインです",
@@ -2848,6 +2900,14 @@ const dict = {
         oft_transfer_in_progress: "転送中",
         waiting_for_bridge: "{{ symbol }}ブリッジを待機中",
         dex_quote_changed: "DEXのクオートが変更されました",
+        pre_bridge_dex_quote_blocked: "見積もりが変更されました",
+        pre_bridge_dex_quote_blocked_line:
+            "ブリッジ中に価格が変動したため、見積もりではスワップを完了できなくなりました。もう一度お試しいただくか、資金を返金してください。",
+        recovering_bridged_funds: "返金中...",
+        pre_bridge_refund_initiated:
+            "資金は元のアドレスへブリッジ経由で返金されており、まもなく着金します。",
+        retry_quote: "再試行",
+        retrying_quote: "クオートを確認しています...",
         zero_conf: "ゼロ確認",
         zero_conf_tooltip: "ブロック内でまだ確認されていない取引を受け入れる",
         on: "オン",

--- a/src/pages/Pay.tsx
+++ b/src/pages/Pay.tsx
@@ -568,8 +568,7 @@ const Pay = () => {
                                 <Switch>
                                     <Match
                                         when={
-                                            swap()?.execution
-                                                ?.preBridgeRecovery !==
+                                            swap()?.bridge?.recovery !==
                                             undefined
                                         }>
                                         <PreBridgeDexQuoteBlocked />
@@ -676,8 +675,7 @@ const Pay = () => {
                                 </Switch>
                                 <Show
                                     when={
-                                        swap()?.execution?.preBridgeRecovery
-                                            ?.status !==
+                                        swap()?.bridge?.recovery?.status !==
                                         PreBridgeRecoveryStatus.Recovered
                                     }>
                                     <BlockExplorerLink

--- a/src/pages/Pay.tsx
+++ b/src/pages/Pay.tsx
@@ -47,6 +47,7 @@ import InvoiceExpired from "../status/InvoiceExpired";
 import InvoiceFailedToPay from "../status/InvoiceFailedToPay";
 import InvoicePending from "../status/InvoicePending";
 import InvoiceSet from "../status/InvoiceSet";
+import PreBridgeDexQuoteBlocked from "../status/PreBridgeDexQuoteBlocked";
 import SwapCreated from "../status/SwapCreated";
 import SwapExpired from "../status/SwapExpired";
 import SwapRefunded from "../status/SwapRefunded";
@@ -67,7 +68,12 @@ import {
     hasSwapTimedOut,
     isRefundableSwapType,
 } from "../utils/rescue";
-import type { ChainSwap, SomeSwap, SubmarineSwap } from "../utils/swapCreator";
+import {
+    type ChainSwap,
+    PreBridgeRecoveryStatus,
+    type SomeSwap,
+    type SubmarineSwap,
+} from "../utils/swapCreator";
 import { getUrlParam } from "../utils/urlParams";
 
 const Pay = () => {
@@ -457,7 +463,12 @@ const Pay = () => {
                         <Show when={swap()?.refundTx === undefined}>
                             <Show
                                 when={swapStatus()}
-                                fallback={<LoadingSpinner />}>
+                                fallback={
+                                    <>
+                                        <LoadingSpinner />
+                                        <hr />
+                                    </>
+                                }>
                                 <div class="swap-status">
                                     {t("status")}:
                                     <span class="btn-small">{status()}</span>
@@ -555,6 +566,14 @@ const Pay = () => {
                                     </>
                                 }>
                                 <Switch>
+                                    <Match
+                                        when={
+                                            swap()?.execution
+                                                ?.preBridgeRecovery !==
+                                            undefined
+                                        }>
+                                        <PreBridgeDexQuoteBlocked />
+                                    </Match>
                                     <Match
                                         when={
                                             swapStatus() ===
@@ -655,10 +674,17 @@ const Pay = () => {
                                         <SwapCreated />
                                     </Match>
                                 </Switch>
-                                <BlockExplorerLink
-                                    swap={swap as Accessor<SomeSwap>}
-                                    swapStatus={swapStatus}
-                                />
+                                <Show
+                                    when={
+                                        swap()?.execution?.preBridgeRecovery
+                                            ?.status !==
+                                        PreBridgeRecoveryStatus.Recovered
+                                    }>
+                                    <BlockExplorerLink
+                                        swap={swap as Accessor<SomeSwap>}
+                                        swapStatus={swapStatus}
+                                    />
+                                </Show>
                             </Show>
                         </Show>
                     </Show>

--- a/src/status/PreBridgeDexQuoteBlocked.tsx
+++ b/src/status/PreBridgeDexQuoteBlocked.tsx
@@ -1,7 +1,6 @@
 import { useNavigate } from "@solidjs/router";
 import log from "loglevel";
 import { Show } from "solid-js";
-import { type Hex, getAddress } from "viem";
 
 import type { AlchemyCall } from "../alchemy/Alchemy";
 import BlockExplorer, {
@@ -20,14 +19,6 @@ import {
     PreBridgeRecoveryStatus,
     type SomeSwap,
 } from "../utils/swapCreator";
-
-const toAlchemyCall = (
-    call: NonNullable<PreBridgeRecovery["receiveCall"]>,
-): AlchemyCall => ({
-    to: getAddress(call.to),
-    value: call.value,
-    data: call.data as Hex | undefined,
-});
 
 const PreBridgeDexQuoteBlocked = () => {
     const navigate = useNavigate();
@@ -107,12 +98,11 @@ const PreBridgeDexQuoteBlocked = () => {
                 bridge: currentSwap.bridge,
             },
         );
-        const calls: AlchemyCall[] = [
-            ...(currentRecovery.receiveCall === undefined
-                ? []
-                : [toAlchemyCall(currentRecovery.receiveCall)]),
-            ...reverseBridgeCalls,
-        ];
+        const calls: AlchemyCall[] = [];
+        if (currentRecovery.receiveCall !== undefined) {
+            calls.push(currentRecovery.receiveCall);
+        }
+        calls.push(...reverseBridgeCalls);
 
         log.info(
             `Refunding bridged funds for swap ${currentSwap.id} to the original sender`,

--- a/src/status/PreBridgeDexQuoteBlocked.tsx
+++ b/src/status/PreBridgeDexQuoteBlocked.tsx
@@ -1,6 +1,8 @@
 import { useNavigate } from "@solidjs/router";
+import { bridgeRegistry } from "boltz-swaps/bridge";
 import log from "loglevel";
 import { Show } from "solid-js";
+import { getAddress } from "viem";
 
 import type { AlchemyCall } from "../alchemy/Alchemy";
 import BlockExplorer, {
@@ -8,7 +10,11 @@ import BlockExplorer, {
 } from "../components/BlockExplorer";
 import ContractTransaction from "../components/ContractTransaction";
 import LoadingSpinner from "../components/LoadingSpinner";
-import { buildPreBridgeReverseBridgeRefundCalls } from "../components/RefundButton";
+import {
+    buildReverseBridgeCalls,
+    resolveBridgeSender,
+} from "../components/RefundButton";
+import { getTokenAddress } from "../consts/Assets";
 import { useGlobalContext } from "../context/Global";
 import { usePayContext } from "../context/Pay";
 import { useWeb3Signer } from "../context/Web3";
@@ -27,7 +33,7 @@ const PreBridgeDexQuoteBlocked = () => {
     const { getGasAbstractionSigner } = useWeb3Signer();
 
     const recovery = (): PreBridgeRecovery | undefined =>
-        swap()?.execution?.preBridgeRecovery;
+        swap()?.bridge?.recovery;
 
     const persistRecovery = async (nextRecovery: PreBridgeRecovery) => {
         const currentSwap = swap();
@@ -36,14 +42,11 @@ const PreBridgeDexQuoteBlocked = () => {
         }
 
         const latestSwap = await getSwap<SomeSwap>(currentSwap.id);
-        if (latestSwap?.execution?.preBridgeRecovery === undefined) {
+        if (latestSwap?.bridge?.recovery === undefined) {
             return;
         }
 
-        latestSwap.execution = {
-            ...latestSwap.execution,
-            preBridgeRecovery: nextRecovery,
-        };
+        latestSwap.bridge.recovery = nextRecovery;
         await setSwapStorage(latestSwap);
         setSwap(latestSwap);
     };
@@ -77,7 +80,9 @@ const PreBridgeDexQuoteBlocked = () => {
             );
             return;
         }
-        if (currentSwap.bridge === undefined || currentSwap.dex === undefined) {
+        const { bridge, dex } = currentSwap;
+        const hopDexDetails = dex?.hops[0]?.dexDetails;
+        if (bridge === undefined || hopDexDetails === undefined) {
             log.warn(
                 `Cannot recover pre-bridge funds for swap ${currentSwap.id}: ` +
                     "missing bridge or DEX details",
@@ -88,16 +93,16 @@ const PreBridgeDexQuoteBlocked = () => {
         const gasAbstractionSigner = getGasAbstractionSigner(
             currentRecovery.asset,
         );
-        const reverseBridgeCalls = await buildPreBridgeReverseBridgeRefundCalls(
-            {
-                transactionSigner: gasAbstractionSigner,
-                asset: currentRecovery.asset,
-                amount: BigInt(currentRecovery.amount),
-                slippage: slippage(),
-                dexDetails: currentSwap.dex,
-                bridge: currentSwap.bridge,
-            },
-        );
+        const reverseBridgeCalls = await buildReverseBridgeCalls({
+            transactionSigner: gasAbstractionSigner,
+            bridge,
+            recipient: await resolveBridgeSender(bridge),
+            sourceToken: getAddress(getTokenAddress(currentRecovery.asset)),
+            amount: BigInt(currentRecovery.amount),
+            quoteChain: hopDexDetails.chain,
+            refundAddress: getAddress(gasAbstractionSigner.address),
+            slippage: slippage(),
+        });
         const calls: AlchemyCall[] = [];
         if (currentRecovery.receiveCall !== undefined) {
             calls.push(currentRecovery.receiveCall);
@@ -152,6 +157,9 @@ const PreBridgeDexQuoteBlocked = () => {
                                                         BlockExplorerTargetKind.Tx
                                                     }
                                                     id={txHash}
+                                                    explorer={bridgeRegistry.getExplorerKind(
+                                                        swap()?.bridge,
+                                                    )}
                                                     typeLabel="refund_tx"
                                                 />
                                             </>

--- a/src/status/PreBridgeDexQuoteBlocked.tsx
+++ b/src/status/PreBridgeDexQuoteBlocked.tsx
@@ -1,0 +1,216 @@
+import { useNavigate } from "@solidjs/router";
+import log from "loglevel";
+import { Show } from "solid-js";
+import { type Hex, getAddress } from "viem";
+
+import type { AlchemyCall } from "../alchemy/Alchemy";
+import BlockExplorer, {
+    BlockExplorerTargetKind,
+} from "../components/BlockExplorer";
+import ContractTransaction from "../components/ContractTransaction";
+import LoadingSpinner from "../components/LoadingSpinner";
+import { buildPreBridgeReverseBridgeRefundCalls } from "../components/RefundButton";
+import { useGlobalContext } from "../context/Global";
+import { usePayContext } from "../context/Pay";
+import { useWeb3Signer } from "../context/Web3";
+import { sendPopulatedTransaction } from "../utils/evmTransaction";
+import {
+    GasAbstractionType,
+    type PreBridgeRecovery,
+    PreBridgeRecoveryStatus,
+    type SomeSwap,
+} from "../utils/swapCreator";
+
+const toAlchemyCall = (
+    call: NonNullable<PreBridgeRecovery["receiveCall"]>,
+): AlchemyCall => ({
+    to: getAddress(call.to),
+    value: call.value,
+    data: call.data as Hex | undefined,
+});
+
+const PreBridgeDexQuoteBlocked = () => {
+    const navigate = useNavigate();
+    const { t, getSwap, setSwapStorage, slippage } = useGlobalContext();
+    const { swap, setSwap } = usePayContext();
+    const { getGasAbstractionSigner } = useWeb3Signer();
+
+    const recovery = (): PreBridgeRecovery | undefined =>
+        swap()?.execution?.preBridgeRecovery;
+
+    const persistRecovery = async (nextRecovery: PreBridgeRecovery) => {
+        const currentSwap = swap();
+        if (currentSwap === null) {
+            return;
+        }
+
+        const latestSwap = await getSwap<SomeSwap>(currentSwap.id);
+        if (latestSwap?.execution?.preBridgeRecovery === undefined) {
+            return;
+        }
+
+        latestSwap.execution = {
+            ...latestSwap.execution,
+            preBridgeRecovery: nextRecovery,
+        };
+        await setSwapStorage(latestSwap);
+        setSwap(latestSwap);
+    };
+
+    const retryQuote = async () => {
+        const currentRecovery = recovery();
+        if (currentRecovery === undefined) {
+            return;
+        }
+
+        log.info(
+            `User requested a pre-bridge quote retry for swap ${swap()?.id}`,
+            {
+                asset: currentRecovery.asset,
+                amount: currentRecovery.amount,
+            },
+        );
+        await persistRecovery({
+            ...currentRecovery,
+            status: PreBridgeRecoveryStatus.Retrying,
+        });
+    };
+
+    const recover = async () => {
+        const currentRecovery = recovery();
+        const currentSwap = swap();
+        if (currentRecovery === undefined || currentSwap === null) {
+            log.warn(
+                `Cannot recover pre-bridge funds for swap ${swap()?.id}: ` +
+                    "missing recovery state or swap",
+            );
+            return;
+        }
+        if (currentSwap.bridge === undefined || currentSwap.dex === undefined) {
+            log.warn(
+                `Cannot recover pre-bridge funds for swap ${currentSwap.id}: ` +
+                    "missing bridge or DEX details",
+            );
+            return;
+        }
+
+        const gasAbstractionSigner = getGasAbstractionSigner(
+            currentRecovery.asset,
+        );
+        const reverseBridgeCalls = await buildPreBridgeReverseBridgeRefundCalls(
+            {
+                transactionSigner: gasAbstractionSigner,
+                asset: currentRecovery.asset,
+                amount: BigInt(currentRecovery.amount),
+                slippage: slippage(),
+                dexDetails: currentSwap.dex,
+                bridge: currentSwap.bridge,
+            },
+        );
+        const calls: AlchemyCall[] = [
+            ...(currentRecovery.receiveCall === undefined
+                ? []
+                : [toAlchemyCall(currentRecovery.receiveCall)]),
+            ...reverseBridgeCalls,
+        ];
+
+        log.info(
+            `Refunding bridged funds for swap ${currentSwap.id} to the original sender`,
+            {
+                asset: currentRecovery.asset,
+                amount: currentRecovery.amount,
+            },
+        );
+        const txHash = await sendPopulatedTransaction(
+            GasAbstractionType.Signer,
+            gasAbstractionSigner,
+            calls,
+        );
+        log.info(
+            `Refunded bridged funds for swap ${currentSwap.id} in ${txHash}`,
+        );
+
+        await persistRecovery({
+            ...currentRecovery,
+            status: PreBridgeRecoveryStatus.Recovered,
+            txHash,
+        });
+    };
+
+    return (
+        <Show when={recovery()} keyed>
+            {(currentRecovery) => {
+                return (
+                    <div>
+                        <Show
+                            when={
+                                currentRecovery.status !==
+                                PreBridgeRecoveryStatus.Recovered
+                            }
+                            fallback={
+                                <>
+                                    <p>{t("pre_bridge_refund_initiated")}</p>
+                                    <Show when={currentRecovery.txHash} keyed>
+                                        {(txHash) => (
+                                            <>
+                                                <hr />
+                                                <BlockExplorer
+                                                    asset={
+                                                        currentRecovery.asset
+                                                    }
+                                                    kind={
+                                                        BlockExplorerTargetKind.Tx
+                                                    }
+                                                    id={txHash}
+                                                    typeLabel="refund_tx"
+                                                />
+                                            </>
+                                        )}
+                                    </Show>
+                                    <hr />
+                                    <span
+                                        class="btn"
+                                        onClick={() => navigate("/swap")}>
+                                        {t("new_swap")}
+                                    </span>
+                                </>
+                            }>
+                            <h2>{t("pre_bridge_dex_quote_blocked")}</h2>
+                            <Show
+                                when={
+                                    currentRecovery.status ===
+                                    PreBridgeRecoveryStatus.Blocked
+                                }
+                                fallback={
+                                    <>
+                                        <p>{t("retrying_quote")}</p>
+                                        <LoadingSpinner />
+                                    </>
+                                }>
+                                <p>{t("pre_bridge_dex_quote_blocked_line")}</p>
+                                <button
+                                    class="btn btn-light"
+                                    onClick={() => void retryQuote()}>
+                                    {t("retry_quote")}
+                                </button>
+                                <ContractTransaction
+                                    asset={currentRecovery.asset}
+                                    signerOverride={() =>
+                                        getGasAbstractionSigner(
+                                            currentRecovery.asset,
+                                        )
+                                    }
+                                    onClick={recover}
+                                    buttonText={t("refund")}
+                                    waitingText={t("recovering_bridged_funds")}
+                                />
+                            </Show>
+                        </Show>
+                    </div>
+                );
+            }}
+        </Show>
+    );
+};
+
+export default PreBridgeDexQuoteBlocked;

--- a/src/status/SwapRefunded.tsx
+++ b/src/status/SwapRefunded.tsx
@@ -1,17 +1,20 @@
 import { useNavigate } from "@solidjs/router";
 import { bridgeRegistry } from "boltz-swaps/bridge";
 import { SwapPosition } from "boltz-swaps/types";
+import { Show } from "solid-js";
 
 import BlockExplorer, {
     BlockExplorerTargetKind,
 } from "../components/BlockExplorer";
+import { getAssetNetwork } from "../consts/Assets";
 import { useGlobalContext } from "../context/Global";
 import { usePayContext } from "../context/Pay";
+import { formatDenomination } from "../utils/denomination";
 
 const SwapRefunded = (props: { refundTxId: string }) => {
     const navigate = useNavigate();
     const { swap } = usePayContext();
-    const { t } = useGlobalContext();
+    const { t, denomination } = useGlobalContext();
     const preBridge = () =>
         swap()?.bridge?.position === SwapPosition.Pre
             ? swap()!.bridge
@@ -19,7 +22,21 @@ const SwapRefunded = (props: { refundTxId: string }) => {
 
     return (
         <div>
-            <p>{t("refunded")}</p>
+            <Show when={preBridge()} fallback={<p>{t("refunded")}</p>}>
+                {(bridge) => (
+                    <p>
+                        {t("refunded_bridge_pending", {
+                            denomination: formatDenomination(
+                                denomination(),
+                                bridge().sourceAsset,
+                            ),
+                            network:
+                                getAssetNetwork(bridge().sourceAsset) ??
+                                bridge().sourceAsset,
+                        })}
+                    </p>
+                )}
+            </Show>
             <hr />
             <BlockExplorer
                 asset={preBridge()?.sourceAsset ?? swap()!.assetSend}

--- a/src/status/TransactionLockupFailed.tsx
+++ b/src/status/TransactionLockupFailed.tsx
@@ -49,6 +49,12 @@ import {
 } from "../utils/swapCreator";
 import SwapRefunded from "./SwapRefunded";
 
+type ReplacementQuote = {
+    sentAmount: number;
+    quote: number;
+    receiveAmount: number;
+};
+
 const Amount = (props: { label: DictKey; amount: number; asset: string }) => {
     const { t, denomination, separator } = useGlobalContext();
     const isErc20 = () => getDecimals(props.asset).isErc20;
@@ -94,7 +100,7 @@ const TransactionLockupFailed = (props: {
     >(undefined);
 
     const [newQuote, newQuoteActions] = createResource<
-        { sentAmount: number; quote: number; receiveAmount: number } | undefined
+        ReplacementQuote | undefined
     >(async () => {
         if (swap() === null || swap()!.type !== SwapType.Chain) {
             return undefined;
@@ -228,7 +234,7 @@ const TransactionLockupFailed = (props: {
 
     const acceptQuote = async (
         currentSwap: ChainSwap,
-        quoteData: { sentAmount: number; quote: number; receiveAmount: number },
+        quoteData: ReplacementQuote,
     ) => {
         log.info(
             `Accepting replacement quote for chain swap ${currentSwap.id}`,
@@ -246,20 +252,19 @@ const TransactionLockupFailed = (props: {
             },
         );
         setLoading(true);
-        currentSwap.receiveAmount = quoteData.receiveAmount;
-        currentSwap.claimDetails.amount = quoteData.quote;
-        if (currentSwap.dex !== undefined) {
-            currentSwap.dex.quoteAmount =
-                currentSwap.dex.position === SwapPosition.Pre
-                    ? quoteData.sentAmount
-                    : quoteData.receiveAmount;
-        }
-
-        await setSwapStorage(currentSwap);
-        setSwap(currentSwap);
-
         try {
             await acceptChainSwapNewQuote(currentSwap.id, quoteData.quote);
+            currentSwap.receiveAmount = quoteData.receiveAmount;
+            currentSwap.claimDetails.amount = quoteData.quote;
+            if (currentSwap.dex !== undefined) {
+                currentSwap.dex.quoteAmount =
+                    currentSwap.dex.position === SwapPosition.Pre
+                        ? quoteData.sentAmount
+                        : quoteData.receiveAmount;
+            }
+
+            await setSwapStorage(currentSwap);
+            setSwap(currentSwap);
             setAutoAcceptedQuote(quoteData.quote);
             log.info(
                 `Accepted replacement quote for chain swap ${currentSwap.id}`,
@@ -369,7 +374,6 @@ const TransactionLockupFailed = (props: {
                                             >
                                         }
                                     />
-                                    <hr />
                                 </Show>
                             </Show>
                             <Show when={swap()?.refundTx !== undefined}>
@@ -426,7 +430,6 @@ const TransactionLockupFailed = (props: {
                             {t("refund")}
                         </button>
                     </div>
-                    <hr />
                 </Show>
             </Show>
         </Show>

--- a/src/utils/swapCreator.ts
+++ b/src/utils/swapCreator.ts
@@ -23,6 +23,7 @@ import {
     SwapType,
 } from "boltz-swaps/types";
 
+import type { AlchemyCall } from "../alchemy/Alchemy";
 import { type AssetType, LN, isEvmAsset } from "../consts/Assets";
 import type { newKeyFn } from "../context/Global";
 import type { EncodedHop } from "./Pair";
@@ -55,12 +56,6 @@ export type PendingBridgeSendCallbacks = {
     persist: (pending: PendingBridgeSend) => Promise<void>;
 };
 
-export type PreBridgeRecoveryCall = {
-    to: string;
-    value?: string;
-    data?: string;
-};
-
 export enum PreBridgeRecoveryStatus {
     Blocked = "blocked",
     Retrying = "retrying",
@@ -71,7 +66,7 @@ export type PreBridgeRecovery = {
     status: PreBridgeRecoveryStatus;
     asset: string;
     amount: string;
-    receiveCall?: PreBridgeRecoveryCall;
+    receiveCall?: AlchemyCall;
     txHash?: string;
 };
 

--- a/src/utils/swapCreator.ts
+++ b/src/utils/swapCreator.ts
@@ -55,6 +55,30 @@ export type PendingBridgeSendCallbacks = {
     persist: (pending: PendingBridgeSend) => Promise<void>;
 };
 
+export type PreBridgeRecoveryCall = {
+    to: string;
+    value?: string;
+    data?: string;
+};
+
+export enum PreBridgeRecoveryStatus {
+    Blocked = "blocked",
+    Retrying = "retrying",
+    Recovered = "recovered",
+}
+
+export type PreBridgeRecovery = {
+    status: PreBridgeRecoveryStatus;
+    asset: string;
+    amount: string;
+    receiveCall?: PreBridgeRecoveryCall;
+    txHash?: string;
+};
+
+export type SwapExecutionState = {
+    preBridgeRecovery?: PreBridgeRecovery;
+};
+
 export type GasAbstraction = {
     lockup: GasAbstractionType;
     claim: GasAbstractionType;
@@ -102,6 +126,10 @@ export type SwapBase = {
 
     // Bridge routes for bridging before lockup or after claim.
     bridge?: BridgeDetail;
+
+    // Local execution state for client-side swap steps that are not backend
+    // statuses.
+    execution?: SwapExecutionState;
 };
 
 export type SubmarineSwap = SwapBase &

--- a/src/utils/swapCreator.ts
+++ b/src/utils/swapCreator.ts
@@ -43,25 +43,14 @@ export type DexDetail = {
     quoteAmount: number | string;
 };
 
-export type BridgeDetail = BridgeRoute & {
-    kind: BridgeKind;
-    position: SwapPosition;
-    txHash?: string;
-    details?: BridgeDetails;
-    pendingSend?: PendingBridgeSend;
-    evmSendCandidate?: PendingEvmBridgeSend;
-};
-
-export type PendingBridgeSendCallbacks = {
-    persist: (pending: PendingBridgeSend) => Promise<void>;
-};
-
 export enum PreBridgeRecoveryStatus {
     Blocked = "blocked",
     Retrying = "retrying",
     Recovered = "recovered",
 }
 
+// Client-side recovery state for a pre-bridge swap whose DEX quote fell short
+// while the funds were bridging. This is not a backend status.
 export type PreBridgeRecovery = {
     status: PreBridgeRecoveryStatus;
     asset: string;
@@ -70,8 +59,21 @@ export type PreBridgeRecovery = {
     txHash?: string;
 };
 
-export type SwapExecutionState = {
-    preBridgeRecovery?: PreBridgeRecovery;
+export type BridgeDetail = BridgeRoute & {
+    kind: BridgeKind;
+    position: SwapPosition;
+    txHash?: string;
+    details?: BridgeDetails;
+    pendingSend?: PendingBridgeSend;
+    evmSendCandidate?: PendingEvmBridgeSend;
+
+    // Recovery state when a pre-bridge DEX quote falls short and the bridged
+    // funds must be retried or refunded back to the original sender.
+    recovery?: PreBridgeRecovery;
+};
+
+export type PendingBridgeSendCallbacks = {
+    persist: (pending: PendingBridgeSend) => Promise<void>;
 };
 
 export type GasAbstraction = {
@@ -121,10 +123,6 @@ export type SwapBase = {
 
     // Bridge routes for bridging before lockup or after claim.
     bridge?: BridgeDetail;
-
-    // Local execution state for client-side swap steps that are not backend
-    // statuses.
-    execution?: SwapExecutionState;
 };
 
 export type SubmarineSwap = SwapBase &

--- a/tests/components/SwapExecutionWorker.spec.tsx
+++ b/tests/components/SwapExecutionWorker.spec.tsx
@@ -585,17 +585,19 @@ describe("SwapExecutionWorker", () => {
 
             expect(quoter.fetchDexQuote).toHaveBeenCalledTimes(3);
             expect(mockSendPopulatedTransaction).not.toHaveBeenCalled();
-            expect(currentSwap.execution).toEqual({
-                preBridgeRecovery: expect.objectContaining({
+            expect(
+                (currentSwap.bridge as Record<string, unknown>).recovery,
+            ).toEqual(
+                expect.objectContaining({
                     status: "blocked",
                     asset: "DST",
                     amount: "150",
                 }),
-            });
+            );
             expect(mockSetSwapStorage).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    execution: expect.objectContaining({
-                        preBridgeRecovery: expect.objectContaining({
+                    bridge: expect.objectContaining({
+                        recovery: expect.objectContaining({
                             status: "blocked",
                             asset: "DST",
                             amount: "150",
@@ -628,7 +630,9 @@ describe("SwapExecutionWorker", () => {
             );
         });
 
-        expect(currentSwap.execution).toBeUndefined();
+        expect(
+            (currentSwap.bridge as Record<string, unknown>).recovery,
+        ).toBeUndefined();
     });
 
     test("should lock immediately without retrying when the lockup clears the renegotiation minimum", async () => {
@@ -661,7 +665,9 @@ describe("SwapExecutionWorker", () => {
             });
 
             expect(quoter.fetchDexQuote).toHaveBeenCalledTimes(1);
-            expect(currentSwap.execution).toBeUndefined();
+            expect(
+                (currentSwap.bridge as Record<string, unknown>).recovery,
+            ).toBeUndefined();
         } finally {
             mockPairs.mockReturnValue({
                 chain: {

--- a/tests/components/SwapExecutionWorker.spec.tsx
+++ b/tests/components/SwapExecutionWorker.spec.tsx
@@ -43,6 +43,18 @@ const mockSetSwap = vi.fn((swap: Record<string, unknown>) => {
 });
 const mockGetSwap = vi.fn(() => Promise.resolve(currentSwap));
 const mockGetSwaps = vi.fn(() => Promise.resolve([currentSwap]));
+const mockFetchPairs = vi.fn().mockResolvedValue(undefined);
+const mockPairs = vi.fn(() => ({
+    chain: {
+        FINAL: {
+            BTC: {
+                limits: {
+                    minimal: 100,
+                },
+            },
+        },
+    },
+}));
 const mockSendPopulatedTransaction = vi
     .fn<(...args: unknown[]) => Promise<string>>()
     .mockResolvedValue("0xcommitment");
@@ -231,6 +243,8 @@ vi.mock("../../src/context/Global", () => ({
         getSwaps: mockGetSwaps,
         setSwapStorage: mockSetSwapStorage,
         slippage: () => 0.5,
+        fetchPairs: mockFetchPairs,
+        pairs: mockPairs,
     }),
 }));
 
@@ -281,8 +295,10 @@ vi.mock("../../packages/boltz-swaps/src/client.ts", () => ({
 }));
 
 vi.mock("../../src/utils/calculate", () => ({
-    calculateAmountOutMin: (amount: bigint) => amount,
-    calculateAmountWithSlippage: (amount: bigint) => amount,
+    calculateAmountOutMin: (amount: bigint, slippage: number) =>
+        amount - BigInt(Math.floor(Number(amount) * slippage)),
+    calculateAmountWithSlippage: (amount: bigint, slippage: number) =>
+        amount + BigInt(Math.floor(Number(amount) * slippage)),
 }));
 
 vi.mock("boltz-swaps/solana", () => ({
@@ -389,12 +405,14 @@ vi.mock("../../src/utils/quoter", () => ({
 vi.mock("boltz-swaps/evm", async (importActual) => ({
     ...(await importActual<typeof EvmModule>()),
     satsToAssetAmount: (value: number) => BigInt(value),
+    assetAmountToSats: (value: bigint) => value,
     createAssetProvider: mockCreateAssetProvider,
 }));
 
 const { SwapExecutionWorker } =
     await import("../../src/components/SwapExecutionWorker");
 const oftUtils = await import("boltz-swaps/oft");
+const quoter = await import("../../src/utils/quoter");
 
 const cctpMessageSentTopic =
     "0x8c5261668696ce22758910d05bab8f186d6eb247ceac2af2e82c7dc17669b036";
@@ -472,6 +490,15 @@ describe("SwapExecutionWorker", () => {
         mockSendPopulatedTransaction
             .mockReset()
             .mockResolvedValue("0xcommitment");
+        vi.mocked(quoter.fetchDexQuote)
+            .mockReset()
+            .mockResolvedValue({
+                trade: {
+                    amountIn: 150n,
+                    amountOut: 150n,
+                    data: "0xquote",
+                },
+            });
         mockPostCommitmentSignatureForTransaction
             .mockReset()
             .mockResolvedValue(undefined);
@@ -490,6 +517,7 @@ describe("SwapExecutionWorker", () => {
             type: "chain",
             status: "invoice.set",
             assetSend: "FINAL",
+            assetReceive: "BTC",
             sendAmount: 100,
             gasAbstraction: {
                 lockup: "signer",
@@ -538,6 +566,115 @@ describe("SwapExecutionWorker", () => {
             expect(currentSwap.commitmentLockupTxHash).toEqual("0xcommitment");
             expect(currentSwap.commitmentSignatureSubmitted).toEqual(true);
         });
+    });
+
+    test("should persist a blocked pre-bridge state when DEX quote stays below the lockup amount", async () => {
+        vi.useFakeTimers();
+        try {
+            vi.mocked(quoter.fetchDexQuote).mockResolvedValue({
+                trade: {
+                    amountIn: 150n,
+                    amountOut: 49n,
+                    data: "0xquote",
+                },
+            });
+
+            render(() => <SwapExecutionWorker />);
+
+            await vi.runAllTimersAsync();
+
+            expect(quoter.fetchDexQuote).toHaveBeenCalledTimes(3);
+            expect(mockSendPopulatedTransaction).not.toHaveBeenCalled();
+            expect(currentSwap.execution).toEqual({
+                preBridgeRecovery: expect.objectContaining({
+                    status: "blocked",
+                    asset: "DST",
+                    amount: "150",
+                }),
+            });
+            expect(mockSetSwapStorage).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    execution: expect.objectContaining({
+                        preBridgeRecovery: expect.objectContaining({
+                            status: "blocked",
+                            asset: "DST",
+                            amount: "150",
+                        }),
+                    }),
+                }),
+            );
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("should execute pre-bridge lockup when the DEX quote is within slippage", async () => {
+        vi.mocked(quoter.fetchDexQuote).mockResolvedValueOnce({
+            trade: {
+                amountIn: 150n,
+                amountOut: 50n,
+                data: "0xquote",
+            },
+        });
+
+        render(() => <SwapExecutionWorker />);
+
+        await waitFor(() => {
+            expect(mockSendPopulatedTransaction).toHaveBeenCalled();
+            expect(mockSetSwapStorage).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    commitmentLockupTxHash: "0xcommitment",
+                }),
+            );
+        });
+
+        expect(currentSwap.execution).toBeUndefined();
+    });
+
+    test("should lock immediately without retrying when the lockup clears the renegotiation minimum", async () => {
+        mockPairs.mockReturnValue({
+            chain: {
+                FINAL: {
+                    BTC: {
+                        limits: {
+                            minimal: 20,
+                        },
+                    },
+                },
+            },
+        });
+        // Below the slippage threshold (requiredAmount 50) but the resulting
+        // lockup (25) still clears the renegotiation minimum (20).
+        vi.mocked(quoter.fetchDexQuote).mockResolvedValue({
+            trade: {
+                amountIn: 150n,
+                amountOut: 49n,
+                data: "0xquote",
+            },
+        });
+
+        try {
+            render(() => <SwapExecutionWorker />);
+
+            await waitFor(() => {
+                expect(mockSendPopulatedTransaction).toHaveBeenCalled();
+            });
+
+            expect(quoter.fetchDexQuote).toHaveBeenCalledTimes(1);
+            expect(currentSwap.execution).toBeUndefined();
+        } finally {
+            mockPairs.mockReturnValue({
+                chain: {
+                    FINAL: {
+                        BTC: {
+                            limits: {
+                                minimal: 100,
+                            },
+                        },
+                    },
+                },
+            });
+        }
     });
 
     test("should mint manual CCTP before executing the pre-bridge lockup", async () => {

--- a/tests/status/PreBridgeDexQuoteBlocked.spec.tsx
+++ b/tests/status/PreBridgeDexQuoteBlocked.spec.tsx
@@ -137,7 +137,7 @@ const makeSwap = (): SomeSwap =>
                     to: messageTransmitter,
                     value: "0",
                     data: "0x1234",
-                },
+                } as AlchemyCall,
             },
         },
     }) as SomeSwap;

--- a/tests/status/PreBridgeDexQuoteBlocked.spec.tsx
+++ b/tests/status/PreBridgeDexQuoteBlocked.spec.tsx
@@ -1,0 +1,218 @@
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { SwapPosition } from "boltz-swaps/types";
+import { createSignal } from "solid-js";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { AlchemyCall } from "../../src/alchemy/Alchemy";
+import type { Signer } from "../../src/context/Web3";
+import type { sendPopulatedTransaction as sendPopulatedTransactionFn } from "../../src/utils/evmTransaction";
+import {
+    PreBridgeRecoveryStatus,
+    type SomeSwap,
+} from "../../src/utils/swapCreator";
+
+const messageTransmitter = "0x1000000000000000000000000000000000000000";
+const tokenAddress = "0x2000000000000000000000000000000000000000";
+const destinationAddress = "0x3000000000000000000000000000000000000000";
+const gasAbstractionAddress = "0x4000000000000000000000000000000000000000";
+
+const [swap, setSwapSignal] = createSignal<SomeSwap | null>(null, {
+    equals: false,
+});
+const [signer, setSigner] = createSignal<Signer | undefined>();
+const getSwap = vi.fn<(id: string) => Promise<SomeSwap | null>>();
+const setSwapStorage = vi.fn<(nextSwap: SomeSwap) => Promise<void>>();
+const setSwap = vi.fn((nextSwap: SomeSwap | null) => {
+    setSwapSignal(nextSwap);
+});
+const getGasAbstractionSigner = vi.fn<(asset: string) => Signer>();
+const sendPopulatedTransaction = vi.fn<typeof sendPopulatedTransactionFn>();
+const buildPreBridgeReverseBridgeRefundCalls = vi.fn();
+
+vi.mock("@solidjs/router", () => ({
+    useNavigate: () => vi.fn(),
+}));
+
+vi.mock("../../src/context/Global", () => ({
+    useGlobalContext: () => ({
+        t: (key: string) => key,
+        getSwap,
+        setSwapStorage,
+        denomination: () => "BTC",
+        separator: () => ".",
+        slippage: () => 0.01,
+    }),
+}));
+
+vi.mock("../../src/context/Pay", () => ({
+    usePayContext: () => ({
+        swap,
+        setSwap,
+    }),
+}));
+
+vi.mock("../../src/context/Web3", () => ({
+    useWeb3Signer: () => ({
+        signer,
+        getGasAbstractionSigner,
+    }),
+}));
+
+vi.mock("../../src/consts/Assets", () => ({
+    getAssetDisplaySymbol: (asset: string) => asset,
+    getAssetNetwork: () => "Arbitrum",
+    getTokenAddress: () => tokenAddress,
+}));
+
+vi.mock("../../src/utils/evmTransaction", () => ({
+    sendPopulatedTransaction,
+}));
+
+type ContractTxProps = {
+    signerOverride?: () => Signer | undefined;
+    onClick: () => Promise<unknown>;
+    buttonText: string;
+    promptText?: string;
+};
+vi.mock("../../src/components/ContractTransaction", () => ({
+    default: (props: ContractTxProps) => (
+        <div>
+            <p data-testid="prompt">{props.promptText}</p>
+            <button
+                data-testid="recover-button"
+                onClick={() => void props.onClick()}>
+                {props.buttonText}
+            </button>
+        </div>
+    ),
+}));
+
+vi.mock("../../src/components/ConnectWallet", () => ({
+    default: () => <button>connect-wallet</button>,
+}));
+
+vi.mock("../../src/components/RefundButton", () => ({
+    buildPreBridgeReverseBridgeRefundCalls,
+}));
+
+const { default: PreBridgeDexQuoteBlocked } =
+    await import("../../src/status/PreBridgeDexQuoteBlocked");
+
+const makeSigner = (address: string) =>
+    ({
+        address,
+        provider: {
+            getChainId: vi.fn().mockResolvedValue(1),
+        },
+    }) as unknown as Signer;
+
+const makeSwap = (): SomeSwap =>
+    ({
+        id: "swap-1",
+        bridge: {
+            position: SwapPosition.Pre,
+            sourceAsset: "USDT0-ETH",
+            destinationAsset: "USDT0",
+            txHash: "0xbridge",
+        },
+        dex: {
+            position: SwapPosition.Pre,
+            hops: [
+                {
+                    dexDetails: {
+                        chain: "1",
+                        tokenIn: tokenAddress,
+                        tokenOut: destinationAddress,
+                    },
+                },
+            ],
+            quoteAmount: "123",
+        },
+        execution: {
+            preBridgeRecovery: {
+                status: PreBridgeRecoveryStatus.Blocked,
+                asset: "USDT0",
+                amount: "123",
+                receiveCall: {
+                    to: messageTransmitter,
+                    value: "0",
+                    data: "0x1234",
+                },
+            },
+        },
+    }) as SomeSwap;
+
+describe("PreBridgeDexQuoteBlocked", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        const currentSwap = makeSwap();
+        setSwapSignal(currentSwap);
+        setSigner(makeSigner(destinationAddress));
+        getSwap.mockResolvedValue(currentSwap);
+        getGasAbstractionSigner.mockReturnValue(
+            makeSigner(gasAbstractionAddress),
+        );
+        sendPopulatedTransaction.mockResolvedValue("0xrecovery");
+        buildPreBridgeReverseBridgeRefundCalls.mockResolvedValue([
+            {
+                to: tokenAddress,
+                value: "0",
+                data: "0xabcd",
+            },
+        ]);
+    });
+
+    test("recovers bridged funds with receive call before transfer and marks swap recovered", async () => {
+        render(() => <PreBridgeDexQuoteBlocked />);
+
+        fireEvent.click(await screen.findByTestId("recover-button"));
+
+        await waitFor(() => {
+            expect(sendPopulatedTransaction).toHaveBeenCalled();
+        });
+
+        const calls = sendPopulatedTransaction.mock
+            .calls[0][2] as AlchemyCall[];
+        expect(calls).toHaveLength(2);
+        expect(calls[0]).toEqual({
+            to: messageTransmitter,
+            value: "0",
+            data: "0x1234",
+        });
+        expect(calls[1]).toMatchObject({
+            to: tokenAddress,
+            value: "0",
+            data: expect.stringMatching(/^0x[0-9a-f]+$/),
+        });
+        await waitFor(() => {
+            expect(setSwapStorage).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    execution: {
+                        preBridgeRecovery: expect.objectContaining({
+                            status: PreBridgeRecoveryStatus.Recovered,
+                            txHash: "0xrecovery",
+                        }),
+                    },
+                }),
+            );
+        });
+    });
+
+    test("marks the swap as retrying when retrying the quote", async () => {
+        render(() => <PreBridgeDexQuoteBlocked />);
+
+        fireEvent.click(await screen.findByText("retry_quote"));
+
+        await waitFor(() => {
+            expect(setSwapStorage).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    execution: {
+                        preBridgeRecovery: expect.objectContaining({
+                            status: PreBridgeRecoveryStatus.Retrying,
+                        }),
+                    },
+                }),
+            );
+        });
+    });
+});

--- a/tests/status/PreBridgeDexQuoteBlocked.spec.tsx
+++ b/tests/status/PreBridgeDexQuoteBlocked.spec.tsx
@@ -27,7 +27,8 @@ const setSwap = vi.fn((nextSwap: SomeSwap | null) => {
 });
 const getGasAbstractionSigner = vi.fn<(asset: string) => Signer>();
 const sendPopulatedTransaction = vi.fn<typeof sendPopulatedTransactionFn>();
-const buildPreBridgeReverseBridgeRefundCalls = vi.fn();
+const buildReverseBridgeCalls = vi.fn();
+const resolveBridgeSender = vi.fn();
 
 vi.mock("@solidjs/router", () => ({
     useNavigate: () => vi.fn(),
@@ -92,7 +93,14 @@ vi.mock("../../src/components/ConnectWallet", () => ({
 }));
 
 vi.mock("../../src/components/RefundButton", () => ({
-    buildPreBridgeReverseBridgeRefundCalls,
+    buildReverseBridgeCalls,
+    resolveBridgeSender,
+}));
+
+vi.mock("boltz-swaps/bridge", () => ({
+    bridgeRegistry: {
+        getExplorerKind: () => undefined,
+    },
 }));
 
 const { default: PreBridgeDexQuoteBlocked } =
@@ -114,6 +122,16 @@ const makeSwap = (): SomeSwap =>
             sourceAsset: "USDT0-ETH",
             destinationAsset: "USDT0",
             txHash: "0xbridge",
+            recovery: {
+                status: PreBridgeRecoveryStatus.Blocked,
+                asset: "USDT0",
+                amount: "123",
+                receiveCall: {
+                    to: messageTransmitter,
+                    value: "0",
+                    data: "0x1234",
+                } as AlchemyCall,
+            },
         },
         dex: {
             position: SwapPosition.Pre,
@@ -128,18 +146,6 @@ const makeSwap = (): SomeSwap =>
             ],
             quoteAmount: "123",
         },
-        execution: {
-            preBridgeRecovery: {
-                status: PreBridgeRecoveryStatus.Blocked,
-                asset: "USDT0",
-                amount: "123",
-                receiveCall: {
-                    to: messageTransmitter,
-                    value: "0",
-                    data: "0x1234",
-                } as AlchemyCall,
-            },
-        },
     }) as SomeSwap;
 
 describe("PreBridgeDexQuoteBlocked", () => {
@@ -153,7 +159,8 @@ describe("PreBridgeDexQuoteBlocked", () => {
             makeSigner(gasAbstractionAddress),
         );
         sendPopulatedTransaction.mockResolvedValue("0xrecovery");
-        buildPreBridgeReverseBridgeRefundCalls.mockResolvedValue([
+        resolveBridgeSender.mockResolvedValue(destinationAddress);
+        buildReverseBridgeCalls.mockResolvedValue([
             {
                 to: tokenAddress,
                 value: "0",
@@ -187,12 +194,12 @@ describe("PreBridgeDexQuoteBlocked", () => {
         await waitFor(() => {
             expect(setSwapStorage).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    execution: {
-                        preBridgeRecovery: expect.objectContaining({
+                    bridge: expect.objectContaining({
+                        recovery: expect.objectContaining({
                             status: PreBridgeRecoveryStatus.Recovered,
                             txHash: "0xrecovery",
                         }),
-                    },
+                    }),
                 }),
             );
         });
@@ -206,11 +213,11 @@ describe("PreBridgeDexQuoteBlocked", () => {
         await waitFor(() => {
             expect(setSwapStorage).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    execution: {
-                        preBridgeRecovery: expect.objectContaining({
+                    bridge: expect.objectContaining({
+                        recovery: expect.objectContaining({
                             status: PreBridgeRecoveryStatus.Retrying,
                         }),
-                    },
+                    }),
                 }),
             );
         });

--- a/tests/status/TransactionLockupFailedAutoAccept.spec.tsx
+++ b/tests/status/TransactionLockupFailedAutoAccept.spec.tsx
@@ -1,0 +1,186 @@
+import { render, waitFor } from "@solidjs/testing-library";
+import { SwapPosition, SwapType } from "boltz-swaps/types";
+
+const mocks = vi.hoisted(() => ({
+    swap: undefined as unknown,
+    setSwap: vi.fn((nextSwap: unknown) => {
+        mocks.swap = nextSwap;
+    }),
+    setSwapStorage: vi.fn().mockResolvedValue(undefined),
+    setFailureReason: vi.fn(),
+    setStatusOverride: vi.fn(),
+    acceptChainSwapNewQuote: vi.fn().mockResolvedValue(undefined),
+    getChainSwapNewQuote: vi.fn(),
+    getChainSwapTransactions: vi.fn().mockResolvedValue({
+        userLock: {
+            transaction: {},
+        },
+    }),
+    fetchPairs: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("boltz-swaps/client", () => ({
+    acceptChainSwapNewQuote: mocks.acceptChainSwapNewQuote,
+    getChainSwapNewQuote: mocks.getChainSwapNewQuote,
+    getChainSwapTransactions: mocks.getChainSwapTransactions,
+}));
+
+vi.mock("../../src/components/RefundButton", () => ({
+    default: () => <button>refund</button>,
+    incorrectAssetError: "incorrect asset was sent",
+}));
+
+vi.mock("../../src/components/LoadingSpinner", () => ({
+    default: () => <div>loading</div>,
+}));
+
+vi.mock("../../src/pages/NotFound", () => ({
+    default: () => <div>not-found</div>,
+}));
+
+vi.mock("../../src/consts/Assets", () => ({
+    isEvmAsset: () => true,
+}));
+
+vi.mock("../../src/context/Global", () => ({
+    useGlobalContext: () => ({
+        t: (key: string) => key,
+        fetchPairs: mocks.fetchPairs,
+        setSwapStorage: mocks.setSwapStorage,
+        pairs: () => ({
+            chain: {
+                FINAL: {
+                    BTC: {
+                        fees: {
+                            minerFees: {
+                                user: {
+                                    claim: 0,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }),
+        slippage: () => 0.01,
+        denomination: () => "sat",
+        separator: () => ".",
+    }),
+}));
+
+vi.mock("../../src/context/Pay", () => ({
+    usePayContext: () => ({
+        failureReason: () => "",
+        swap: () => mocks.swap,
+        setSwap: mocks.setSwap,
+        setFailureReason: mocks.setFailureReason,
+    }),
+}));
+
+vi.mock("../../src/utils/Pair", () => ({
+    default: class MockPair {
+        isRoutable = false;
+    },
+}));
+
+vi.mock("../../src/utils/compat", () => ({
+    decodeAddress: vi.fn(),
+    findOutputByScript: vi.fn(),
+    getOutputAmount: vi.fn(),
+    getTransaction: vi.fn(),
+}));
+
+vi.mock("../../src/utils/denomination", () => ({
+    formatAmount: (amount: { toString: () => string }) => amount.toString(),
+    formatDenomination: () => "sat",
+    formatSwapAmountForLog: (amount: { toString: () => string }) =>
+        amount.toString(),
+    getDecimals: () => ({ isErc20: false, decimals: 8 }),
+}));
+
+vi.mock("../../src/utils/helper", () => ({
+    parseBlindingKey: vi.fn(),
+}));
+
+vi.mock("../../src/utils/rescue", () => ({
+    isRefundableSwapType: () => false,
+}));
+
+const { default: TransactionLockupFailed } =
+    await import("../../src/status/TransactionLockupFailed");
+
+const makeSwap = () => ({
+    id: "swap-1",
+    type: SwapType.Chain,
+    assetSend: "FINAL",
+    assetReceive: "BTC",
+    sendAmount: 100,
+    receiveAmount: 1_000,
+    claimAddress: "claim",
+    signer: "signer",
+    claimDetails: {
+        amount: 1_000,
+    },
+    dex: {
+        position: SwapPosition.Pre,
+        quoteAmount: "100",
+        hops: [],
+    },
+});
+
+describe("TransactionLockupFailed pre-bridge auto-accept", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.swap = makeSwap();
+        mocks.getChainSwapNewQuote.mockResolvedValue({ amount: 991 });
+    });
+
+    test("auto-accepts a pre-bridge replacement quote within slippage", async () => {
+        render(() => (
+            <TransactionLockupFailed
+                setStatusOverride={mocks.setStatusOverride}
+            />
+        ));
+
+        await waitFor(() => {
+            expect(mocks.acceptChainSwapNewQuote).toHaveBeenCalledWith(
+                "swap-1",
+                991,
+            );
+        });
+
+        expect(
+            mocks.acceptChainSwapNewQuote.mock.invocationCallOrder[0],
+        ).toBeLessThan(mocks.setSwapStorage.mock.invocationCallOrder[0]);
+        expect(mocks.setSwapStorage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                receiveAmount: 990,
+                claimDetails: expect.objectContaining({
+                    amount: 991,
+                }),
+                dex: expect.objectContaining({
+                    quoteAmount: 100,
+                }),
+            }),
+        );
+    });
+
+    test("does not auto-accept a pre-bridge replacement quote outside slippage", async () => {
+        mocks.getChainSwapNewQuote.mockResolvedValue({ amount: 990 });
+
+        render(() => (
+            <TransactionLockupFailed
+                setStatusOverride={mocks.setStatusOverride}
+            />
+        ));
+
+        await waitFor(() => {
+            expect(mocks.setStatusOverride).toHaveBeenCalledWith(
+                "quote.available",
+            );
+        });
+
+        expect(mocks.acceptChainSwapNewQuote).not.toHaveBeenCalled();
+        expect(mocks.setSwapStorage).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Closes #1446

**How to easily test it:**
1. Create a USDT/USDC swap which includes a pre-bridge;
2. After you created the swap, update the function `fetchDexQuote` from `src/utils/quoter.ts`, so it does this early return (you can adjust the percentage to decide how much you want the quote to drift):
```
export const fetchDexQuote = async (
    hop: Hop,
    amountIn: bigint,
    getGasToken?: boolean,
    gasTokenAmount?: bigint,
): Promise<ClaimQuote> => {
     const debugTrade = await fetchQuote(Direction.In, hop, amountIn);
    return {
        trade: {
            ...debugTrade,
            amountOut: (debugTrade.amountOut * 60n) / 100n,
        },
    };
```
3. Press the "Send" button to bridge the asset;
4. Once the bridge is completed, the new error screen will show up, allowing the user to refund or retry the quote.

- if quote drifts within the slippage, swap continues normally
- if quote drifts outside the slippage on chain swaps, I show the renegotiation flow (Accept / refund buttons)
- if quote drifts outside the slippage on submarine swaps, I just show the "Retry quote" + "Refund" buttons
- If quote drifts below the absolute minimum for the pair, I just show the "Retry quote" + "Refund" buttons

Refunds are always sent back to the original network

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a pre-bridge DEX quote “blocked” recovery flow with configurable retry attempts and a guided recover action.
* **UI Enhancements**
  * Updated the Pay page to display the blocked-quote recovery screen when pre-bridge recovery is present, and refined loading/refund UI details.
* **Localization**
  * Added new multilingual status messages for “refunded bridge pending” and blocked-quote states.
* **Bug Fixes**
  * Improved quote sufficiency checks to use slippage-adjusted thresholds and refined pre-bridge eligibility for retrying states.
  * Enhanced reverse-bridge refund follow-up call construction for pre-bridge scenarios.
* **Tests**
  * Added/expanded coverage for retry, recovery, and slippage boundary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->