### PR TITLE
test: E2E for ERC20 lockups and refunds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -130,6 +130,7 @@ jobs:
                   ETHEREUM_E2E_RPC_URL: ${{ vars.ETHEREUM_E2E_RPC_URL }}
                   CI: true
                   VITE_RSK_LOG_SCAN_ENDPOINT: "http://localhost:8545"
+                  VITE_ARBITRUM_LOG_SCAN_ENDPOINT: "http://localhost:18545"
               run:
                   bun run test:e2e -- --shard=${{ matrix.shardIndex }}/${{
                   matrix.shardTotal }}

--- a/e2e/arbitrum/erc20Lockup.spec.ts
+++ b/e2e/arbitrum/erc20Lockup.spec.ts
@@ -1,0 +1,120 @@
+import { erc20SwapAbi } from "boltz-swaps/generated/evm-abis";
+import {
+    type Hex,
+    type PublicClient,
+    createWalletClient,
+    getAddress,
+    http,
+    parseEventLogs,
+    parseUnits,
+} from "viem";
+
+import { injectWalletProvider } from "../fixtures/ethereum";
+import {
+    generateBitcoinBlock,
+    generateLiquidBlock,
+    getLiquidAddress,
+} from "../utils";
+import {
+    actionTimeout,
+    approveAndSend,
+    arbitrumE2eChain,
+    arbitrumRpcUrl,
+    clearEoaDelegation,
+    createSwap,
+    describeArbitrumE2e,
+    expect,
+    fundErc20FromWhale,
+    getRegtestTokenAddress,
+    getStablesE2eWalletAddress,
+    test,
+    testTimeout,
+    waitForLockupTxHash,
+} from "./shared";
+
+const tbtcFundingSource = getAddress(
+    process.env.TBTC_E2E_ARB_FUNDING_SOURCE ??
+        "0xCb198a55e2a88841E855bE4EAcaad99422416b33",
+);
+const tbtcSendAmount = "0.001";
+const tbtcFundingAmount = parseUnits("0.01", 18);
+
+const expectLockupTx = async (publicClient: PublicClient, txHash: Hex) => {
+    const receipt = await publicClient.waitForTransactionReceipt({
+        hash: txHash,
+        timeout: actionTimeout,
+    });
+    expect(receipt.status).toBe("success");
+
+    const [lockup] = parseEventLogs({
+        abi: erc20SwapAbi,
+        eventName: "Lockup",
+        logs: receipt.logs,
+    });
+    expect(lockup).toBeDefined();
+    expect(lockup.args.amount).toBeGreaterThan(0n);
+};
+
+describeArbitrumE2e("Arbitrum ERC20 lockup e2e", () => {
+    test.describe.configure({ mode: "serial" });
+
+    test.beforeEach(async () => {
+        await generateBitcoinBlock();
+        await generateLiquidBlock();
+    });
+
+    test("locks TBTC via Permit2 and claims an L-BTC chain swap", async ({
+        arbitrum,
+        page,
+    }) => {
+        test.setTimeout(testTimeout);
+
+        const walletAddress = await getStablesE2eWalletAddress(
+            arbitrum.publicClient,
+        );
+        const walletClient = createWalletClient({
+            account: walletAddress,
+            chain: arbitrumE2eChain,
+            transport: http(arbitrumRpcUrl(), { timeout: actionTimeout }),
+        });
+
+        await fundErc20FromWhale({
+            publicClient: arbitrum.publicClient,
+            chain: arbitrumE2eChain,
+            rpcUrl: arbitrum.rpcUrl,
+            token: getRegtestTokenAddress("TBTC"),
+            whale: tbtcFundingSource,
+            recipient: walletAddress,
+            amount: tbtcFundingAmount,
+        });
+        await clearEoaDelegation(arbitrum.publicClient, walletAddress);
+
+        await injectWalletProvider({
+            page,
+            publicClient: arbitrum.publicClient,
+            walletClient,
+            chain: arbitrumE2eChain,
+        });
+
+        const swapId = await createSwap(
+            page,
+            "TBTC",
+            "L-BTC",
+            await getLiquidAddress(),
+            tbtcSendAmount,
+            { walletAddress },
+        );
+
+        await approveAndSend(page, walletAddress);
+        await expectLockupTx(
+            arbitrum.publicClient,
+            await waitForLockupTxHash(page, swapId),
+        );
+
+        const claimed = page.locator("div[data-status='transaction.claimed']");
+        await expect(async () => {
+            await generateLiquidBlock();
+            await expect(claimed).toBeVisible({ timeout: 5_000 });
+        }).toPass({ timeout: actionTimeout });
+    });
+});

--- a/e2e/arbitrum/erc20Refund.spec.ts
+++ b/e2e/arbitrum/erc20Refund.spec.ts
@@ -1,0 +1,215 @@
+import type { Page } from "@playwright/test";
+import {
+    type Address,
+    createWalletClient,
+    getAddress,
+    http,
+    parseUnits,
+} from "viem";
+
+import { config } from "../../src/config";
+import dict from "../../src/i18n/i18n";
+import { injectWalletProvider } from "../fixtures/ethereum";
+import {
+    generateBitcoinBlock,
+    generateLiquidBlock,
+    getLiquidAddress,
+} from "../utils";
+import {
+    actionTimeout,
+    approveAndSend,
+    arbitrumE2eChain,
+    arbitrumRpcUrl,
+    clearEoaDelegation,
+    connectWallet,
+    createSwap,
+    describeArbitrumE2e,
+    expect,
+    fundErc20FromWhale,
+    getRegtestTokenAddress,
+    getStablesE2eWalletAddress,
+    getTokenBalance,
+    mineArbitrumBlocks,
+    quoteRequestTimeout,
+    test,
+    testTimeout,
+    waitForLockupTxHash,
+} from "./shared";
+
+const tbtcFundingSource = getAddress(
+    process.env.TBTC_E2E_ARB_FUNDING_SOURCE ??
+        "0xCb198a55e2a88841E855bE4EAcaad99422416b33",
+);
+const tbtcSendAmount = "0.001";
+const tbtcFundingAmount = parseUnits("0.01", 18);
+const timeoutBlocks = 400;
+
+const clearBrowserStorage = async (page: Page) => {
+    await page.evaluate(async () => {
+        window.localStorage.clear();
+
+        await Promise.all(
+            ["swaps", "lastUsedEvmIndex"].map(
+                (name) =>
+                    new Promise<void>((resolve, reject) => {
+                        const request = indexedDB.deleteDatabase(name);
+                        request.onsuccess = () => resolve();
+                        request.onerror = () => reject(request.error);
+                        request.onblocked = () =>
+                            reject(new Error(`deleting ${name} was blocked`));
+                    }),
+            ),
+        );
+    });
+
+    await page.reload();
+};
+
+// Block every claim path that reveals the preimage (cooperative, API broadcast,
+// and the explorer-broadcast fallback) so the TBTC lockup stays refundable.
+const blockChainSwapClaim = async (page: Page) => {
+    await page.route("**/v2/swap/chain/*/claim", (route) => route.abort());
+    await page.route("**/v2/chain/L-BTC/transaction", (route) => route.abort());
+
+    for (const explorer of config.assets?.["L-BTC"]?.blockExplorerApis ?? []) {
+        for (const base of [explorer.normal, explorer.tor]) {
+            if (base !== undefined) {
+                await page.route(`${base}/tx`, (route) => route.abort());
+            }
+        }
+    }
+};
+
+const startExternalRescue = async (page: Page) => {
+    await page.goto("/rescue");
+    await page
+        .getByRole("button", { name: dict.en.rescue_external_swap })
+        .click();
+};
+
+// Retry the upload + scan until the swap shows refundable; the scan never refetches on its own.
+const rescueAndSelectRefundableSwap = async (
+    page: Page,
+    walletAddress: Address,
+    rescueFilePath: string,
+) => {
+    const refundableSwap = page
+        .locator(".rescue-external-results .swaplist-item")
+        .filter({
+            has: page.getByRole("link", {
+                name: dict.en.refund,
+                exact: true,
+            }),
+        })
+        .first();
+
+    await expect(async () => {
+        await startExternalRescue(page);
+        await page.getByTestId("refundUpload").setInputFiles(rescueFilePath);
+        await connectWallet(page, walletAddress);
+        await page
+            .getByRole("button", { name: dict.en.rescue, exact: true })
+            .click();
+        await expect(refundableSwap).toBeVisible({
+            timeout: quoteRequestTimeout,
+        });
+    }).toPass({ timeout: actionTimeout, intervals: [2_000, 5_000, 10_000] });
+
+    await refundableSwap.click();
+};
+
+describeArbitrumE2e("Arbitrum ERC20 refund e2e", () => {
+    test.describe.configure({ mode: "serial" });
+
+    test.beforeEach(async () => {
+        await generateBitcoinBlock();
+        await generateLiquidBlock();
+    });
+
+    test("refunds an expired TBTC chain swap via external rescue", async ({
+        arbitrum,
+        page,
+    }, testInfo) => {
+        test.setTimeout(testTimeout);
+        const rescueFilePath = testInfo.outputPath("rescue-file.json");
+
+        const walletAddress = await getStablesE2eWalletAddress(
+            arbitrum.publicClient,
+        );
+        const walletClient = createWalletClient({
+            account: walletAddress,
+            chain: arbitrumE2eChain,
+            transport: http(arbitrumRpcUrl(), { timeout: actionTimeout }),
+        });
+        const token = getRegtestTokenAddress("TBTC");
+
+        await fundErc20FromWhale({
+            publicClient: arbitrum.publicClient,
+            chain: arbitrumE2eChain,
+            rpcUrl: arbitrum.rpcUrl,
+            token,
+            whale: tbtcFundingSource,
+            recipient: walletAddress,
+            amount: tbtcFundingAmount,
+        });
+        await clearEoaDelegation(arbitrum.publicClient, walletAddress);
+
+        await injectWalletProvider({
+            page,
+            publicClient: arbitrum.publicClient,
+            walletClient,
+            chain: arbitrumE2eChain,
+        });
+
+        await blockChainSwapClaim(page);
+
+        const swapId = await createSwap(
+            page,
+            "TBTC",
+            "L-BTC",
+            await getLiquidAddress(),
+            tbtcSendAmount,
+            { walletAddress, rescueFilePath },
+        );
+
+        await approveAndSend(page, walletAddress);
+        await waitForLockupTxHash(page, swapId);
+        const balanceAfterLockup = await getTokenBalance(
+            arbitrum.publicClient,
+            token,
+            walletAddress,
+        );
+
+        await clearBrowserStorage(page);
+        await mineArbitrumBlocks(arbitrum.publicClient, timeoutBlocks);
+
+        await rescueAndSelectRefundableSwap(
+            page,
+            walletAddress,
+            rescueFilePath,
+        );
+
+        const refundButton = page.getByRole("button", {
+            name: dict.en.refund,
+            exact: true,
+        });
+        await expect(refundButton).toBeVisible({ timeout: actionTimeout });
+        await refundButton.click();
+
+        await expect(page.getByText(dict.en.refunded)).toBeVisible({
+            timeout: actionTimeout,
+        });
+
+        await expect
+            .poll(
+                async () =>
+                    await getTokenBalance(
+                        arbitrum.publicClient,
+                        token,
+                        walletAddress,
+                    ),
+                { timeout: actionTimeout },
+            )
+            .toBeGreaterThan(balanceAfterLockup);
+    });
+});

--- a/e2e/arbitrum/lbtcUsdt0.spec.ts
+++ b/e2e/arbitrum/lbtcUsdt0.spec.ts
@@ -5,308 +5,47 @@ import {
     type Chain,
     type Hex,
     type PublicClient,
-    createPublicClient,
     createWalletClient,
-    defineChain,
     getAddress,
     http,
     isAddressEqual,
-    parseAbi,
     parseEther,
     parseEventLogs,
     parseUnits,
 } from "viem";
 
-import { config } from "../../src/config";
 import dict from "../../src/i18n/i18n";
-import { expect, shouldRunArbitrumE2e, test } from "../fixtures/arbitrum";
 import { injectWalletProvider } from "../fixtures/ethereum";
 import {
     elementsSendToAddress,
     generateBitcoinBlock,
     generateLiquidBlock,
-    getCurrentSwapId,
     getLiquidAddress,
-    verifyRescueFile,
 } from "../utils";
-
-const describeArbitrumE2e = (title: string, callback: () => void) => {
-    if (shouldRunArbitrumE2e()) {
-        test.describe(title, callback);
-    } else {
-        test.describe.skip(title, callback);
-    }
-};
-
-const erc20Abi = parseAbi([
-    "function balanceOf(address owner) view returns (uint256)",
-    "function transfer(address recipient, uint256 amount) returns (bool)",
-]);
-
-const lbtcSendAmount = "0.001";
-const usdt0EthSendAmount = "40";
-const actionTimeout = 60_000;
-const probeTimeout = 1_000;
-const quoteRequestTimeout = 10_000;
-const testTimeout = 150_000;
-
-// Whale holding USDT0-ETH (mainnet USDT) on the Ethereum fork; impersonated to
-// fund the test wallet, mirroring the backend TBTC funding in the fixture.
-const stablesFundingSource = getAddress(
-    process.env.STABLES_E2E_USDT0_ETH_FUNDING_SOURCE ??
-        "0xF977814e90dA44bFA03b6295A0616a897441aceC",
-);
-const stablesFundingAmount = parseUnits("500", 6);
-
-const ethereumRpcUrl = () =>
-    `http://127.0.0.1:${process.env.ETHEREUM_E2E_PORT ?? "18546"}`;
-
-const ethereumE2eChain = defineChain({
-    id: 1,
-    name: "Ethereum E2E",
-    nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
-    rpcUrls: { default: { http: [ethereumRpcUrl()] } },
-});
-
-const getRegtestTokenAddress = (
-    asset: "USDT0" | "USDT0-ETH" | "TBTC",
-): Address => {
-    const address = config.assets?.[asset]?.token?.address;
-    if (address === undefined) {
-        throw new Error(`missing ${asset} token address`);
-    }
-
-    return getAddress(address);
-};
-
-const createEthereumClient = () => {
-    const rpcUrl = ethereumRpcUrl();
-    return createPublicClient({
-        chain: {
-            ...ethereumE2eChain,
-            rpcUrls: { default: { http: [rpcUrl] } },
-        },
-        transport: http(rpcUrl, { timeout: actionTimeout }),
-    });
-};
-
-const waitForEthereumRpc = async (publicClient: PublicClient) => {
-    await expect
-        .poll(
-            async () => {
-                try {
-                    return await publicClient.getChainId();
-                } catch {
-                    return 0;
-                }
-            },
-            {
-                timeout: actionTimeout,
-                message: "Ethereum e2e RPC is ready",
-            },
-        )
-        .toBe(ethereumE2eChain.id);
-};
-
-const getStablesE2eAccountIndex = () => {
-    const index = Number(process.env.STABLES_E2E_ACCOUNT_INDEX ?? "1");
-    if (!Number.isInteger(index) || index < 0) {
-        throw new Error(
-            "STABLES_E2E_ACCOUNT_INDEX must be a non-negative integer",
-        );
-    }
-
-    return index;
-};
-
-const getStablesE2eWalletAddress = async (
-    publicClient: PublicClient,
-): Promise<Address> => {
-    const accounts = (await publicClient.request({
-        method: "eth_accounts",
-        params: [],
-    } as never)) as Address[];
-    const walletAddress = accounts[getStablesE2eAccountIndex()];
-    if (walletAddress === undefined) {
-        throw new Error("STABLES_E2E_ACCOUNT_INDEX is not available in Anvil");
-    }
-
-    return getAddress(walletAddress);
-};
-
-const waitForDexQuote = async (args: {
-    tokenIn: Address;
-    tokenOut: Address;
-    amountIn: bigint;
-    label: string;
-}) => {
-    const params = new URLSearchParams({
-        tokenIn: args.tokenIn,
-        tokenOut: args.tokenOut,
-        amountIn: args.amountIn.toString(),
-    });
-    const url = `${config.apiUrl.normal}/v2/quote/ARB/in?${params}`;
-
-    await expect
-        .poll(
-            async () => {
-                try {
-                    const response = await fetch(url, {
-                        signal: AbortSignal.timeout(quoteRequestTimeout),
-                    });
-                    if (!response.ok) {
-                        return 0;
-                    }
-                    const quotes = await response.json();
-                    return Array.isArray(quotes) ? quotes.length : 0;
-                } catch {
-                    return 0;
-                }
-            },
-            {
-                timeout: actionTimeout,
-                message: `quote not ready for ${args.label}`,
-            },
-        )
-        .toBeGreaterThan(0);
-};
-
-type StoredBridgeSwap = {
-    bridge?: { txHash?: Hex };
-};
-
-const getStoredSwap = async (
-    page: Page,
-    id: string,
-): Promise<StoredBridgeSwap | null> =>
-    await page.evaluate(
-        async ({ id }) =>
-            await new Promise<StoredBridgeSwap | null>((resolve, reject) => {
-                const request = indexedDB.open("swaps");
-                request.onerror = () => reject(request.error);
-                request.onsuccess = () => {
-                    const db = request.result;
-                    const transaction = db.transaction(
-                        "keyvaluepairs",
-                        "readonly",
-                    );
-                    const getRequest = transaction
-                        .objectStore("keyvaluepairs")
-                        .get(id);
-                    getRequest.onsuccess = () => {
-                        db.close();
-                        resolve(getRequest.result ?? null);
-                    };
-                    getRequest.onerror = () => reject(getRequest.error);
-                };
-            }),
-        { id },
-    );
-
-const waitForBridgeTxHash = async (page: Page, id: string): Promise<Hex> => {
-    await expect
-        .poll(async () => (await getStoredSwap(page, id))?.bridge?.txHash, {
-            timeout: actionTimeout,
-        })
-        .toMatch(/^0x[0-9a-fA-F]{64}$/);
-
-    return (await getStoredSwap(page, id))!.bridge!.txHash!;
-};
-
-const bridgeCanonicalAsset = (asset: string) =>
-    asset.startsWith("USDT0") ? "USDT0" : asset;
-
-const chooseAsset = async (page: Page, asset: string) => {
-    const canonical = bridgeCanonicalAsset(asset);
-    await page.getByTestId(`select-${canonical}`).click();
-
-    if (
-        canonical !== asset ||
-        (await page
-            .getByTestId("network-back")
-            .isVisible({ timeout: probeTimeout })
-            .catch(() => false))
-    ) {
-        await page.getByTestId(`select-${asset}`).click();
-    }
-
-    await expect(page.locator(".asset-select-overlay")).toBeHidden({
-        timeout: actionTimeout,
-    });
-};
-
-const selectAssets = async (
-    page: Page,
-    sendAsset: string,
-    receiveAsset: string,
-) => {
-    const assetSelectors = page.locator("div[class^='asset asset-']");
-    await assetSelectors.first().click();
-    await chooseAsset(page, sendAsset);
-    await assetSelectors.last().click();
-    await chooseAsset(page, receiveAsset);
-};
-
-const createSwap = async (
-    page: Page,
-    sendAsset: string,
-    receiveAsset: string,
-    destinationAddress: string,
-    sendAmount: string,
-    options?: { skipGoto?: boolean; walletAddress?: Address },
-) => {
-    if (options?.skipGoto !== true) {
-        await page.goto("/");
-    }
-    await selectAssets(page, sendAsset, receiveAsset);
-    await page.getByTestId("onchainAddress").fill(destinationAddress);
-    await page.getByTestId("sendAmount").fill(sendAmount);
-
-    const receiveAmount = page.getByTestId("receiveAmount");
-    await expect(receiveAmount).not.toHaveValue("", {
-        timeout: actionTimeout,
-    });
-    await expect(receiveAmount).not.toHaveValue("0", {
-        timeout: actionTimeout,
-    });
-
-    if (options?.walletAddress !== undefined) {
-        await connectWallet(page, options.walletAddress);
-    }
-
-    const createButton = page.getByTestId("create-swap-button");
-    await expect(createButton).toBeEnabled({ timeout: actionTimeout });
-    await createButton.click();
-
-    const downloadButton = page.getByRole("button", {
-        name: dict.en.download_new_key,
-    });
-    const swapReady = page
-        .locator("div[data-status='swap.created']")
-        .or(page.locator("div[data-status='invoice.set']"));
-
-    await expect(swapReady.or(downloadButton)).toBeVisible({
-        timeout: actionTimeout,
-    });
-    if (await downloadButton.isVisible().catch(() => false)) {
-        await verifyRescueFile(page);
-    }
-    await expect(swapReady).toBeVisible({ timeout: actionTimeout });
-
-    return getCurrentSwapId(page);
-};
-
-const getTokenBalance = async (
-    publicClient: PublicClient,
-    token: Address,
-    owner: Address,
-) =>
-    await publicClient.readContract({
-        address: token,
-        abi: erc20Abi,
-        functionName: "balanceOf",
-        args: [owner],
-    });
+import {
+    actionTimeout,
+    approveAndSend,
+    connectWallet,
+    createEthereumClient,
+    createSwap,
+    describeArbitrumE2e,
+    erc20Abi,
+    ethereumE2eChain,
+    ethereumRpcUrl,
+    expect,
+    getRegtestTokenAddress,
+    getStablesE2eWalletAddress,
+    getTokenBalance,
+    lbtcSendAmount,
+    stablesFundingAmount,
+    stablesFundingSource,
+    test,
+    testTimeout,
+    usdt0EthSendAmount,
+    waitForBridgeTxHash,
+    waitForDexQuote,
+    waitForEthereumRpc,
+} from "./shared";
 
 // Funds the test wallet with gas + USDT0-ETH by impersonating a whale on the
 // Anvil fork, so the test does not depend on an external funding container.
@@ -376,53 +115,6 @@ const expectEthereumWalletReady = async (
     expect(
         await getTokenBalance(publicClient, token, owner),
     ).toBeGreaterThanOrEqual(parseUnits(usdt0EthSendAmount, 6));
-};
-
-const connectWallet = async (page: Page, walletAddress: Address) => {
-    const connect = page.getByRole("button", {
-        name: new RegExp(dict.en.connect_wallet, "i"),
-    });
-    const connectedAddress = page.locator(`text=${walletAddress.slice(0, 8)}`);
-
-    await expect(connectedAddress.or(connect)).toBeVisible({
-        timeout: actionTimeout,
-    });
-
-    if (await connect.isVisible().catch(() => false)) {
-        await connect.click();
-
-        const modal = page.locator("[data-testid='wallet-connect-modal']");
-        if (
-            await modal.isVisible({ timeout: probeTimeout }).catch(() => false)
-        ) {
-            await modal
-                .locator(".provider-modal-entry-wrapper")
-                .filter({ hasText: /metamask|browser native/i })
-                .first()
-                .click();
-        }
-    }
-
-    await expect(connectedAddress).toBeVisible({
-        timeout: actionTimeout,
-    });
-};
-
-const clickSendBridge = async (page: Page, walletAddress: Address) => {
-    await connectWallet(page, walletAddress);
-
-    const approve = page.getByRole("button", { name: /^approve$/i });
-    const send = page.getByRole("button", { name: /^send$/i });
-
-    await expect(send.or(approve)).toBeVisible({
-        timeout: actionTimeout,
-    });
-    if (await approve.isVisible().catch(() => false)) {
-        await approve.click();
-    }
-
-    await expect(send).toBeEnabled({ timeout: actionTimeout });
-    await send.click();
 };
 
 const expectOftSendTx = async (
@@ -654,7 +346,7 @@ describeArbitrumE2e("Arbitrum stablecoin e2e", () => {
             usdt0EthSendAmount,
             { walletAddress },
         );
-        await clickSendBridge(page, walletAddress);
+        await approveAndSend(page, walletAddress);
 
         await expectOftSendTx(
             ethereum,

--- a/e2e/arbitrum/shared.ts
+++ b/e2e/arbitrum/shared.ts
@@ -1,0 +1,514 @@
+import type { Locator, Page } from "@playwright/test";
+import {
+    type Address,
+    type Hex,
+    type PublicClient,
+    type WalletClient,
+    createPublicClient,
+    createWalletClient,
+    defineChain,
+    getAddress,
+    http,
+    parseAbi,
+    parseEther,
+    parseUnits,
+} from "viem";
+
+import { config } from "../../src/config";
+import dict from "../../src/i18n/i18n";
+import { expect, shouldRunArbitrumE2e, test } from "../fixtures/arbitrum";
+import { getCurrentSwapId, verifyRescueFile } from "../utils";
+
+export { expect, shouldRunArbitrumE2e, test };
+
+export const describeArbitrumE2e = (title: string, callback: () => void) => {
+    if (shouldRunArbitrumE2e()) {
+        test.describe(title, callback);
+    } else {
+        test.describe.skip(title, callback);
+    }
+};
+
+export const erc20Abi = parseAbi([
+    "function balanceOf(address owner) view returns (uint256)",
+    "function transfer(address recipient, uint256 amount) returns (bool)",
+]);
+
+export const lbtcSendAmount = "0.001";
+export const usdt0EthSendAmount = "40";
+export const actionTimeout = 60_000;
+export const probeTimeout = 1_000;
+export const quoteRequestTimeout = 10_000;
+export const testTimeout = 150_000;
+
+const isVisibleWithin = (locator: Locator, timeout = probeTimeout) =>
+    locator
+        .waitFor({ state: "visible", timeout })
+        .then(() => true)
+        .catch(() => false);
+
+export const stablesFundingSource = getAddress(
+    process.env.STABLES_E2E_USDT0_ETH_FUNDING_SOURCE ??
+        "0xF977814e90dA44bFA03b6295A0616a897441aceC",
+);
+export const stablesFundingAmount = parseUnits("500", 6);
+
+export const arbitrumRpcUrl = () =>
+    `http://127.0.0.1:${process.env.ARBITRUM_E2E_PORT ?? "18545"}`;
+
+export const ethereumRpcUrl = () =>
+    `http://127.0.0.1:${process.env.ETHEREUM_E2E_PORT ?? "18546"}`;
+
+export const arbitrumE2eChain = defineChain({
+    id: 42161,
+    name: "Arbitrum One E2E",
+    nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+    rpcUrls: { default: { http: [arbitrumRpcUrl()] } },
+});
+
+export const ethereumE2eChain = defineChain({
+    id: 1,
+    name: "Ethereum E2E",
+    nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+    rpcUrls: { default: { http: [ethereumRpcUrl()] } },
+});
+
+export const getRegtestTokenAddress = (
+    asset: "USDT0" | "USDT0-ETH" | "TBTC",
+): Address => {
+    const address = config.assets?.[asset]?.token?.address;
+    if (address === undefined) {
+        throw new Error(`missing ${asset} token address`);
+    }
+
+    return getAddress(address);
+};
+
+export const createEthereumClient = () => {
+    const rpcUrl = ethereumRpcUrl();
+    return createPublicClient({
+        chain: {
+            ...ethereumE2eChain,
+            rpcUrls: { default: { http: [rpcUrl] } },
+        },
+        transport: http(rpcUrl, { timeout: actionTimeout }),
+    });
+};
+
+export const waitForEthereumRpc = async (publicClient: PublicClient) => {
+    await expect
+        .poll(
+            async () => {
+                try {
+                    return await publicClient.getChainId();
+                } catch {
+                    return 0;
+                }
+            },
+            {
+                timeout: actionTimeout,
+                message: "Ethereum e2e RPC is ready",
+            },
+        )
+        .toBe(ethereumE2eChain.id);
+};
+
+export const getStablesE2eAccountIndex = () => {
+    const index = Number(process.env.STABLES_E2E_ACCOUNT_INDEX ?? "1");
+    if (!Number.isInteger(index) || index < 0) {
+        throw new Error(
+            "STABLES_E2E_ACCOUNT_INDEX must be a non-negative integer",
+        );
+    }
+
+    return index;
+};
+
+export const getStablesE2eWalletAddress = async (
+    publicClient: PublicClient,
+): Promise<Address> => {
+    const accounts = (await publicClient.request({
+        method: "eth_accounts",
+        params: [],
+    } as never)) as Address[];
+    const walletAddress = accounts[getStablesE2eAccountIndex()];
+    if (walletAddress === undefined) {
+        throw new Error("STABLES_E2E_ACCOUNT_INDEX is not available in Anvil");
+    }
+
+    return getAddress(walletAddress);
+};
+
+export const waitForDexQuote = async (args: {
+    tokenIn: Address;
+    tokenOut: Address;
+    amountIn: bigint;
+    label: string;
+}) => {
+    const params = new URLSearchParams({
+        tokenIn: args.tokenIn,
+        tokenOut: args.tokenOut,
+        amountIn: args.amountIn.toString(),
+    });
+    const url = `${config.apiUrl.normal}/v2/quote/ARB/in?${params}`;
+
+    await expect
+        .poll(
+            async () => {
+                try {
+                    const response = await fetch(url, {
+                        signal: AbortSignal.timeout(quoteRequestTimeout),
+                    });
+                    if (!response.ok) {
+                        return 0;
+                    }
+                    const quotes = await response.json();
+                    return Array.isArray(quotes) ? quotes.length : 0;
+                } catch {
+                    return 0;
+                }
+            },
+            {
+                timeout: actionTimeout,
+                message: `quote not ready for ${args.label}`,
+            },
+        )
+        .toBeGreaterThan(0);
+};
+
+type StoredSwap = {
+    bridge?: { txHash?: Hex };
+    lockupTx?: Hex;
+    commitmentLockupTxHash?: Hex;
+};
+
+export const getStoredSwap = async (
+    page: Page,
+    id: string,
+): Promise<StoredSwap | null> =>
+    await page.evaluate(
+        async ({ id }) => {
+            const databases = await indexedDB.databases();
+            if (!databases.some((db) => db.name === "swaps")) {
+                return null;
+            }
+
+            return await new Promise<StoredSwap | null>((resolve, reject) => {
+                const request = indexedDB.open("swaps");
+                request.onerror = () => reject(request.error);
+                request.onsuccess = () => {
+                    const db = request.result;
+                    // Store is created lazily; guard so a missing-store throw can't hang the promise.
+                    if (!db.objectStoreNames.contains("keyvaluepairs")) {
+                        db.close();
+                        resolve(null);
+                        return;
+                    }
+                    try {
+                        const transaction = db.transaction(
+                            "keyvaluepairs",
+                            "readonly",
+                        );
+                        transaction.onerror = () => {
+                            db.close();
+                            reject(transaction.error);
+                        };
+                        const getRequest = transaction
+                            .objectStore("keyvaluepairs")
+                            .get(id);
+                        getRequest.onsuccess = () => {
+                            db.close();
+                            resolve(getRequest.result ?? null);
+                        };
+                        getRequest.onerror = () => {
+                            db.close();
+                            reject(getRequest.error);
+                        };
+                    } catch (error) {
+                        db.close();
+                        reject(error);
+                    }
+                };
+            });
+        },
+        { id },
+    );
+
+export const waitForBridgeTxHash = async (
+    page: Page,
+    id: string,
+): Promise<Hex> => {
+    await expect
+        .poll(async () => (await getStoredSwap(page, id))?.bridge?.txHash, {
+            timeout: actionTimeout,
+        })
+        .toMatch(/^0x[0-9a-fA-F]{64}$/);
+
+    return (await getStoredSwap(page, id))!.bridge!.txHash!;
+};
+
+export const waitForLockupTxHash = async (
+    page: Page,
+    id: string,
+): Promise<Hex> => {
+    await expect
+        .poll(
+            async () => {
+                const swap = await getStoredSwap(page, id);
+                return swap?.lockupTx ?? swap?.commitmentLockupTxHash;
+            },
+            { timeout: actionTimeout },
+        )
+        .toMatch(/^0x[0-9a-fA-F]{64}$/);
+
+    const swap = await getStoredSwap(page, id);
+    return (swap!.lockupTx ?? swap!.commitmentLockupTxHash)!;
+};
+
+const bridgeCanonicalAsset = (asset: string) =>
+    asset.startsWith("USDT0") ? "USDT0" : asset;
+
+export const chooseAsset = async (page: Page, asset: string) => {
+    const canonical = bridgeCanonicalAsset(asset);
+    await page.getByTestId(`select-${canonical}`).click();
+
+    if (
+        canonical !== asset ||
+        (await isVisibleWithin(page.getByTestId("network-back")))
+    ) {
+        await page.getByTestId(`select-${asset}`).click();
+    }
+
+    await expect(page.locator(".asset-select-overlay")).toBeHidden({
+        timeout: actionTimeout,
+    });
+};
+
+export const selectAssets = async (
+    page: Page,
+    sendAsset: string,
+    receiveAsset: string,
+) => {
+    const assetSelectors = page.locator("div[class^='asset asset-']");
+    await assetSelectors.first().click();
+    await chooseAsset(page, sendAsset);
+    await assetSelectors.last().click();
+    await chooseAsset(page, receiveAsset);
+};
+
+export const saveRescueFile = async (page: Page, path: string) => {
+    const downloadPromise = page.waitForEvent("download", {
+        timeout: actionTimeout,
+    });
+    await page.getByRole("button", { name: dict.en.download_new_key }).click();
+    await (await downloadPromise).saveAs(path);
+
+    const upload = page.getByTestId("rescueFileUpload");
+    await expect(upload).toBeVisible({ timeout: actionTimeout });
+    await upload.setInputFiles(path);
+    await expect(upload).toBeHidden({ timeout: actionTimeout });
+};
+
+export const createSwap = async (
+    page: Page,
+    sendAsset: string,
+    receiveAsset: string,
+    destinationAddress: string,
+    sendAmount: string,
+    options?: {
+        skipGoto?: boolean;
+        walletAddress?: Address;
+        rescueFilePath?: string;
+    },
+) => {
+    if (options?.skipGoto !== true) {
+        await page.goto("/");
+    }
+    await selectAssets(page, sendAsset, receiveAsset);
+    await page.getByTestId("onchainAddress").fill(destinationAddress);
+    await page.getByTestId("sendAmount").fill(sendAmount);
+
+    const receiveAmount = page.getByTestId("receiveAmount");
+    await expect(receiveAmount).not.toHaveValue("", {
+        timeout: actionTimeout,
+    });
+    await expect(receiveAmount).not.toHaveValue("0", {
+        timeout: actionTimeout,
+    });
+
+    if (options?.walletAddress !== undefined) {
+        await connectWallet(page, options.walletAddress);
+    }
+
+    const createButton = page.getByTestId("create-swap-button");
+    await expect(createButton).toBeEnabled({ timeout: actionTimeout });
+    await createButton.click();
+
+    const downloadButton = page.getByRole("button", {
+        name: dict.en.download_new_key,
+    });
+    const swapReady = page
+        .locator("div[data-status='swap.created']")
+        .or(page.locator("div[data-status='invoice.set']"));
+
+    await expect(swapReady.or(downloadButton).first()).toBeVisible({
+        timeout: actionTimeout,
+    });
+    if (await downloadButton.isVisible().catch(() => false)) {
+        if (options?.rescueFilePath !== undefined) {
+            await saveRescueFile(page, options.rescueFilePath);
+        } else {
+            await verifyRescueFile(page);
+        }
+    }
+    await expect(swapReady).toBeVisible({ timeout: actionTimeout });
+
+    return getCurrentSwapId(page);
+};
+
+export const getTokenBalance = async (
+    publicClient: PublicClient,
+    token: Address,
+    owner: Address,
+) =>
+    await publicClient.readContract({
+        address: token,
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [owner],
+    });
+
+export const fundErc20FromWhale = async (args: {
+    publicClient: PublicClient;
+    chain: typeof arbitrumE2eChain;
+    rpcUrl: string;
+    token: Address;
+    whale: Address;
+    recipient: Address;
+    amount: bigint;
+    gasRecipientAmount?: bigint;
+}) => {
+    const { publicClient, chain, rpcUrl, token, whale, recipient, amount } =
+        args;
+
+    const tokenCode = await publicClient.getCode({ address: token });
+    if (tokenCode === undefined || tokenCode === "0x") {
+        throw new Error(`fork is missing token contract ${token}`);
+    }
+
+    // Fund gas before the balance early-return so later steps can always pay.
+    await publicClient.request({
+        method: "anvil_setBalance" as never,
+        params: [
+            recipient,
+            "0x" + (args.gasRecipientAmount ?? parseEther("10")).toString(16),
+        ] as never,
+    });
+
+    if ((await getTokenBalance(publicClient, token, recipient)) >= amount) {
+        return;
+    }
+
+    if ((await getTokenBalance(publicClient, token, whale)) < amount) {
+        throw new Error(`funding whale ${whale} has insufficient balance`);
+    }
+
+    await publicClient.request({
+        method: "anvil_setBalance" as never,
+        params: [whale, "0x" + parseEther("1").toString(16)] as never,
+    });
+    await publicClient.request({
+        method: "anvil_impersonateAccount" as never,
+        params: [whale] as never,
+    });
+
+    try {
+        const walletClient = createWalletClient({
+            account: whale,
+            chain,
+            transport: http(rpcUrl, { timeout: actionTimeout }),
+        });
+        const hash = await walletClient.writeContract({
+            address: token,
+            abi: erc20Abi,
+            functionName: "transfer",
+            args: [recipient, amount],
+        });
+        await publicClient.waitForTransactionReceipt({ hash });
+    } finally {
+        await publicClient.request({
+            method: "anvil_stopImpersonatingAccount" as never,
+            params: [whale] as never,
+        });
+    }
+};
+
+// Clears an EIP-7702 delegation inherited from forked mainnet state, which would
+// otherwise make Permit2 verify the lockup permit via EIP-1271 instead of ECDSA.
+export const clearEoaDelegation = async (
+    publicClient: PublicClient,
+    address: Address,
+) => {
+    await publicClient.request({
+        method: "anvil_setCode" as never,
+        params: [address, "0x"] as never,
+    });
+};
+
+// Mines blocks on the Arbitrum fork (anvil-arb), not the local RSK Anvil.
+export const mineArbitrumBlocks = async (
+    publicClient: PublicClient,
+    blocks: number,
+) => {
+    await publicClient.request({
+        method: "anvil_mine" as never,
+        params: ["0x" + blocks.toString(16)] as never,
+    });
+};
+
+export const connectWallet = async (page: Page, walletAddress: Address) => {
+    const connect = page.getByRole("button", {
+        name: new RegExp(dict.en.connect_wallet, "i"),
+    });
+    const connectedAddress = page.locator(`text=${walletAddress.slice(0, 8)}`);
+
+    await expect(connectedAddress.or(connect)).toBeVisible({
+        timeout: actionTimeout,
+    });
+
+    if (await connect.isVisible().catch(() => false)) {
+        await connect.click();
+
+        const modal = page.locator("[data-testid='wallet-connect-modal']");
+        if (await isVisibleWithin(modal)) {
+            await modal
+                .locator(".provider-modal-entry-wrapper")
+                .filter({ hasText: /metamask|browser native/i })
+                .first()
+                .click();
+        }
+    }
+
+    await expect(connectedAddress).toBeVisible({
+        timeout: actionTimeout,
+    });
+};
+
+export const approveAndSend = async (page: Page, walletAddress: Address) => {
+    await connectWallet(page, walletAddress);
+
+    const approve = page.getByRole("button", { name: /^approve$/i });
+    const send = page.getByRole("button", { name: /^send$/i });
+
+    await expect(send.or(approve).first()).toBeVisible({
+        timeout: actionTimeout,
+    });
+    if (await approve.isVisible().catch(() => false)) {
+        await approve.click();
+    }
+
+    await expect(send).toBeEnabled({ timeout: actionTimeout });
+    await send.click();
+};
+
+export type { Address, Hex, PublicClient, WalletClient };

--- a/src/components/SwapExecutionWorker.tsx
+++ b/src/components/SwapExecutionWorker.tsx
@@ -169,7 +169,7 @@ const usesManualCctpReceive = (
     swap.bridge.position === SwapPosition.Pre &&
     swap.bridge.destinationAsset === USDC;
 
-const needsCommitmentPost = (
+export const needsCommitmentPost = (
     swap: SomeSwap | null | undefined,
 ): swap is SomeSwap & { commitmentLockupTxHash: string } =>
     swap !== undefined &&

--- a/src/status/TransactionConfirmed.tsx
+++ b/src/status/TransactionConfirmed.tsx
@@ -655,7 +655,7 @@ const Amount = (props: {
     );
 };
 
-const AutoClaimHops = (props: {
+export const AutoClaimHops = (props: {
     amount: number;
     swapId: string;
     gasAbstraction: GasAbstractionType;

--- a/tests/components/SwapExecutionWorker.spec.tsx
+++ b/tests/components/SwapExecutionWorker.spec.tsx
@@ -12,6 +12,7 @@ import {
 
 import type * as LibProviderModule from "../../packages/boltz-swaps/src/evm/provider";
 import { config as runtimeConfig } from "../../src/config";
+import { swapStatusPending } from "../../src/consts/SwapStatus";
 
 let currentSwap: Record<string, unknown>;
 let mockNetworkTransport = "evm";
@@ -421,7 +422,7 @@ vi.mock("boltz-swaps/evm", async (importActual) => ({
     createAssetProvider: mockCreateAssetProvider,
 }));
 
-const { SwapExecutionWorker } =
+const { SwapExecutionWorker, needsCommitmentPost } =
     await import("../../src/components/SwapExecutionWorker");
 const oftUtils = await import("boltz-swaps/oft");
 const quoter = await import("../../src/utils/quoter");
@@ -479,6 +480,59 @@ const buildCctpMessage = ({
         "00".repeat(32);
     return `0x${header}${body}`;
 };
+
+const makeCommitmentSwap = (overrides: Record<string, unknown>) =>
+    ({
+        commitmentLockupTxHash: "0xcommitment",
+        commitmentSignatureSubmitted: false,
+        status: swapStatusPending.SwapCreated,
+        ...overrides,
+    }) as unknown as Parameters<typeof needsCommitmentPost>[0];
+
+describe("needsCommitmentPost", () => {
+    test("true when the commitment lockup is posted, the signature is pending, and the status is still pending", () => {
+        expect(needsCommitmentPost(makeCommitmentSwap({}))).toBe(true);
+        expect(
+            needsCommitmentPost(
+                makeCommitmentSwap({ status: swapStatusPending.InvoiceSet }),
+            ),
+        ).toBe(true);
+        expect(
+            needsCommitmentPost(makeCommitmentSwap({ status: undefined })),
+        ).toBe(true);
+    });
+
+    test("false when there is no commitment lockup tx hash", () => {
+        expect(
+            needsCommitmentPost(
+                makeCommitmentSwap({ commitmentLockupTxHash: undefined }),
+            ),
+        ).toBe(false);
+    });
+
+    test("false when the commitment signature was already submitted", () => {
+        expect(
+            needsCommitmentPost(
+                makeCommitmentSwap({ commitmentSignatureSubmitted: true }),
+            ),
+        ).toBe(false);
+    });
+
+    test("false when the swap progressed past a pending-commitment status", () => {
+        expect(
+            needsCommitmentPost(
+                makeCommitmentSwap({
+                    status: swapStatusPending.TransactionServerConfirmed,
+                }),
+            ),
+        ).toBe(false);
+    });
+
+    test("false for null or undefined swaps", () => {
+        expect(needsCommitmentPost(null)).toBe(false);
+        expect(needsCommitmentPost(undefined)).toBe(false);
+    });
+});
 
 describe("SwapExecutionWorker", () => {
     beforeEach(() => {

--- a/tests/status/AutoClaimHops.spec.tsx
+++ b/tests/status/AutoClaimHops.spec.tsx
@@ -1,0 +1,199 @@
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import type * as BoltzClientModule from "boltz-swaps/client";
+import type * as BoltzContractsModule from "boltz-swaps/evm/contracts";
+import { SwapPosition } from "boltz-swaps/types";
+import { createSignal } from "solid-js";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { Signer } from "../../src/context/Web3";
+import type * as EvmTransactionModule from "../../src/utils/evmTransaction";
+import type { ClaimQuote } from "../../src/utils/quoter";
+import type * as SwapCreatorModule from "../../src/utils/swapCreator";
+import { GasAbstractionType, type SomeSwap } from "../../src/utils/swapCreator";
+
+const signerAddress = "0x3000000000000000000000000000000000000000";
+
+const [swap, setSwapSignal] = createSignal<SomeSwap | null>(null, {
+    equals: false,
+});
+const [signer, setSigner] = createSignal<Signer | undefined>();
+const getSwap = vi.fn<(id: string) => Promise<SomeSwap | null>>();
+const notify = vi.fn();
+const modifySwap = vi.fn();
+const getErc20Swap = vi.fn();
+const getGasAbstractionSigner = vi.fn();
+const fetchDexQuote = vi.fn<(...args: unknown[]) => Promise<ClaimQuote>>();
+const sendPopulatedTransaction =
+    vi.fn<(...args: unknown[]) => Promise<string>>();
+
+vi.mock("../../src/context/Global", () => ({
+    useGlobalContext: () => ({
+        t: (key: string) => key,
+        slippage: () => 0.01,
+        notify,
+        getSwap,
+        denomination: () => "sat",
+        separator: () => ".",
+    }),
+}));
+
+vi.mock("../../src/context/Pay", () => ({
+    usePayContext: () => ({ swap }),
+}));
+
+vi.mock("../../src/context/Web3", () => ({
+    useWeb3Signer: () => ({ getErc20Swap, signer, getGasAbstractionSigner }),
+}));
+
+vi.mock("../../src/hooks/useModifySwap", () => ({
+    useModifySwap: () => modifySwap,
+}));
+
+vi.mock("../../src/utils/quoter", () => ({
+    fetchDexQuote,
+    gasTopUpSupported: () => false,
+    getGasTopUpNativeAmount: vi.fn(),
+    fetchGasTokenQuote: vi.fn(),
+}));
+
+vi.mock("boltz-swaps/evm", () => ({
+    satsToAssetAmount: (amount: number) => BigInt(amount),
+    dexCalldataToRouterCalls: () => [],
+    signErc20ClaimToRouter: () => Promise.resolve("0xclaimsignature"),
+    signRouterClaim: () => Promise.resolve("0xroutersignature"),
+    encodeRouterClaimExecuteTx: () => ({
+        to: "0x4000000000000000000000000000000000000000",
+        data: "0x",
+    }),
+}));
+
+vi.mock("boltz-swaps/evm/contracts", async (importOriginal) => ({
+    ...(await importOriginal<typeof BoltzContractsModule>()),
+    createRouterContract: () => ({
+        address: "0x4000000000000000000000000000000000000000",
+    }),
+}));
+
+vi.mock("boltz-swaps/client", async (importOriginal) => ({
+    ...(await importOriginal<typeof BoltzClientModule>()),
+    encodeDexQuote: () => Promise.resolve("0xdexcalldata"),
+}));
+
+vi.mock("../../src/utils/evmTransaction", async (importOriginal) => ({
+    ...(await importOriginal<typeof EvmTransactionModule>()),
+    sendPopulatedTransaction: (...args: unknown[]) =>
+        sendPopulatedTransaction(...args),
+}));
+
+vi.mock("../../src/utils/swapCreator", async (importOriginal) => ({
+    ...(await importOriginal<typeof SwapCreatorModule>()),
+    getFinalAssetReceive: () => "USDT0",
+}));
+
+vi.mock("../../src/components/ContractTransaction", () => ({
+    default: () => null,
+}));
+
+const { AutoClaimHops } = await import("../../src/status/TransactionConfirmed");
+
+const makeSigner = (address: string) =>
+    ({
+        address,
+        provider: { getChainId: vi.fn().mockResolvedValue(42161) },
+    }) as unknown as Signer;
+
+const makeQuote = (amountOut: bigint): ClaimQuote => ({
+    trade: { amountIn: 1_000_000n, amountOut, data: {} },
+});
+
+const dexDetail = {
+    position: SwapPosition.Post,
+    hops: [
+        {
+            from: "USDT0",
+            dexDetails: {
+                chain: "42161",
+                tokenIn: "0x1000000000000000000000000000000000000000",
+                tokenOut: "0x2000000000000000000000000000000000000000",
+            },
+        },
+    ],
+    quoteAmount: "1000000",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;
+
+const renderAutoClaimHops = () =>
+    render(() => (
+        <AutoClaimHops
+            amount={1_000}
+            swapId="swap-1"
+            gasAbstraction={GasAbstractionType.Signer}
+            preimage="0xpreimage"
+            assetSend="USDT0"
+            assetReceive="USDT0"
+            signerAddress={signerAddress}
+            refundAddress={signerAddress}
+            timeoutBlockHeight={100}
+            getGasToken={false}
+            dex={dexDetail}
+            autoClaimEnabled={true}
+        />
+    ));
+
+describe("AutoClaimHops", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        setSwapSignal({ id: "swap-1", sendAmount: 1_000 } as SomeSwap);
+        setSigner(makeSigner(signerAddress));
+        getGasAbstractionSigner.mockReturnValue(makeSigner(signerAddress));
+        getSwap.mockResolvedValue({
+            id: "swap-1",
+            sendAmount: 1_000,
+            dex: dexDetail,
+        } as SomeSwap);
+        sendPopulatedTransaction.mockResolvedValue("0xclaimtx");
+    });
+
+    test("prompts for approval when the fresh quote is below the slippage threshold", async () => {
+        fetchDexQuote.mockResolvedValue(makeQuote(500_000n));
+
+        renderAutoClaimHops();
+
+        expect(
+            await screen.findByText("dex_quote_changed"),
+        ).toBeInTheDocument();
+        expect(getSwap).not.toHaveBeenCalled();
+        expect(sendPopulatedTransaction).not.toHaveBeenCalled();
+        expect(notify).not.toHaveBeenCalled();
+    });
+
+    test("accepting the changed quote triggers the claim", async () => {
+        fetchDexQuote.mockResolvedValue(makeQuote(500_000n));
+
+        renderAutoClaimHops();
+
+        fireEvent.click(await screen.findByText("accept"));
+
+        await waitFor(() => expect(getSwap).toHaveBeenCalledWith("swap-1"));
+        await waitFor(() =>
+            expect(sendPopulatedTransaction).toHaveBeenCalledTimes(1),
+        );
+        await waitFor(() =>
+            expect(screen.queryByText("dex_quote_changed")).toBeNull(),
+        );
+        expect(notify).not.toHaveBeenCalled();
+    });
+
+    test("auto-claims without prompting when the fresh quote is within tolerance", async () => {
+        fetchDexQuote.mockResolvedValue(makeQuote(2_000_000n));
+
+        renderAutoClaimHops();
+
+        await waitFor(() => expect(getSwap).toHaveBeenCalledWith("swap-1"));
+        await waitFor(() =>
+            expect(sendPopulatedTransaction).toHaveBeenCalledTimes(1),
+        );
+        expect(screen.queryByText("dex_quote_changed")).toBeNull();
+        expect(notify).not.toHaveBeenCalled();
+    });
+});

--- a/tests/status/PreBridgeDexQuoteBlocked.spec.tsx
+++ b/tests/status/PreBridgeDexQuoteBlocked.spec.tsx
@@ -115,6 +115,11 @@ vi.mock("boltz-swaps/bridge", () => ({
     },
 }));
 
+vi.mock("../../src/components/BlockExplorer", () => ({
+    default: () => <a data-testid="block-explorer">explorer</a>,
+    BlockExplorerTargetKind: { Tx: "tx" },
+}));
+
 const { default: PreBridgeDexQuoteBlocked } =
     await import("../../src/status/PreBridgeDexQuoteBlocked");
 
@@ -233,5 +238,50 @@ describe("PreBridgeDexQuoteBlocked", () => {
                 }),
             );
         });
+    });
+
+    test("renders the blocked state with retry and refund actions", async () => {
+        render(() => <PreBridgeDexQuoteBlocked />);
+
+        expect(
+            await screen.findByText("pre_bridge_dex_quote_blocked"),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText("pre_bridge_dex_quote_blocked_line"),
+        ).toBeInTheDocument();
+        expect(screen.getByText("retry_quote")).toBeInTheDocument();
+        expect(screen.getByTestId("recover-button")).toBeInTheDocument();
+        expect(screen.queryByText("retrying_quote")).toBeNull();
+    });
+
+    test("renders the retrying state without action buttons", async () => {
+        const retrying = makeSwap();
+        retrying.bridge!.recovery!.status = PreBridgeRecoveryStatus.Retrying;
+        setSwapSignal(retrying);
+
+        render(() => <PreBridgeDexQuoteBlocked />);
+
+        expect(await screen.findByText("retrying_quote")).toBeInTheDocument();
+        expect(
+            screen.getByText("pre_bridge_dex_quote_blocked"),
+        ).toBeInTheDocument();
+        expect(screen.queryByText("retry_quote")).toBeNull();
+        expect(screen.queryByTestId("recover-button")).toBeNull();
+    });
+
+    test("renders the recovered state with the refund-initiated message", async () => {
+        const recovered = makeSwap();
+        recovered.bridge!.recovery!.status = PreBridgeRecoveryStatus.Recovered;
+        recovered.bridge!.recovery!.txHash = "0xrecovery";
+        setSwapSignal(recovered);
+
+        render(() => <PreBridgeDexQuoteBlocked />);
+
+        expect(
+            await screen.findByText("pre_bridge_refund_initiated"),
+        ).toBeInTheDocument();
+        expect(screen.getByText("new_swap")).toBeInTheDocument();
+        expect(screen.getByTestId("block-explorer")).toBeInTheDocument();
+        expect(screen.queryByText("pre_bridge_dex_quote_blocked")).toBeNull();
     });
 });


### PR DESCRIPTION
Depends on https://github.com/BoltzExchange/regtest/pull/110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Arbitrum end-to-end coverage for lockup + claim flows and expired-swap refunds via the external rescue-file process.
  * Introduced shared Arbitrum E2E utilities to standardize wallet connections, asset selection, and swap/transaction verification.

* **Bug Fixes**
  * Updated CI Playwright configuration to include an additional log scan endpoint.
  * Improved end-to-end reliability with consistent readiness polling and deterministic in-browser swap/tx checks.

* **Tests**
  * Expanded unit/UI tests for commitment gating, auto-claim quote-change handling, and pre-bridge quote blocked/retrying/recovered states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->