### PR TITLE
fix: show claiming status on USDT/USDC->X chain swaps

### DIFF
--- a/src/context/Pay.tsx
+++ b/src/context/Pay.tsx
@@ -67,6 +67,7 @@ export type PayContextType = {
     shouldIgnoreBackendStatus: Accessor<boolean>;
     setShouldIgnoreBackendStatus: Setter<boolean>;
     claimSwap: (swapId: string, data: SwapStatus) => Promise<void>;
+    isSwapClaiming: (swapId: string) => boolean;
 };
 
 const PayContext = createContext<PayContextType>();
@@ -166,9 +167,12 @@ const PayProvider = (props: { children: JSX.Element }) => {
         }
     };
 
-    const claimingSwaps = new Set<string>();
+    const [claimingSwaps, setClaimingSwaps] = createSignal(new Set<string>(), {
+        equals: false,
+    });
+    const isSwapClaiming = (swapId: string) => claimingSwaps().has(swapId);
     const claimSwap = async (swapId: string, data: SwapStatus) => {
-        if (claimingSwaps.has(swapId)) {
+        if (claimingSwaps().has(swapId)) {
             return;
         }
 
@@ -240,7 +244,10 @@ const PayProvider = (props: { children: JSX.Element }) => {
             })
         ) {
             try {
-                claimingSwaps.add(swapId);
+                setClaimingSwaps((swaps) => {
+                    swaps.add(swapId);
+                    return swaps;
+                });
 
                 const res = await claim(
                     deriveKey,
@@ -328,7 +335,10 @@ const PayProvider = (props: { children: JSX.Element }) => {
                 log.error(msg, e);
                 notify("error", msg);
             } finally {
-                claimingSwaps.delete(swapId);
+                setClaimingSwaps((swaps) => {
+                    swaps.delete(swapId);
+                    return swaps;
+                });
             }
         } else if (
             currentSwap.type === SwapType.Submarine &&
@@ -434,6 +444,7 @@ const PayProvider = (props: { children: JSX.Element }) => {
                 shouldIgnoreBackendStatus,
                 setShouldIgnoreBackendStatus,
                 claimSwap,
+                isSwapClaiming,
             }}>
             {props.children}
         </PayContext.Provider>

--- a/src/status/Broadcasting.tsx
+++ b/src/status/Broadcasting.tsx
@@ -1,0 +1,15 @@
+import LoadingSpinner from "../components/LoadingSpinner";
+import { useGlobalContext } from "../context/Global";
+
+const Broadcasting = () => {
+    const { t } = useGlobalContext();
+
+    return (
+        <div>
+            <h2>{t("broadcasting_claim")}</h2>
+            <LoadingSpinner />
+        </div>
+    );
+};
+
+export default Broadcasting;

--- a/src/status/TransactionClaimed.tsx
+++ b/src/status/TransactionClaimed.tsx
@@ -14,7 +14,6 @@ import {
 } from "solid-js";
 
 import ExternalLink from "../components/ExternalLink";
-import LoadingSpinner from "../components/LoadingSpinner";
 import { config } from "../config";
 import { getAssetNetwork, isEvmAsset } from "../consts/Assets";
 import { useGlobalContext } from "../context/Global";
@@ -27,17 +26,7 @@ import {
     getFinalAssetReceive,
     getPostBridgeDetail,
 } from "../utils/swapCreator";
-
-const Broadcasting = () => {
-    const { t } = useGlobalContext();
-
-    return (
-        <div>
-            <h2>{t("broadcasting_claim")}</h2>
-            <LoadingSpinner />
-        </div>
-    );
-};
+import Broadcasting from "./Broadcasting";
 
 const paymentValidationUrl = (invoice: string, preimage: string): string => {
     const url = new URL(config.preimageValidation);

--- a/src/status/TransactionMempool.tsx
+++ b/src/status/TransactionMempool.tsx
@@ -3,20 +3,34 @@ import { type Accessor, Show } from "solid-js";
 
 import LoadingSpinner from "../components/LoadingSpinner";
 import { useGlobalContext } from "../context/Global";
+import { usePayContext } from "../context/Pay";
 import type { SomeSwap } from "../utils/swapCreator";
+import Broadcasting from "./Broadcasting";
 
 const TransactionMempool = (props: { swap: Accessor<SomeSwap | null> }) => {
     const { t } = useGlobalContext();
+    const { isSwapClaiming } = usePayContext();
+
+    const claimingNow = () => {
+        const currentSwap = props.swap();
+        return (
+            currentSwap !== null &&
+            (isSwapClaiming(currentSwap.id) ||
+                currentSwap.claimTx !== undefined)
+        );
+    };
 
     return (
-        <div>
-            <h2>{t("tx_in_mempool")}</h2>
-            <p>{t("tx_in_mempool_subline")}</p>
-            <Show when={props.swap()?.type === SwapType.Chain}>
-                <h3>{t("tx_in_mempool_warning")}</h3>
-            </Show>
-            <LoadingSpinner />
-        </div>
+        <Show when={!claimingNow()} fallback={<Broadcasting />}>
+            <div>
+                <h2>{t("tx_in_mempool")}</h2>
+                <p>{t("tx_in_mempool_subline")}</p>
+                <Show when={props.swap()?.type === SwapType.Chain}>
+                    <h3>{t("tx_in_mempool_warning")}</h3>
+                </Show>
+                <LoadingSpinner />
+            </div>
+        </Show>
     );
 };
 

--- a/tests/pages/Pay.spec.tsx
+++ b/tests/pages/Pay.spec.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor } from "@solidjs/testing-library";
 import { OutputType } from "boltz-core";
 import { getLockupTransaction, getSwapStatus } from "boltz-swaps/client";
 import { SwapPosition, SwapType } from "boltz-swaps/types";
+import { createSignal } from "solid-js";
 
 import { config } from "../../src/config";
 import { config as mainnetConfig } from "../../src/configs/mainnet";
@@ -15,6 +16,7 @@ import {
 } from "../../src/consts/SwapStatus";
 import dict from "../../src/i18n/i18n";
 import Pay from "../../src/pages/Pay";
+import TransactionMempool from "../../src/status/TransactionMempool";
 import {
     getSwapUTXOs,
     getTransactionOutSpend,
@@ -555,5 +557,141 @@ describe("Pay", () => {
                 expect.objectContaining({ claimTx: expect.any(String) }),
             );
         });
+    });
+
+    test("reports isSwapClaiming while a claim is in flight and clears it once settled", async () => {
+        const swapFromStorage = {
+            id: "123",
+            type: SwapType.Chain,
+            assetReceive: BTC,
+            assetSend: LBTC,
+            version: OutputType.Taproot,
+            claimTx: undefined,
+            lockupDetails: {},
+        } as unknown as ChainSwap;
+
+        swapsGetItemMock.mockResolvedValue(swapFromStorage);
+        vi.mocked(isSwapClaimable).mockReturnValue(true);
+
+        let resolveClaim!: (value: ChainSwap | undefined) => void;
+        vi.mocked(claim).mockReturnValue(
+            new Promise<ChainSwap | undefined>((resolve) => {
+                resolveClaim = resolve;
+            }),
+        );
+
+        renderPay();
+        payContext.setSwap({ ...swapFromStorage });
+
+        expect(payContext.isSwapClaiming("123")).toBe(false);
+
+        const claimPromise = payContext.claimSwap("123", {
+            id: "123",
+            status: swapStatusPending.TransactionMempool,
+            transaction: {
+                id: "lockup-txid",
+                hex: "00",
+            },
+        });
+
+        await waitFor(() => {
+            expect(payContext.isSwapClaiming("123")).toBe(true);
+        });
+
+        resolveClaim(undefined);
+        await claimPromise;
+
+        await waitFor(() => {
+            expect(payContext.isSwapClaiming("123")).toBe(false);
+        });
+    });
+
+    test("clears isSwapClaiming after a claim rejects", async () => {
+        const swapFromStorage = {
+            id: "123",
+            type: SwapType.Chain,
+            assetReceive: BTC,
+            assetSend: LBTC,
+            version: OutputType.Taproot,
+            claimTx: undefined,
+            lockupDetails: {},
+        } as unknown as ChainSwap;
+
+        swapsGetItemMock.mockResolvedValue(swapFromStorage);
+        vi.mocked(isSwapClaimable).mockReturnValue(true);
+        vi.mocked(claim).mockRejectedValue(new Error("claim broadcast failed"));
+
+        renderPay();
+        payContext.setSwap({ ...swapFromStorage });
+
+        await payContext.claimSwap("123", {
+            id: "123",
+            status: swapStatusPending.TransactionMempool,
+            transaction: {
+                id: "lockup-txid",
+                hex: "00",
+            },
+        });
+
+        await waitFor(() => {
+            expect(globalSignals.notificationType()).toBe("error");
+        });
+        expect(payContext.isSwapClaiming("123")).toBe(false);
+    });
+
+    test("swaps the mempool view for the broadcasting view while the real claim signal is set", async () => {
+        const swapFromStorage = {
+            id: "123",
+            type: SwapType.Chain,
+            assetReceive: BTC,
+            assetSend: LBTC,
+            version: OutputType.Taproot,
+            claimTx: undefined,
+            lockupDetails: {},
+        } as unknown as ChainSwap;
+
+        swapsGetItemMock.mockResolvedValue(swapFromStorage);
+        vi.mocked(isSwapClaimable).mockReturnValue(true);
+
+        let resolveClaim!: (value: ChainSwap | undefined) => void;
+        vi.mocked(claim).mockReturnValue(
+            new Promise<ChainSwap | undefined>((resolve) => {
+                resolveClaim = resolve;
+            }),
+        );
+
+        const [swap] = createSignal<SomeSwap | null>(
+            swapFromStorage as unknown as SomeSwap,
+        );
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <TransactionMempool swap={swap} />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        await screen.findByText(dict.en.tx_in_mempool_subline);
+        expect(screen.queryByText(dict.en.broadcasting_claim)).toBeNull();
+
+        const claimPromise = payContext.claimSwap("123", {
+            id: "123",
+            status: swapStatusPending.TransactionMempool,
+            transaction: {
+                id: "lockup-txid",
+                hex: "00",
+            },
+        });
+
+        await screen.findByText(dict.en.broadcasting_claim);
+        expect(screen.queryByText(dict.en.tx_in_mempool_subline)).toBeNull();
+
+        resolveClaim(undefined);
+        await claimPromise;
+
+        await screen.findByText(dict.en.tx_in_mempool_subline);
+        expect(screen.queryByText(dict.en.broadcasting_claim)).toBeNull();
     });
 });

--- a/tests/status/Broadcasting.spec.tsx
+++ b/tests/status/Broadcasting.spec.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@solidjs/testing-library";
+
+import i18n from "../../src/i18n/i18n";
+import Broadcasting from "../../src/status/Broadcasting";
+import { contextWrapper } from "../helper";
+
+describe("Broadcasting", () => {
+    test("renders the broadcasting claim heading", () => {
+        render(() => <Broadcasting />, { wrapper: contextWrapper });
+
+        expect(
+            screen.getByText(i18n.en.broadcasting_claim),
+        ).toBeInTheDocument();
+    });
+
+    test("renders a loading spinner while broadcasting", () => {
+        render(() => <Broadcasting />, { wrapper: contextWrapper });
+
+        expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    });
+});

--- a/tests/status/TransactionMempool.spec.tsx
+++ b/tests/status/TransactionMempool.spec.tsx
@@ -1,14 +1,37 @@
-import { render, screen } from "@solidjs/testing-library";
+import { render, screen, waitFor } from "@solidjs/testing-library";
 import { SwapType } from "boltz-swaps/types";
 import { createSignal } from "solid-js";
 
 import { BTC, RBTC } from "../../src/consts/Assets";
+import type * as PayContextModule from "../../src/context/Pay";
 import i18n from "../../src/i18n/i18n";
 import TransactionMempool from "../../src/status/TransactionMempool";
 import type { SomeSwap } from "../../src/utils/swapCreator";
 import { contextWrapper } from "../helper";
 
+const payContextMock = vi.hoisted(
+    (): { isSwapClaiming: (id: string) => boolean } => ({
+        isSwapClaiming: () => false,
+    }),
+);
+
+vi.mock("../../src/context/Pay", async () => {
+    const actual = await vi.importActual<typeof PayContextModule>(
+        "../../src/context/Pay",
+    );
+    return {
+        ...actual,
+        usePayContext: () => ({
+            isSwapClaiming: (id: string) => payContextMock.isSwapClaiming(id),
+        }),
+    };
+});
+
 describe("TransactionMempool", () => {
+    beforeEach(() => {
+        payContextMock.isSwapClaiming = () => false;
+    });
+
     test("renders without throwing when swap is null", () => {
         const [swap] = createSignal<SomeSwap | null>(null);
 
@@ -19,6 +42,9 @@ describe("TransactionMempool", () => {
         expect(screen.getByText(i18n.en.tx_in_mempool)).toBeInTheDocument();
         expect(
             screen.queryByText(i18n.en.tx_in_mempool_warning),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByText(i18n.en.broadcasting_claim),
         ).not.toBeInTheDocument();
     });
 
@@ -49,6 +75,99 @@ describe("TransactionMempool", () => {
 
         expect(
             screen.queryByText(i18n.en.tx_in_mempool_warning),
+        ).not.toBeInTheDocument();
+    });
+
+    test("shows the broadcasting view while the swap is being claimed", () => {
+        payContextMock.isSwapClaiming = (id) => id === "swap-claiming";
+        const [swap] = createSignal<SomeSwap | null>({
+            id: "swap-claiming",
+            type: SwapType.Chain,
+            assetReceive: RBTC,
+        } as SomeSwap);
+
+        render(() => <TransactionMempool swap={swap} />, {
+            wrapper: contextWrapper,
+        });
+
+        expect(
+            screen.getByText(i18n.en.broadcasting_claim),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText(i18n.en.tx_in_mempool),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByText(i18n.en.tx_in_mempool_warning),
+        ).not.toBeInTheDocument();
+    });
+
+    test("shows the broadcasting view when the swap already has a claim transaction", () => {
+        payContextMock.isSwapClaiming = () => false;
+        const [swap] = createSignal<SomeSwap | null>({
+            id: "swap-claimtx",
+            type: SwapType.Reverse,
+            assetReceive: BTC,
+            claimTx: "claim-txid",
+        } as unknown as SomeSwap);
+
+        render(() => <TransactionMempool swap={swap} />, {
+            wrapper: contextWrapper,
+        });
+
+        expect(
+            screen.getByText(i18n.en.broadcasting_claim),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText(i18n.en.tx_in_mempool),
+        ).not.toBeInTheDocument();
+    });
+
+    test("shows the mempool view when the swap is neither claiming nor claimed", () => {
+        const [swap] = createSignal<SomeSwap | null>({
+            id: "swap-waiting",
+            type: SwapType.Reverse,
+            assetReceive: BTC,
+        } as SomeSwap);
+
+        render(() => <TransactionMempool swap={swap} />, {
+            wrapper: contextWrapper,
+        });
+
+        expect(screen.getByText(i18n.en.tx_in_mempool)).toBeInTheDocument();
+        expect(
+            screen.queryByText(i18n.en.broadcasting_claim),
+        ).not.toBeInTheDocument();
+    });
+
+    test("reactively switches from waiting to broadcasting when claiming begins", async () => {
+        const [claiming, setClaiming] = createSignal(false);
+        // eslint-disable-next-line solid/reactivity
+        payContextMock.isSwapClaiming = () => claiming();
+
+        const [swap] = createSignal<SomeSwap | null>({
+            id: "swap-reactive",
+            type: SwapType.Chain,
+            assetReceive: RBTC,
+        } as SomeSwap);
+
+        render(() => <TransactionMempool swap={swap} />, {
+            wrapper: contextWrapper,
+        });
+
+        expect(screen.getByText(i18n.en.tx_in_mempool)).toBeInTheDocument();
+        expect(
+            screen.queryByText(i18n.en.broadcasting_claim),
+        ).not.toBeInTheDocument();
+
+        setClaiming(true);
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(i18n.en.broadcasting_claim),
+            ).toBeInTheDocument();
+        });
+        expect(
+            screen.queryByText(i18n.en.tx_in_mempool),
         ).not.toBeInTheDocument();
     });
 });


### PR DESCRIPTION
Closes #1505 

On USDT/USDC swaps with 0-conf enabled, WebApp would start claiming at `transaction.server.mempool`, which is correct, but the UI would still display "waiting for confirmation to complete the swap".

At that point, the WebApp was not waiting anymore, it was already claiming. The message displayed was just incorrect. This fixes this by updating this UI when claiming.

<img width="1130" height="900" alt="image" src="https://github.com/user-attachments/assets/a84aaa26-a31c-4734-bc9b-c134283e2eed" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Broadcasting” status view with a loading indicator for in-progress claim broadcasts.

* **Bug Fixes**
  * Improved swap claim-state tracking so the app more reliably shows the correct screen during claiming and after completion.
  * The transaction claimed view now reuses the shared broadcasting status display for consistency.
  * Updated the mempool screen to switch to the broadcasting view while a claim is in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->