### PR TITLE
refactor: make swap bridge status more intuitive

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -69,6 +69,8 @@ const dict = {
         congrats: "Congratulations!",
         successfully_swapped:
             "You successfully received {{ amount }} {{ denomination }}!",
+        bridge_transfer_pending:
+            "Swap complete! Your {{ amount }} {{ denomination }} was sent via the {{ network }} bridge. Bridge transfers may take a few minutes to finish.",
         timeout_eta: "Timeout ETA",
         pay_invoice: "Swap: {{ id }}",
         pay_swap_404: "Swap not found!",
@@ -608,6 +610,8 @@ const dict = {
         congrats: "Herzlichen Glückwunsch!",
         successfully_swapped:
             "Du hast erfolgreich {{ amount }} {{ denomination }} empfangen!",
+        bridge_transfer_pending:
+            "Swap abgeschlossen! Deine {{ amount }} {{ denomination }} wurden über die {{ network }}-Bridge gesendet. Bridge-Transfers können einige Minuten dauern.",
         timeout_eta: "Timeout-ETA",
         pay_invoice: "Swap: {{ id }}",
         pay_swap_404: "Swap nicht gefunden!",
@@ -1164,6 +1168,8 @@ const dict = {
         congrats: "¡Felicitaciones!",
         successfully_swapped:
             "Has recibido con éxito {{ amount }} {{ denomination }}!",
+        bridge_transfer_pending:
+            "¡Intercambio completado! Tus {{ amount }} {{ denomination }} se enviaron a través del puente {{ network }}. Las transferencias por puentes pueden tardar unos minutos en finalizar.",
         timeout_eta: "Tiempo de espera estimado",
         pay_invoice: "Intercambio: {{ id }}",
         pay_swap_404: "¡Intercambio no encontrado!",
@@ -1717,6 +1723,8 @@ const dict = {
         congrats: "Parabéns!",
         successfully_swapped:
             "{{ amount }} {{ denomination }} recebidos com sucesso!",
+        bridge_transfer_pending:
+            "Troca concluída! Seus {{ amount }} {{ denomination }} foram enviados pela ponte {{ network }}. Transferências por pontes podem levar alguns minutos para finalizar.",
         timeout_eta: "Estimativa de Expiração",
         pay_invoice: "Troca: {{ id }}",
         pay_swap_404: "Troca não encontrada!",
@@ -2259,6 +2267,8 @@ const dict = {
         create_and_paste: "粘贴闪电发票、BOLT12 地址或 LNURL 以接收资金",
         congrats: "恭喜！",
         successfully_swapped: "您成功收到{{ amount }}{{ denomination }}！",
+        bridge_transfer_pending:
+            "交换已完成！您的 {{ amount }} {{ denomination }} 已通过 {{ network }} 桥发送。桥接转账可能需要几分钟才能完成。",
         timeout_eta: "超过预期时间",
         pay_invoice: "交换：{{ id }}",
         pay_swap_404: "找不到交换！",
@@ -2757,6 +2767,8 @@ const dict = {
             "資金を受け取るために、ライトニングインボイス、BOLT12、またはLNURLを貼り付けてください",
         congrats: "おめでとうございます！",
         successfully_swapped: "スワップが正常に完了しました",
+        bridge_transfer_pending:
+            "スワップが完了しました！{{ amount }} {{ denomination }} は {{ network }} ブリッジ経由で送信されました。ブリッジ転送の完了には数分かかる場合があります。",
         timeout_eta: "タイムアウト予想時間",
         pay_invoice: "スワップ：{{ id }}",
         pay_swap_404: "スワップが見つかりません！",

--- a/src/pages/Pay.tsx
+++ b/src/pages/Pay.tsx
@@ -436,6 +436,16 @@ const Pay = () => {
         />
     );
 
+    // Post-bridge swaps need a "check status" link to follow the transfer to the
+    // destination chain; their status components render it themselves. Other
+    // swaps just get the plain transaction link, the default button below.
+    const shouldShowPostBridgeExplorer = createMemo(
+        () =>
+            transactionClaimedPostBridge() ||
+            swap()?.bridge?.recovery?.status ===
+                PreBridgeRecoveryStatus.Recovered,
+    );
+
     return (
         <Show
             when={swap()}
@@ -691,12 +701,7 @@ const Pay = () => {
                                         <SwapCreated />
                                     </Match>
                                 </Switch>
-                                <Show
-                                    when={
-                                        !transactionClaimedPostBridge() &&
-                                        swap()?.bridge?.recovery?.status !==
-                                            PreBridgeRecoveryStatus.Recovered
-                                    }>
+                                <Show when={!shouldShowPostBridgeExplorer()}>
                                     {blockExplorerLink()}
                                 </Show>
                             </Show>

--- a/src/pages/Pay.tsx
+++ b/src/pages/Pay.tsx
@@ -73,6 +73,7 @@ import {
     PreBridgeRecoveryStatus,
     type SomeSwap,
     type SubmarineSwap,
+    getPostBridgeDetail,
 } from "../utils/swapCreator";
 import { getUrlParam } from "../utils/urlParams";
 
@@ -414,6 +415,27 @@ const Pay = () => {
         () => statusOverride() || renameSwapStatus(swapStatus()),
     );
 
+    const isTransactionClaimedStatus = createMemo(
+        () =>
+            swapStatus() === swapStatusSuccess.TransactionClaimed ||
+            swapStatus() === swapStatusSuccess.InvoiceSettled ||
+            swapStatus() === swapStatusPending.TransactionClaimPending ||
+            swapStatus() === swapStatusPending.InvoicePaid,
+    );
+
+    const transactionClaimedPostBridge = createMemo(
+        () =>
+            isTransactionClaimedStatus() &&
+            getPostBridgeDetail(swap()?.bridge) !== undefined,
+    );
+
+    const blockExplorerLink = () => (
+        <BlockExplorerLink
+            swap={swap as Accessor<SomeSwap>}
+            swapStatus={swapStatus}
+        />
+    );
+
     return (
         <Show
             when={swap()}
@@ -573,18 +595,14 @@ const Pay = () => {
                                         }>
                                         <PreBridgeDexQuoteBlocked />
                                     </Match>
-                                    <Match
-                                        when={
-                                            swapStatus() ===
-                                                swapStatusSuccess.TransactionClaimed ||
-                                            swapStatus() ===
-                                                swapStatusSuccess.InvoiceSettled ||
-                                            swapStatus() ===
-                                                swapStatusPending.TransactionClaimPending ||
-                                            swapStatus() ===
-                                                swapStatusPending.InvoicePaid
-                                        }>
-                                        <TransactionClaimed />
+                                    <Match when={isTransactionClaimedStatus()}>
+                                        <TransactionClaimed
+                                            bridgeStatusLink={
+                                                transactionClaimedPostBridge()
+                                                    ? blockExplorerLink()
+                                                    : undefined
+                                            }
+                                        />
                                     </Match>
                                     <Match
                                         when={
@@ -675,13 +693,11 @@ const Pay = () => {
                                 </Switch>
                                 <Show
                                     when={
+                                        !transactionClaimedPostBridge() &&
                                         swap()?.bridge?.recovery?.status !==
-                                        PreBridgeRecoveryStatus.Recovered
+                                            PreBridgeRecoveryStatus.Recovered
                                     }>
-                                    <BlockExplorerLink
-                                        swap={swap as Accessor<SomeSwap>}
-                                        swapStatus={swapStatus}
-                                    />
+                                    {blockExplorerLink()}
                                 </Show>
                             </Show>
                         </Show>

--- a/src/status/TransactionClaimed.tsx
+++ b/src/status/TransactionClaimed.tsx
@@ -3,18 +3,28 @@ import { BigNumber } from "bignumber.js";
 import { getSubmarinePreimage } from "boltz-swaps/client";
 import { SwapPosition, SwapType } from "boltz-swaps/types";
 import log from "loglevel";
-import { Show, createEffect, createResource, createSignal } from "solid-js";
+import {
+    type JSX,
+    Show,
+    createEffect,
+    createResource,
+    createSignal,
+} from "solid-js";
 
 import ExternalLink from "../components/ExternalLink";
 import LoadingSpinner from "../components/LoadingSpinner";
 import { config } from "../config";
-import { isEvmAsset } from "../consts/Assets";
+import { getAssetNetwork, isEvmAsset } from "../consts/Assets";
 import { useGlobalContext } from "../context/Global";
 import { usePayContext } from "../context/Pay";
 import { formatAmount, formatDenomination } from "../utils/denomination";
 import { formatError } from "../utils/errors";
 import { checkInvoicePreimage } from "../utils/invoice";
-import { type SubmarineSwap, getFinalAssetReceive } from "../utils/swapCreator";
+import {
+    type SubmarineSwap,
+    getFinalAssetReceive,
+    getPostBridgeDetail,
+} from "../utils/swapCreator";
 
 const Broadcasting = () => {
     const { t } = useGlobalContext();
@@ -34,7 +44,7 @@ const paymentValidationUrl = (invoice: string, preimage: string): string => {
     return url.toString();
 };
 
-const TransactionClaimed = () => {
+const TransactionClaimed = (props: { bridgeStatusLink?: JSX.Element }) => {
     const navigate = useNavigate();
 
     const { notify } = useGlobalContext();
@@ -83,28 +93,53 @@ const TransactionClaimed = () => {
         );
     });
 
+    const receiveAmount = () =>
+        formatAmount(
+            BigNumber(
+                (swap()!.dex?.position === SwapPosition.Post
+                    ? swap()!.dex?.quoteAmount
+                    : swap()!.receiveAmount) ?? 0,
+            ),
+            denomination(),
+            separator(),
+            getFinalAssetReceive(swap()!),
+        );
+
+    const receiveDenomination = () =>
+        formatDenomination(denomination(), getFinalAssetReceive(swap()!));
+
+    const postBridge = () => getPostBridgeDetail(swap()?.bridge);
+
     return (
         <div>
             <Show when={claimBroadcast() === true} fallback={<Broadcasting />}>
                 <h2>{t("congrats")}</h2>
-                <p>
-                    {t("successfully_swapped", {
-                        amount: formatAmount(
-                            BigNumber(
-                                (swap()!.dex?.position === SwapPosition.Post
-                                    ? swap()!.dex?.quoteAmount
-                                    : swap()!.receiveAmount) ?? 0,
-                            ),
-                            denomination(),
-                            separator(),
-                            getFinalAssetReceive(swap()!),
-                        ),
-                        denomination: formatDenomination(
-                            denomination(),
-                            getFinalAssetReceive(swap()!),
-                        ),
-                    })}
-                </p>
+                <Show
+                    when={postBridge()}
+                    fallback={
+                        <p>
+                            {t("successfully_swapped", {
+                                amount: receiveAmount(),
+                                denomination: receiveDenomination(),
+                            })}
+                        </p>
+                    }>
+                    {(bridge) => (
+                        <>
+                            <p>
+                                {t("bridge_transfer_pending", {
+                                    amount: receiveAmount(),
+                                    denomination: receiveDenomination(),
+                                    network:
+                                        getAssetNetwork(
+                                            bridge().destinationAsset,
+                                        ) ?? bridge().destinationAsset,
+                                })}
+                            </p>
+                            {props.bridgeStatusLink}
+                        </>
+                    )}
+                </Show>
                 <hr />
                 <span class="btn" onClick={() => navigate("/swap")}>
                     {t("new_swap")}

--- a/tests/pages/Pay.spec.tsx
+++ b/tests/pages/Pay.spec.tsx
@@ -3,9 +3,11 @@ import { useLocation } from "@solidjs/router";
 import { render, screen, waitFor } from "@solidjs/testing-library";
 import { OutputType } from "boltz-core";
 import { getLockupTransaction, getSwapStatus } from "boltz-swaps/client";
-import { SwapType } from "boltz-swaps/types";
+import { SwapPosition, SwapType } from "boltz-swaps/types";
 
-import { BTC, LBTC, LN } from "../../src/consts/Assets";
+import { config } from "../../src/config";
+import { config as mainnetConfig } from "../../src/configs/mainnet";
+import { BTC, LBTC, LN, USDT0 } from "../../src/consts/Assets";
 import {
     swapStatusFailed,
     swapStatusPending,
@@ -165,6 +167,9 @@ describe("Pay", () => {
             assetSend: LBTC,
             lockupDetails: {},
         });
+        config.assets!["USDT0-ETH"] ??= structuredClone(
+            mainnetConfig.assets!["USDT0-ETH"],
+        );
         mockUseLocation.mockReturnValue({
             hash: "",
             key: "",
@@ -378,6 +383,55 @@ describe("Pay", () => {
         const refundEta = await screen.findByTestId("refund-eta");
         const expectedDate = new Date(timeoutEta * 1000).toLocaleString();
         expect(refundEta).toHaveTextContent(expectedDate);
+    });
+
+    test("should show post-bridge status link directly below completed message", async () => {
+        const claimTx = "0xclaim";
+        const postBridgeSwap = {
+            id: "123",
+            type: SwapType.Reverse,
+            assetSend: BTC,
+            assetReceive: USDT0,
+            receiveAmount: 123_456,
+            claimTx,
+            bridge: {
+                kind: "oft",
+                sourceAsset: USDT0,
+                destinationAsset: "USDT0-ETH",
+                position: SwapPosition.Post,
+            },
+        } as ReverseSwap;
+
+        swapsGetItemMock.mockResolvedValue(postBridgeSwap);
+        mockGetSwapStatus.mockResolvedValue({
+            status: swapStatusSuccess.TransactionClaimed,
+        });
+        renderPay();
+        payContext.setSwap(postBridgeSwap);
+        payContext.setSwapStatus(swapStatusSuccess.TransactionClaimed);
+
+        const message = await screen.findByText(
+            /Swap complete!.*was sent via the Ethereum bridge/u,
+        );
+        const bridgeLink = (await screen.findByText(
+            dict.en.check_bridge_status,
+        )) as HTMLAnchorElement;
+        const newSwap = await screen.findByText(dict.en.new_swap);
+
+        expect(
+            message.compareDocumentPosition(bridgeLink) &
+                Node.DOCUMENT_POSITION_FOLLOWING,
+        ).toBeTruthy();
+        expect(
+            bridgeLink.compareDocumentPosition(newSwap) &
+                Node.DOCUMENT_POSITION_FOLLOWING,
+        ).toBeTruthy();
+        expect(screen.getAllByText(dict.en.check_bridge_status)).toHaveLength(
+            1,
+        );
+        expect(bridgeLink.href).toEqual(
+            `${config.layerZeroExplorerUrl}/tx/${claimTx}`,
+        );
     });
 
     test("should show refund button automatically when swap has timed out with UTXOs", async () => {

--- a/tests/status/TransactionClaimed.spec.tsx
+++ b/tests/status/TransactionClaimed.spec.tsx
@@ -1,9 +1,12 @@
 import { render, screen } from "@solidjs/testing-library";
-import { SwapType } from "boltz-swaps/types";
+import { SwapPosition, SwapType } from "boltz-swaps/types";
 
-import { BTC, LBTC, RBTC } from "../../src/consts/Assets";
+import { config } from "../../src/config";
+import { config as mainnetConfig } from "../../src/configs/mainnet";
+import { BTC, LBTC, RBTC, USDT0 } from "../../src/consts/Assets";
 import i18n from "../../src/i18n/i18n";
 import TransactionClaimed from "../../src/status/TransactionClaimed";
+import type { SomeSwap } from "../../src/utils/swapCreator";
 import { TestComponent, contextWrapper, payContext } from "../helper";
 
 vi.mock("../../packages/boltz-swaps/src/client.ts", () => ({
@@ -15,6 +18,9 @@ vi.mock("../../packages/boltz-swaps/src/client.ts", () => ({
 describe("TransactionClaimed", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        config.assets!["USDT0-ETH"] ??= structuredClone(
+            mainnetConfig.assets!["USDT0-ETH"],
+        );
     });
 
     test.each`
@@ -43,5 +49,38 @@ describe("TransactionClaimed", () => {
         await expect(
             screen.findByText(i18n.en.congrats),
         ).resolves.not.toBeUndefined();
+    });
+
+    test("explains post-bridge delivery is still in progress", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <TransactionClaimed />
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+        payContext.setSwap({
+            type: SwapType.Reverse,
+            assetReceive: USDT0,
+            receiveAmount: 123_456,
+            claimTx: "0xclaim",
+            bridge: {
+                kind: "oft",
+                sourceAsset: USDT0,
+                destinationAsset: "USDT0-ETH",
+                position: SwapPosition.Post,
+            },
+        } as unknown as SomeSwap);
+
+        await expect(
+            screen.findByText(
+                /Swap complete!.*was sent via the Ethereum bridge/u,
+            ),
+        ).resolves.not.toBeUndefined();
+        expect(screen.queryByText(/You successfully received/u)).toBeNull();
     });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the “swap complete” status to handle post-bridge delivery, showing a bridge transfer pending message with the destination network and an estimated completion delay.
  * Added (and correctly suppresses/updates) a bridge explorer link related to the post-bridge transaction state.
* **Localization**
  * Added the new `bridge_transfer_pending` translation across supported languages.
* **Tests**
  * Added coverage for post-bridge claimed UI, including message ordering and ensuring only the correct bridge link is rendered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->