### PR TITLE
feat: WebSocket support in SDK

### DIFF
--- a/packages/boltz-swaps/examples/chainSwapLbtcToTbtc.ts
+++ b/packages/boltz-swaps/examples/chainSwapLbtcToTbtc.ts
@@ -5,7 +5,7 @@
 // Flow:
 //   1. Create the chain swap (source = L-BTC, destination = TBTC on Arbitrum).
 //   2. You fund the returned L-BTC lockup address from any external wallet.
-//   3. Poll `swap.status(id)` yourself; once Boltz has locked TBTC,
+//   3. Watch `swap.watch(id)` for status; once Boltz has locked TBTC,
 //      `swap.chain.execute(...)` claims it to your Arbitrum address.
 //
 // ── Run ────────────────────────────────────────────────────────────────────
@@ -57,9 +57,6 @@ declare const process: {
     env: Record<string, string | undefined>;
     exit: (code: number) => never;
 };
-
-const sleep = (ms: number): Promise<void> =>
-    new Promise((resolve) => setTimeout(resolve, ms));
 
 type Keypair = { privateKey: Uint8Array; publicKey: Uint8Array };
 
@@ -188,17 +185,20 @@ const main = async () => {
         `\nExpected to receive ~${createdSwap.claimDetails.amount} TBTC base units (18 dec).`,
     );
 
-    // 3) Poll the status yourself until Boltz has locked TBTC, then claim it.
-    //    `execute` does the claim only — it does not poll.
-    console.log("\nPolling swap status every 5s (Ctrl+C to stop)…");
+    // 3) Watch the status until Boltz has locked TBTC, then claim it.
+    //    `execute` does the claim only — it does not watch.
+    console.log("\nWatching swap status (Ctrl+C to stop)…");
     let lastStatus = "";
-    for (;;) {
-        const { status } = await boltz.swap.status(createdSwap.id);
+    for await (const { status } of boltz.swap.watch(createdSwap.id)) {
         if (status !== lastStatus) {
             console.log(`  status: ${status}`);
             lastStatus = status;
         }
-        if (isChainSwapClaimable({ status })) {
+        if (
+            isChainSwapClaimable({
+                status,
+            })
+        ) {
             break;
         }
         if (isFinalStatus(status)) {
@@ -208,7 +208,6 @@ const main = async () => {
                     : `swap already settled (${status})`,
             );
         }
-        await sleep(5_000);
     }
 
     console.log("\nClaiming TBTC…");

--- a/packages/boltz-swaps/examples/reverseSwapToLbtc.ts
+++ b/packages/boltz-swaps/examples/reverseSwapToLbtc.ts
@@ -5,7 +5,7 @@
 // Flow:
 //   1. Create the reverse swap. Boltz returns a hold invoice.
 //   2. You pay that invoice from any Lightning wallet.
-//   3. Boltz locks L-BTC on-chain; poll `swap.status(id)` yourself.
+//   3. Boltz locks L-BTC on-chain; watch `swap.watch(id)` for status updates.
 //   4. Once the lockup confirms, `swap.reverse.execute(...)` claims the L-BTC
 //      to your address (cooperatively; it falls back to the script path if
 //      Boltz refuses to co-sign). Claiming reveals the preimage, which settles
@@ -38,9 +38,6 @@ declare const process: {
     env: Record<string, string | undefined>;
     exit: (code: number) => never;
 };
-
-const sleep = (ms: number): Promise<void> =>
-    new Promise((resolve) => setTimeout(resolve, ms));
 
 type Keypair = { privateKey: Uint8Array; publicKey: Uint8Array };
 
@@ -116,10 +113,9 @@ const main = async () => {
         `\nBoltz will lock ${createdSwap.onchainAmount} sats of L-BTC once paid.`,
     );
 
-    console.log("\nPolling swap status every 5s (Ctrl+C to stop)…");
+    console.log("\nWatching swap status (Ctrl+C to stop)…");
     let lastStatus = "";
-    for (;;) {
-        const { status } = await boltz.swap.status(createdSwap.id);
+    for await (const { status } of boltz.swap.watch(createdSwap.id)) {
         if (status !== lastStatus) {
             console.log(`  status: ${status}`);
             lastStatus = status;
@@ -134,7 +130,6 @@ const main = async () => {
                     : `swap already settled (${status})`,
             );
         }
-        await sleep(5_000);
     }
 
     const receiveAmount = createdSwap.onchainAmount - pair.fees.minerFees.claim;

--- a/packages/boltz-swaps/examples/routeArkadeToUsdcBase.ts
+++ b/packages/boltz-swaps/examples/routeArkadeToUsdcBase.ts
@@ -11,7 +11,7 @@
 //      the via/landing asset (here TBTC, the chain-swap destination), committing
 //      the signer's EOA as the claim address.
 //   2. You fund the returned Arkade lockup from your Arkade wallet.
-//   3. Poll `swap.status(id)` yourself; once Boltz has locked the destination,
+//   3. Watch `swap.watch(id)` for status; once Boltz has locked the destination,
 //      `route.execute(...)` claims it and, in the same tx, runs the DEX swap and
 //      bridges USDC to your Base address.
 //
@@ -67,9 +67,6 @@ declare const process: {
     env: Record<string, string | undefined>;
     exit: (code: number) => never;
 };
-
-const sleep = (ms: number): Promise<void> =>
-    new Promise((resolve) => setTimeout(resolve, ms));
 
 type Keypair = { privateKey: Uint8Array; publicKey: Uint8Array };
 
@@ -197,17 +194,23 @@ const main = async () => {
     }
     const signer = buildSigner(account, rpcUrl);
 
-    // 2) Poll the status yourself until Boltz has locked the destination, then
-    //    claim. `execute` does the claim only — it does not poll.
-    console.log("\nPolling swap status every 5s (Ctrl+C to stop)…");
+    // 2) Watch the status until Boltz has locked the destination, then claim.
+    //    `execute` does the claim only — it does not watch.
+    console.log("\nWatching swap status (Ctrl+C to stop)…");
     let lastStatus = "";
-    for (;;) {
-        const { status } = await boltz.swap.status(createdSwap.id);
+    for await (const { status, zeroConfRejected } of boltz.swap.watch(
+        createdSwap.id,
+    )) {
         if (status !== lastStatus) {
             console.log(`  status: ${status}`);
             lastStatus = status;
         }
-        if (isChainSwapClaimable({ status })) {
+        if (
+            isChainSwapClaimable({
+                status,
+                zeroConf: zeroConfRejected !== true,
+            })
+        ) {
             break;
         }
         if (isFinalStatus(status)) {
@@ -217,7 +220,6 @@ const main = async () => {
                     : `swap already settled (${status})`,
             );
         }
-        await sleep(5_000);
     }
 
     // 3) Pin the minimum we will accept. In a real app, derive this from the

--- a/packages/boltz-swaps/examples/routeLbtcToUsdcBase.ts
+++ b/packages/boltz-swaps/examples/routeLbtcToUsdcBase.ts
@@ -11,7 +11,7 @@
 //      the via/landing asset (the chain-swap destination), committing the
 //      signer's EOA as the claim address.
 //   2. You fund the returned L-BTC lockup address from any external wallet.
-//   3. Poll `swap.status(id)` yourself; once Boltz has locked the destination,
+//   3. Watch `swap.watch(id)` for status; once Boltz has locked the destination,
 //      `route.execute(...)` claims it and, in the same tx, runs the DEX swap and
 //      bridges USDC to your Base address.
 //
@@ -67,9 +67,6 @@ declare const process: {
     env: Record<string, string | undefined>;
     exit: (code: number) => never;
 };
-
-const sleep = (ms: number): Promise<void> =>
-    new Promise((resolve) => setTimeout(resolve, ms));
 
 type Keypair = { privateKey: Uint8Array; publicKey: Uint8Array };
 
@@ -195,17 +192,20 @@ const main = async () => {
     }
     const signer = buildSigner(account, rpcUrl);
 
-    // 2) Poll the status yourself until Boltz has locked the destination, then
-    //    claim. `execute` does the claim only — it does not poll.
-    console.log("\nPolling swap status every 5s (Ctrl+C to stop)…");
+    // 2) Watch the status until Boltz has locked the destination, then claim.
+    //    `execute` does the claim only — it does not watch.
+    console.log("\nWatching swap status (Ctrl+C to stop)…");
     let lastStatus = "";
-    for (;;) {
-        const { status } = await boltz.swap.status(createdSwap.id);
+    for await (const { status } of boltz.swap.watch(createdSwap.id)) {
         if (status !== lastStatus) {
             console.log(`  status: ${status}`);
             lastStatus = status;
         }
-        if (isChainSwapClaimable({ status })) {
+        if (
+            isChainSwapClaimable({
+                status,
+            })
+        ) {
             break;
         }
         if (isFinalStatus(status)) {
@@ -215,7 +215,6 @@ const main = async () => {
                     : `swap already settled (${status})`,
             );
         }
-        await sleep(5_000);
     }
 
     // 3) Pin the minimum we will accept. In a real app, derive this from the

--- a/packages/boltz-swaps/examples/submarineSwapFromLbtc.ts
+++ b/packages/boltz-swaps/examples/submarineSwapFromLbtc.ts
@@ -41,9 +41,6 @@ declare const process: {
     exit: (code: number) => never;
 };
 
-const sleep = (ms: number): Promise<void> =>
-    new Promise((resolve) => setTimeout(resolve, ms));
-
 type Keypair = { privateKey: Uint8Array; publicKey: Uint8Array };
 
 const fromPrivateKey = (privateKey: Uint8Array): Keypair => ({
@@ -107,11 +104,10 @@ const main = async () => {
         console.log(`  lockup blinding key: ${createdSwap.blindingKey}`);
     }
 
-    console.log("\nPolling swap status every 5s (Ctrl+C to stop)…");
+    console.log("\nWatching swap status (Ctrl+C to stop)…");
     let lastStatus = "";
     let coSigned = false;
-    for (;;) {
-        const { status } = await boltz.swap.status(createdSwap.id);
+    for await (const { status } of boltz.swap.watch(createdSwap.id)) {
         if (status !== lastStatus) {
             console.log(`  status: ${status}`);
             lastStatus = status;
@@ -143,7 +139,6 @@ const main = async () => {
                     : `unexpected terminal status ${status}`,
             );
         }
-        await sleep(5_000);
     }
 };
 

--- a/packages/boltz-swaps/integration/statusSource.regtest.spec.ts
+++ b/packages/boltz-swaps/integration/statusSource.regtest.spec.ts
@@ -1,0 +1,163 @@
+import { secp256k1 } from "@noble/curves/secp256k1.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { hex } from "@scure/base";
+import { createBoltzClient, getPairs } from "boltz-swaps";
+import { SwapStatus, isFinalStatus } from "boltz-swaps/status";
+import {
+    type SwapUpdate,
+    createPollingStatusSource,
+    createWebSocketStatusSource,
+} from "boltz-swaps/statusSource";
+import { SwapType } from "boltz-swaps/types";
+
+import {
+    BOLTZ_API_URL,
+    generateBitcoinBlock,
+    getBitcoinAddress,
+    payInvoiceInBackground,
+    sleep,
+} from "./regtest.ts";
+
+const makeKeys = () => {
+    const privateKey = secp256k1.utils.randomSecretKey();
+    return { privateKey, publicKey: secp256k1.getPublicKey(privateKey, true) };
+};
+
+describe("status source integration (regtest)", () => {
+    const boltz = createBoltzClient({
+        boltzApiUrl: BOLTZ_API_URL,
+        network: "regtest",
+    });
+
+    const createReverseSwap = async (): Promise<{
+        id: string;
+        invoice: string;
+    }> => {
+        const pairs = await getPairs();
+        const pair = pairs[SwapType.Reverse]["BTC"]?.["BTC"];
+        if (pair?.hash === undefined) {
+            throw new Error("no reverse BTC -> BTC pair");
+        }
+        const claimKeys = makeKeys();
+        const preimage = crypto.getRandomValues(new Uint8Array(32));
+        const created = await boltz.swap.reverse.create({
+            from: "BTC",
+            to: "BTC",
+            invoiceAmount: 100_000,
+            preimageHash: hex.encode(sha256(preimage)),
+            pairHash: pair.hash,
+            claimPublicKey: hex.encode(claimKeys.publicKey),
+            claimAddress: await getBitcoinAddress(),
+        });
+        return { id: created.id, invoice: created.invoice };
+    };
+
+    test("swap.statuses returns a single id (the backend accepts one ?ids=)", async () => {
+        const { id } = await createReverseSwap();
+
+        const statuses = await boltz.swap.statuses([id]);
+        const single = await boltz.swap.status(id);
+
+        expect(Object.keys(statuses)).toEqual([id]);
+        expect(statuses[id].status).toBe(single.status);
+        expect(statuses[id].status).toBe(SwapStatus.SwapCreated);
+    }, 60_000);
+
+    test("swap.statuses fetches multiple ids in one bulk request", async () => {
+        const [a, b] = await Promise.all([
+            createReverseSwap(),
+            createReverseSwap(),
+        ]);
+
+        const statuses = await boltz.swap.statuses([a.id, b.id]);
+
+        expect(new Set(Object.keys(statuses))).toEqual(new Set([a.id, b.id]));
+        expect(statuses[a.id].status).toBe(SwapStatus.SwapCreated);
+        expect(statuses[b.id].status).toBe(SwapStatus.SwapCreated);
+    }, 60_000);
+
+    test("swap.statuses rejects the whole call when an id is unknown (all-or-nothing)", async () => {
+        const { id } = await createReverseSwap();
+        await expect(
+            boltz.swap.statuses([id, "doesnotexist"]),
+        ).rejects.toBeDefined();
+    }, 60_000);
+
+    test("polling source emits once for an unchanged status and ignores a re-subscribe", async () => {
+        const { id } = await createReverseSwap();
+
+        const source = createPollingStatusSource({ intervalMs: 500 });
+        const seen: SwapUpdate[] = [];
+        const handler = (u: SwapUpdate): void => {
+            seen.push(u);
+        };
+        try {
+            source.subscribe(id, handler);
+
+            await sleep(3_000);
+            expect(seen).toHaveLength(1);
+            expect(seen[0].status).toBe(SwapStatus.SwapCreated);
+
+            source.subscribe(id, handler);
+            await sleep(1_000);
+            expect(seen).toHaveLength(1);
+        } finally {
+            source.close?.();
+        }
+    }, 60_000);
+
+    test("websocket source pushes the current status on subscribe", async () => {
+        const { id } = await createReverseSwap();
+
+        const source = createWebSocketStatusSource();
+        try {
+            const update = await new Promise<SwapUpdate>((resolve, reject) => {
+                const timer = setTimeout(
+                    () => reject(new Error("timed out waiting for WS push")),
+                    30_000,
+                );
+                source.subscribe(id, (u) => {
+                    clearTimeout(timer);
+                    resolve(u);
+                });
+            });
+            expect(update.id).toBe(id);
+            expect(update.status).toBe(SwapStatus.SwapCreated);
+        } finally {
+            source.close?.();
+        }
+    }, 60_000);
+
+    test("swap.watch streams the reverse-swap status progression over the default (WS) source", async () => {
+        const { id, invoice } = await createReverseSwap();
+
+        const controller = new AbortController();
+        const abortTimer = setTimeout(() => controller.abort(), 90_000);
+        const seen: string[] = [];
+        try {
+            for await (const update of boltz.swap.watch(id, {
+                signal: controller.signal,
+            })) {
+                seen.push(update.status);
+                if (update.status === SwapStatus.SwapCreated) {
+                    payInvoiceInBackground(invoice);
+                }
+                if (update.status === SwapStatus.TransactionMempool) {
+                    await generateBitcoinBlock();
+                }
+                if (update.status === SwapStatus.TransactionConfirmed) {
+                    break;
+                }
+                if (isFinalStatus(update.status)) {
+                    throw new Error(`reverse swap failed: ${update.status}`);
+                }
+            }
+        } finally {
+            clearTimeout(abortTimer);
+        }
+
+        expect(seen[0]).toBe(SwapStatus.SwapCreated);
+        expect(seen).toContain(SwapStatus.TransactionMempool);
+        expect(seen[seen.length - 1]).toBe(SwapStatus.TransactionConfirmed);
+    }, 120_000);
+});

--- a/packages/boltz-swaps/package.json
+++ b/packages/boltz-swaps/package.json
@@ -75,6 +75,11 @@
             "types": "./dist/status.d.ts",
             "default": "./dist/status.js"
         },
+        "./statusSource": {
+            "source": "./src/statusSource/index.ts",
+            "types": "./dist/statusSource/index.d.ts",
+            "default": "./dist/statusSource/index.js"
+        },
         "./chain": {
             "source": "./src/chain.ts",
             "types": "./dist/chain.d.ts",

--- a/packages/boltz-swaps/src/client.ts
+++ b/packages/boltz-swaps/src/client.ts
@@ -516,6 +516,32 @@ export const getReverseTransaction = (id: string) =>
 export const getSwapStatus = (id: string) =>
     fetcher<SwapStatusResponse>(`/v2/swap/${id}`);
 
+const maxStatusIds = 64;
+
+export const getSwapStatuses = async (
+    ids: string[],
+): Promise<Record<string, SwapStatusResponse>> => {
+    if (ids.length === 0) {
+        return {};
+    }
+    const chunks: string[][] = [];
+    for (let i = 0; i < ids.length; i += maxStatusIds) {
+        chunks.push(ids.slice(i, i + maxStatusIds));
+    }
+    const parts = await Promise.all(
+        chunks.map((chunk) =>
+            fetcher<Record<string, SwapStatusResponse>>(
+                `/v2/swap/status?${chunk.map((id) => `ids=${encodeURIComponent(id)}`).join("&")}`,
+            ),
+        ),
+    );
+    const merged: Record<string, SwapStatusResponse> = {};
+    for (const part of parts) {
+        Object.assign(merged, part);
+    }
+    return merged;
+};
+
 export const getChainSwapClaimDetails = (id: string) =>
     fetcher<{
         pubNonce: string;

--- a/packages/boltz-swaps/src/config.ts
+++ b/packages/boltz-swaps/src/config.ts
@@ -1,3 +1,4 @@
+import type { StatusSource } from "./statusSource/types.ts";
 import {
     type Asset,
     type AssetBridge,
@@ -44,6 +45,11 @@ export interface BoltzSwapsConfig<A extends string = string> {
     // When true, cooperative-signature Boltz endpoints throw before sending.
     // Should only be used for testing.
     cooperativeDisabled?: boolean;
+
+    // Source of swap-status updates for `swap.subscribe` / `swap.watch`.
+    // Defaults to a WebSocket stream with a REST polling fallback
+    // (createDefaultStatusSource).
+    statusSource?: StatusSource;
 }
 
 // Loose input shape accepted by `setBoltzSwapsConfig` / `createBoltzClient`.
@@ -122,6 +128,7 @@ const mergeWithDefaults = <A extends string>(
         "network",
         "gasSponsor",
         "defaultSlippage",
+        "statusSource",
     ] as const) {
         Object.defineProperty(merged, key, {
             enumerable: true,

--- a/packages/boltz-swaps/src/errors.ts
+++ b/packages/boltz-swaps/src/errors.ts
@@ -72,6 +72,9 @@ export const setWalletRejectionMessage = (message: string): void => {
     walletRejectionMessage = message;
 };
 
+export const toError = (value: unknown): Error =>
+    value instanceof Error ? value : new Error(formatError(value));
+
 export const formatError = (message: unknown): string => {
     if (isWalletRejectionError(message)) {
         return walletRejectionMessage;

--- a/packages/boltz-swaps/src/index.ts
+++ b/packages/boltz-swaps/src/index.ts
@@ -11,6 +11,7 @@ export * from "./reverse.ts";
 export * from "./route.ts";
 export * from "./routeExecute.ts";
 export * from "./sdk.ts";
+export * from "./statusSource/index.ts";
 export * from "./submarine.ts";
 export * from "./types.ts";
 

--- a/packages/boltz-swaps/src/sdk.ts
+++ b/packages/boltz-swaps/src/sdk.ts
@@ -42,6 +42,7 @@ import {
     getSubmarineClaimDetails,
     getSubmarinePreimage,
     getSwapStatus,
+    getSwapStatuses,
     postChainSwapDetails,
     quoteDexAmountIn,
     quoteDexAmountOut,
@@ -49,6 +50,7 @@ import {
 import {
     type BoltzSwapsConfig,
     type BoltzSwapsConfigInput,
+    getBoltzSwapsConfig,
     getConfiguredNetwork,
     isEvmAsset,
     setBoltzSwapsConfig,
@@ -88,6 +90,15 @@ import {
     createRoute,
     executeRoute,
 } from "./routeExecute.ts";
+import {
+    type StatusErrorHandler,
+    type StatusSource,
+    type StatusUpdateHandler,
+    type SwapUpdate,
+    type WatchOptions,
+    createDefaultStatusSource,
+    watchStatus,
+} from "./statusSource/index.ts";
 import {
     type RefundResult,
     type RefundSubmarineUtxoParams,
@@ -246,6 +257,13 @@ export interface BoltzClient<A extends string = string> {
     };
     readonly swap: {
         status(id: string): Promise<SwapStatusResponse>;
+        statuses(ids: string[]): Promise<Record<string, SwapStatusResponse>>;
+        subscribe(
+            id: string,
+            onUpdate: StatusUpdateHandler,
+            onError?: StatusErrorHandler,
+        ): () => void;
+        watch(id: string, options?: WatchOptions): AsyncIterable<SwapUpdate>;
         chain: {
             create(
                 args: ChainSwapCreateArgs<A>,
@@ -318,6 +336,7 @@ const configKeys: ReadonlyArray<keyof BoltzSwapsConfig> = [
     "network",
     "gasSponsor",
     "defaultSlippage",
+    "statusSource",
 ];
 
 const buildConfigProxy = <A extends string>(
@@ -341,6 +360,13 @@ export const createBoltzClient = <A extends string = string>(
     input: BoltzClientConfig<A>,
 ): BoltzClient<A> => {
     setBoltzSwapsConfig(buildConfigProxy(input));
+
+    // One status source per client so the WebSocket source can multiplex all
+    // of the client's swaps over a single connection.
+    let statusSource: StatusSource | undefined;
+    const getStatusSource = (): StatusSource =>
+        (statusSource ??=
+            getBoltzSwapsConfig().statusSource ?? createDefaultStatusSource());
 
     const client: BoltzClient<A> = {
         dex: {
@@ -377,6 +403,10 @@ export const createBoltzClient = <A extends string = string>(
         },
         swap: {
             status: (id) => getSwapStatus(id),
+            statuses: (ids) => getSwapStatuses(ids),
+            subscribe: (id, onUpdate, onError) =>
+                getStatusSource().subscribe(id, onUpdate, onError),
+            watch: (id, options) => watchStatus(getStatusSource(), id, options),
             chain: {
                 create: ({
                     from,

--- a/packages/boltz-swaps/src/statusSource/default.ts
+++ b/packages/boltz-swaps/src/statusSource/default.ts
@@ -1,0 +1,23 @@
+import { createPollingStatusSource } from "./polling.ts";
+import type { StatusSource } from "./types.ts";
+import {
+    type WebSocketStatusSourceOptions,
+    createWebSocketStatusSource,
+} from "./websocket.ts";
+
+export type DefaultStatusSourceOptions = WebSocketStatusSourceOptions & {
+    // Interval for the polling fallback, in milliseconds. Default 5000.
+    pollIntervalMs?: number;
+};
+
+// The SDK's default StatusSource: a WebSocket stream backed by a REST polling
+// fallback.
+export const createDefaultStatusSource = (
+    options: DefaultStatusSourceOptions = {},
+): StatusSource => {
+    const { pollIntervalMs, ...wsOptions } = options;
+    return createWebSocketStatusSource({
+        fallback: createPollingStatusSource({ intervalMs: pollIntervalMs }),
+        ...wsOptions,
+    });
+};

--- a/packages/boltz-swaps/src/statusSource/emit.ts
+++ b/packages/boltz-swaps/src/statusSource/emit.ts
@@ -1,0 +1,33 @@
+import { toError } from "../errors.ts";
+import { getLogger } from "../logger.ts";
+import type {
+    StatusErrorHandler,
+    StatusUpdateHandler,
+    SwapUpdate,
+} from "./types.ts";
+
+export const safeEmit = (
+    handler: StatusUpdateHandler,
+    update: SwapUpdate,
+): void => {
+    try {
+        handler(update);
+    } catch (e) {
+        getLogger().warn("status subscriber threw", e);
+    }
+};
+
+export const safeEmitError = (
+    handlers: Iterable<StatusErrorHandler>,
+    error: unknown,
+    id: string,
+): void => {
+    const normalized = toError(error);
+    for (const handler of handlers) {
+        try {
+            handler(normalized, id);
+        } catch (e) {
+            getLogger().warn("status error subscriber threw", e);
+        }
+    }
+};

--- a/packages/boltz-swaps/src/statusSource/index.ts
+++ b/packages/boltz-swaps/src/statusSource/index.ts
@@ -1,0 +1,5 @@
+export * from "./types.ts";
+export * from "./polling.ts";
+export * from "./websocket.ts";
+export * from "./default.ts";
+export * from "./watch.ts";

--- a/packages/boltz-swaps/src/statusSource/polling.ts
+++ b/packages/boltz-swaps/src/statusSource/polling.ts
@@ -1,0 +1,211 @@
+import { getSwapStatus, getSwapStatuses } from "../client.ts";
+import { safeEmit, safeEmitError } from "./emit.ts";
+import type {
+    StatusErrorHandler,
+    StatusSource,
+    StatusUpdateHandler,
+    SwapUpdate,
+    Unsubscribe,
+} from "./types.ts";
+
+export type PollingStatusSourceOptions = {
+    // Delay between fetches in ms. Default 5000.
+    intervalMs?: number;
+};
+
+type PollingEntry = {
+    handlers: Set<StatusUpdateHandler>;
+    errorHandlers: Set<StatusErrorHandler>;
+    lastUpdate?: SwapUpdate;
+    lastSignature?: string;
+};
+
+// REST polling StatusSource: one shared loop bulk-fetches all tracked ids per
+// interval (GET /v2/swap/status) and fans each out to its subscribers, emitting
+// only when an id's status changes.
+export const createPollingStatusSource = (
+    options: PollingStatusSourceOptions = {},
+): StatusSource => {
+    const intervalMs = options.intervalMs ?? 5_000;
+    const entries = new Map<string, PollingEntry>();
+
+    let intervalTimer: ReturnType<typeof setTimeout> | undefined;
+    let immediateTimer: ReturnType<typeof setTimeout> | undefined;
+    let polling = false;
+    let repollRequested = false;
+    let closed = false;
+
+    const deliver = (id: string, update: SwapUpdate): void => {
+        const entry = entries.get(id);
+        if (entry === undefined) {
+            return;
+        }
+        entry.lastUpdate = update;
+        const signature = JSON.stringify(update);
+        if (entry.lastSignature === signature) {
+            // Unchanged since the last delivery: skip, matching the WebSocket
+            // source, which only emits when the backend pushes a change.
+            return;
+        }
+        entry.lastSignature = signature;
+        for (const handler of entry.handlers) {
+            safeEmit(handler, update);
+        }
+    };
+
+    const deliverError = (id: string, error: unknown): void => {
+        const entry = entries.get(id);
+        if (entry === undefined) {
+            return;
+        }
+        safeEmitError(entry.errorHandlers, error, id);
+    };
+
+    const pollIndividually = async (ids: string[]): Promise<void> => {
+        await Promise.all(
+            ids.map(async (id) => {
+                try {
+                    const status = await getSwapStatus(id);
+                    deliver(id, { id, ...status });
+                } catch (error) {
+                    deliverError(id, error);
+                }
+            }),
+        );
+    };
+
+    const pollAll = async (ids: string[]): Promise<void> => {
+        try {
+            const result = await getSwapStatuses(ids);
+            for (const id of ids) {
+                const status = result[id];
+                if (status !== undefined) {
+                    deliver(id, { id, ...status });
+                }
+            }
+        } catch {
+            // Bulk is all-or-nothing (one unknown id 400s the batch); fall back
+            // to per-id fetches so bad ids surface their own error individually.
+            await pollIndividually(ids);
+        }
+    };
+
+    const scheduleInterval = (): void => {
+        if (entries.size === 0 || intervalTimer !== undefined) {
+            return;
+        }
+        intervalTimer = setTimeout(() => {
+            intervalTimer = undefined;
+            void tick();
+        }, intervalMs);
+    };
+
+    const scheduleImmediate = (): void => {
+        if (polling) {
+            repollRequested = true;
+            return;
+        }
+        if (immediateTimer !== undefined) {
+            return;
+        }
+        immediateTimer = setTimeout(() => {
+            immediateTimer = undefined;
+            void tick();
+        }, 0);
+    };
+
+    const tick = async (): Promise<void> => {
+        if (polling) {
+            return;
+        }
+        if (intervalTimer !== undefined) {
+            clearTimeout(intervalTimer);
+            intervalTimer = undefined;
+        }
+        const ids = [...entries.keys()];
+        if (ids.length === 0) {
+            return;
+        }
+        polling = true;
+        repollRequested = false;
+        try {
+            await pollAll(ids);
+        } finally {
+            polling = false;
+            if (entries.size > 0) {
+                if (repollRequested) {
+                    repollRequested = false;
+                    scheduleImmediate();
+                } else {
+                    scheduleInterval();
+                }
+            }
+        }
+    };
+
+    return {
+        subscribe(id, onUpdate, onError): Unsubscribe {
+            if (closed) {
+                return () => {};
+            }
+            let entry = entries.get(id);
+            const isNew = entry === undefined;
+            if (entry === undefined) {
+                entry = { handlers: new Set(), errorHandlers: new Set() };
+                entries.set(id, entry);
+            }
+            const handlerIsNew = !entry.handlers.has(onUpdate);
+            if (handlerIsNew) {
+                entry.handlers.add(onUpdate);
+            }
+            if (onError !== undefined) {
+                entry.errorHandlers.add(onError);
+            }
+            // Late joiner: hand over the current status immediately (skipped for
+            // an idempotent re-subscribe of a handler already registered).
+            if (!isNew && handlerIsNew && entry.lastUpdate !== undefined) {
+                safeEmit(onUpdate, entry.lastUpdate);
+            }
+            // New id: poll promptly, not after a full interval (coalesced).
+            if (isNew) {
+                scheduleImmediate();
+            }
+
+            return () => {
+                const current = entries.get(id);
+                if (current === undefined) {
+                    return;
+                }
+                current.handlers.delete(onUpdate);
+                if (onError !== undefined) {
+                    current.errorHandlers.delete(onError);
+                }
+                if (current.handlers.size === 0) {
+                    entries.delete(id);
+                    if (entries.size === 0) {
+                        if (intervalTimer !== undefined) {
+                            clearTimeout(intervalTimer);
+                            intervalTimer = undefined;
+                        }
+                        if (immediateTimer !== undefined) {
+                            clearTimeout(immediateTimer);
+                            immediateTimer = undefined;
+                        }
+                    }
+                }
+            };
+        },
+        close(): void {
+            closed = true;
+            if (intervalTimer !== undefined) {
+                clearTimeout(intervalTimer);
+                intervalTimer = undefined;
+            }
+            if (immediateTimer !== undefined) {
+                clearTimeout(immediateTimer);
+                immediateTimer = undefined;
+            }
+            entries.clear();
+        },
+    };
+};

--- a/packages/boltz-swaps/src/statusSource/types.ts
+++ b/packages/boltz-swaps/src/statusSource/types.ts
@@ -1,0 +1,23 @@
+export type SwapUpdate = {
+    id: string;
+    status: string;
+    failureReason?: string;
+    zeroConfRejected?: boolean;
+    transaction?: { id: string; hex?: string };
+};
+
+export type StatusUpdateHandler = (update: SwapUpdate) => void;
+export type StatusErrorHandler = (error: Error, id: string) => void;
+export type Unsubscribe = () => void;
+
+// Pluggable source of swap-status updates; inject via BoltzSwapsConfig.
+export interface StatusSource {
+    // Delivers the current status as soon as known; unsubscribe is idempotent.
+    subscribe(
+        id: string,
+        onUpdate: StatusUpdateHandler,
+        onError?: StatusErrorHandler,
+    ): Unsubscribe;
+
+    close?(): void;
+}

--- a/packages/boltz-swaps/src/statusSource/watch.ts
+++ b/packages/boltz-swaps/src/statusSource/watch.ts
@@ -1,0 +1,102 @@
+import { isFinalStatus } from "../status.ts";
+import type { StatusSource, SwapUpdate, Unsubscribe } from "./types.ts";
+
+export type WatchOptions = {
+    // Abort the iteration (and unsubscribe) when this signal fires.
+    signal?: AbortSignal;
+    // Surface source errors as an iterator throw. Default false: keep streaming.
+    throwOnError?: boolean;
+    // Stop and unsubscribe once a terminal status arrives. Default true.
+    stopOnFinal?: boolean;
+};
+
+export async function* watchStatus(
+    source: StatusSource,
+    id: string,
+    options: WatchOptions = {},
+): AsyncGenerator<SwapUpdate> {
+    if (options.signal?.aborted === true) {
+        return;
+    }
+    const stopOnFinal = options.stopOnFinal ?? true;
+
+    const queue: SwapUpdate[] = [];
+    let wake: (() => void) | undefined;
+    let failure: unknown;
+    let failed = false;
+    let done = false;
+
+    const notify = (): void => {
+        const resume = wake;
+        wake = undefined;
+        resume?.();
+    };
+
+    let torndown = false;
+    let pendingTeardown = false;
+    // eslint-disable-next-line prefer-const -- read by teardown, may fire during subscribe()
+    let unsubscribe: Unsubscribe | undefined;
+    const teardown = (): void => {
+        if (torndown) {
+            return;
+        }
+        if (unsubscribe === undefined) {
+            pendingTeardown = true;
+            return;
+        }
+        torndown = true;
+        unsubscribe();
+    };
+
+    unsubscribe = source.subscribe(
+        id,
+        (update) => {
+            queue.push(update);
+            if (stopOnFinal && isFinalStatus(update.status)) {
+                done = true;
+                teardown();
+            }
+            notify();
+        },
+        (error) => {
+            if (options.throwOnError === true) {
+                failure = error;
+                failed = true;
+                teardown();
+                notify();
+            }
+        },
+    );
+    if (pendingTeardown) {
+        teardown();
+    }
+
+    const onAbort = (): void => {
+        done = true;
+        teardown();
+        notify();
+    };
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+
+    try {
+        for (;;) {
+            while (queue.length === 0 && !done && !failed) {
+                await new Promise<void>((resolve) => {
+                    wake = resolve;
+                });
+            }
+            while (queue.length > 0) {
+                yield queue.shift() as SwapUpdate;
+            }
+            if (failed) {
+                throw failure;
+            }
+            if (done) {
+                return;
+            }
+        }
+    } finally {
+        teardown();
+        options.signal?.removeEventListener("abort", onAbort);
+    }
+}

--- a/packages/boltz-swaps/src/statusSource/websocket.ts
+++ b/packages/boltz-swaps/src/statusSource/websocket.ts
@@ -1,0 +1,452 @@
+import { getBoltzApiUrl } from "../config.ts";
+import { getLogger } from "../logger.ts";
+import { safeEmit, safeEmitError } from "./emit.ts";
+import type {
+    StatusErrorHandler,
+    StatusSource,
+    StatusUpdateHandler,
+    SwapUpdate,
+    Unsubscribe,
+} from "./types.ts";
+
+// Minimal structural shape both the browser global `WebSocket` and Node's `ws`
+// satisfy, so we never need a hard `ws` dependency or `@types/ws`.
+export type WebSocketLike = {
+    readonly readyState: number;
+    send(data: string): void;
+    close(code?: number, reason?: string): void;
+    onopen: ((event: unknown) => void) | null;
+    onmessage: ((event: { data: unknown }) => void) | null;
+    onclose: ((event: { wasClean?: boolean }) => void) | null;
+    onerror: ((event: unknown) => void) | null;
+};
+export type WebSocketConstructor = new (url: string) => WebSocketLike;
+
+export type ReconnectOptions = {
+    initialDelayMs?: number;
+    maxDelayMs?: number;
+    factor?: number;
+    // Jitter fraction (0..1) applied to each delay. Default 0.5.
+    jitter?: number;
+    // Activate the polling fallback after this many failed connects. Default 3.
+    fallbackAfterAttempts?: number;
+};
+
+export type WebSocketStatusSourceOptions = {
+    // Defaults to globalThis.WebSocket. Node < 22: pass `(await import("ws")).default`.
+    webSocketImpl?: WebSocketConstructor;
+    // Backoff policy, or false to disable auto-reconnect.
+    reconnect?: ReconnectOptions | false;
+    // Serves updates while the WebSocket is down (e.g. createPollingStatusSource()).
+    fallback?: StatusSource;
+    // Force-reconnect a socket that hasn't opened within this many ms. Default 15000.
+    connectTimeoutMs?: number;
+    // Ping interval once open; an unanswered interval force-reconnects. Default 15000, 0 disables.
+    pingIntervalMs?: number;
+};
+
+const WS_OPEN = 1;
+const CHANNEL = "swap.update";
+
+const formatWsUrl = (url: string): string =>
+    url.replace("http://", "ws://").replace("https://", "wss://");
+
+const toFrame = (data: unknown): string =>
+    typeof data === "string"
+        ? data
+        : (data as { toString(): string }).toString();
+
+type ResolvedReconnect = Required<ReconnectOptions>;
+
+const resolveReconnect = (
+    reconnect: ReconnectOptions | false | undefined,
+): ResolvedReconnect | false => {
+    if (reconnect === false) {
+        return false;
+    }
+    return {
+        initialDelayMs: 1_000,
+        maxDelayMs: 30_000,
+        factor: 2,
+        jitter: 0.5,
+        fallbackAfterAttempts: 3,
+        ...(reconnect ?? {}),
+    };
+};
+
+// WebSocket StatusSource: one multiplexed socket to /v2/ws. Routes each
+// `swap.update` to its id's subscribers. Degrades to `fallback` if down.
+export const createWebSocketStatusSource = (
+    options: WebSocketStatusSourceOptions = {},
+): StatusSource => {
+    const reconnect = resolveReconnect(options.reconnect);
+    const fallback = options.fallback;
+    const connectTimeoutMs = options.connectTimeoutMs ?? 15_000;
+    const pingIntervalMs = options.pingIntervalMs ?? 15_000;
+
+    const subscribers = new Map<string, Set<StatusUpdateHandler>>();
+    const errorHandlers = new Map<string, Set<StatusErrorHandler>>();
+    const lastUpdate = new Map<string, SwapUpdate>();
+    const fallbackUnsubs = new Map<string, Unsubscribe>();
+
+    let constructor: WebSocketConstructor | null | undefined;
+    let ws: WebSocketLike | undefined;
+    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let openTimer: ReturnType<typeof setTimeout> | undefined;
+    let pingTimer: ReturnType<typeof setInterval> | undefined;
+    let awaitingPong = false;
+    let attempt = 0;
+    let fallbackActive = false;
+    let sourceClosed = false;
+
+    const resolveConstructor = (): WebSocketConstructor | null => {
+        if (constructor === undefined) {
+            constructor =
+                options.webSocketImpl ??
+                (globalThis as { WebSocket?: WebSocketConstructor })
+                    .WebSocket ??
+                null;
+        }
+        return constructor;
+    };
+
+    const dispatch = (update: SwapUpdate): void => {
+        const handlers = subscribers.get(update.id);
+        if (handlers === undefined) {
+            // A late frame for an already-unsubscribed id: drop it without
+            // recording lastUpdate, so cleaned-up ids don't leak entries.
+            return;
+        }
+        lastUpdate.set(update.id, update);
+        for (const handler of handlers) {
+            safeEmit(handler, update);
+        }
+    };
+
+    const emitError = (id: string, error: unknown): void => {
+        const handlers = errorHandlers.get(id);
+        if (handlers === undefined) {
+            return;
+        }
+        safeEmitError(handlers, error, id);
+    };
+
+    const startFallback = (id: string): void => {
+        if (fallback === undefined || fallbackUnsubs.has(id)) {
+            return;
+        }
+        fallbackUnsubs.set(
+            id,
+            fallback.subscribe(id, dispatch, (error) => emitError(id, error)),
+        );
+    };
+
+    const activateFallback = (): void => {
+        if (fallbackActive || fallback === undefined) {
+            return;
+        }
+        fallbackActive = true;
+        getLogger().warn("WebSocket status source degraded to polling");
+        for (const id of subscribers.keys()) {
+            startFallback(id);
+        }
+    };
+
+    const deactivateFallback = (): void => {
+        if (!fallbackActive) {
+            return;
+        }
+        fallbackActive = false;
+        for (const unsubscribe of fallbackUnsubs.values()) {
+            unsubscribe();
+        }
+        fallbackUnsubs.clear();
+    };
+
+    const send = (op: "subscribe" | "unsubscribe", ids: string[]): void => {
+        if (ids.length === 0 || ws === undefined || ws.readyState !== WS_OPEN) {
+            return;
+        }
+        ws.send(JSON.stringify({ op, channel: CHANNEL, args: ids }));
+    };
+
+    const handleMessage = (data: unknown): void => {
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(toFrame(data));
+        } catch (e) {
+            getLogger().warn("WebSocket status: unparseable frame", e);
+            return;
+        }
+        const message = parsed as {
+            event?: string;
+            channel?: string;
+            args?: unknown[];
+        };
+        if (message.event === "ping" || message.event === "pong") {
+            return;
+        }
+        if (
+            message.event !== "update" ||
+            message.channel !== CHANNEL ||
+            !Array.isArray(message.args)
+        ) {
+            return;
+        }
+        for (const arg of message.args) {
+            const update = arg as SwapUpdate;
+            if (
+                update === null ||
+                typeof update !== "object" ||
+                typeof update.id !== "string" ||
+                typeof update.status !== "string"
+            ) {
+                continue;
+            }
+            dispatch({
+                id: update.id,
+                status: update.status,
+                failureReason: update.failureReason,
+                zeroConfRejected: update.zeroConfRejected,
+                transaction: update.transaction,
+            });
+        }
+    };
+
+    const clearOpenTimer = (): void => {
+        if (openTimer !== undefined) {
+            clearTimeout(openTimer);
+            openTimer = undefined;
+        }
+    };
+
+    const stopPinging = (): void => {
+        if (pingTimer !== undefined) {
+            clearInterval(pingTimer);
+            pingTimer = undefined;
+        }
+        awaitingPong = false;
+    };
+
+    // Heartbeat: ping each interval; any inbound frame clears `awaitingPong`, so
+    // only a silent socket trips it, force-reconnecting it (catches half-open).
+    const startPinging = (socket: WebSocketLike): void => {
+        stopPinging();
+        if (pingIntervalMs <= 0) {
+            return;
+        }
+        pingTimer = setInterval(() => {
+            if (ws !== socket || socket.readyState !== WS_OPEN) {
+                return;
+            }
+            if (awaitingPong) {
+                getLogger().warn(
+                    "WebSocket status: ping unanswered; reconnecting",
+                );
+                socket.close();
+                handleDisconnect(socket);
+                return;
+            }
+            awaitingPong = true;
+            socket.send(JSON.stringify({ op: "ping" }));
+        }, pingIntervalMs);
+    };
+
+    // Drop the socket if it's still current and reconnect. The `ws !== socket`
+    // guard ignores superseded sockets (a stale close can't spawn a reconnect).
+    const handleDisconnect = (socket: WebSocketLike): void => {
+        if (ws !== socket) {
+            return;
+        }
+        clearOpenTimer();
+        stopPinging();
+        ws = undefined;
+        if (reconnect === false) {
+            // Not reconnecting: degrade to the fallback (if any) for good
+            // rather than going silently dark.
+            activateFallback();
+            return;
+        }
+        scheduleReconnect();
+    };
+
+    const scheduleReconnect = (): void => {
+        if (reconnect === false || sourceClosed || subscribers.size === 0) {
+            return;
+        }
+        attempt += 1;
+        if (attempt >= reconnect.fallbackAfterAttempts) {
+            activateFallback();
+        }
+        const ceiling = Math.min(
+            reconnect.maxDelayMs,
+            reconnect.initialDelayMs * reconnect.factor ** (attempt - 1),
+        );
+        const delay = ceiling * (1 - reconnect.jitter * Math.random());
+        if (reconnectTimer !== undefined) {
+            clearTimeout(reconnectTimer);
+        }
+        reconnectTimer = setTimeout(() => {
+            reconnectTimer = undefined;
+            connect();
+        }, delay);
+    };
+
+    const connect = (): void => {
+        if (
+            sourceClosed ||
+            ws !== undefined ||
+            reconnectTimer !== undefined ||
+            subscribers.size === 0
+        ) {
+            return;
+        }
+        const ctor = resolveConstructor();
+        if (ctor === null) {
+            activateFallback();
+            return;
+        }
+
+        const socket = new ctor(formatWsUrl(getBoltzApiUrl()) + "/v2/ws");
+        ws = socket;
+        openTimer = setTimeout(() => {
+            openTimer = undefined;
+            getLogger().warn("WebSocket status: connect timed out");
+            socket.close();
+            handleDisconnect(socket);
+        }, connectTimeoutMs);
+
+        // Ignore events from a socket we've abandoned (e.g. connect-timeout
+        // closed it): a late onopen/onmessage would corrupt backoff/lastUpdate.
+        socket.onopen = (): void => {
+            if (ws !== socket) {
+                return;
+            }
+            clearOpenTimer();
+            attempt = 0;
+            deactivateFallback();
+            send("subscribe", Array.from(subscribers.keys()));
+            startPinging(socket);
+        };
+        socket.onmessage = (event): void => {
+            if (ws !== socket) {
+                return;
+            }
+            // Any inbound frame proves the connection is alive.
+            awaitingPong = false;
+            handleMessage(event.data);
+        };
+        socket.onerror = (event): void => {
+            if (ws !== socket) {
+                return;
+            }
+            getLogger().error("WebSocket status source error", event);
+        };
+        socket.onclose = (): void => handleDisconnect(socket);
+    };
+
+    const cleanup = (id: string): void => {
+        subscribers.delete(id);
+        errorHandlers.delete(id);
+        lastUpdate.delete(id);
+        const unsubscribe = fallbackUnsubs.get(id);
+        if (unsubscribe !== undefined) {
+            unsubscribe();
+            fallbackUnsubs.delete(id);
+        }
+        send("unsubscribe", [id]);
+        if (subscribers.size === 0) {
+            // Reset to a clean, non-degraded state so a later subscriber starts
+            // fresh rather than inheriting a stale high backoff / degraded flag.
+            deactivateFallback();
+            attempt = 0;
+            if (reconnectTimer !== undefined) {
+                clearTimeout(reconnectTimer);
+                reconnectTimer = undefined;
+            }
+            clearOpenTimer();
+            stopPinging();
+            ws?.close();
+            ws = undefined;
+        }
+    };
+
+    return {
+        subscribe(id, onUpdate, onError): Unsubscribe {
+            if (sourceClosed) {
+                return () => {};
+            }
+            if (resolveConstructor() === null && fallback === undefined) {
+                throw new Error(
+                    "No WebSocket implementation available. Pass `webSocketImpl` " +
+                        "(e.g. `(await import('ws')).default`) or use createPollingStatusSource.",
+                );
+            }
+
+            let handlers = subscribers.get(id);
+            const isNewId = handlers === undefined || handlers.size === 0;
+            const handlerIsNew =
+                handlers === undefined || !handlers.has(onUpdate);
+            if (handlers === undefined) {
+                handlers = new Set();
+                subscribers.set(id, handlers);
+            }
+            handlers.add(onUpdate);
+            if (onError !== undefined) {
+                let errs = errorHandlers.get(id);
+                if (errs === undefined) {
+                    errs = new Set();
+                    errorHandlers.set(id, errs);
+                }
+                errs.add(onError);
+            }
+
+            connect();
+            if (isNewId) {
+                // First subscriber for this id: ask the server (it pushes the
+                // current status on subscribe) and start fallback if degraded.
+                send("subscribe", [id]);
+                if (fallbackActive) {
+                    startFallback(id);
+                }
+            } else if (handlerIsNew) {
+                // Late joiner to an already-tracked id: hand over the current
+                // status immediately. Skipped for an idempotent re-subscribe of
+                // a handler already registered, so it isn't replayed.
+                const known = lastUpdate.get(id);
+                if (known !== undefined) {
+                    safeEmit(onUpdate, known);
+                }
+            }
+
+            return () => {
+                const current = subscribers.get(id);
+                if (current === undefined) {
+                    return;
+                }
+                current.delete(onUpdate);
+                if (onError !== undefined) {
+                    errorHandlers.get(id)?.delete(onError);
+                }
+                if (current.size === 0) {
+                    cleanup(id);
+                }
+            };
+        },
+        close(): void {
+            sourceClosed = true;
+            if (reconnectTimer !== undefined) {
+                clearTimeout(reconnectTimer);
+                reconnectTimer = undefined;
+            }
+            clearOpenTimer();
+            stopPinging();
+            deactivateFallback();
+            ws?.close();
+            ws = undefined;
+            subscribers.clear();
+            errorHandlers.clear();
+            lastUpdate.clear();
+        },
+    };
+};

--- a/packages/boltz-swaps/src/statusSource/websocket.ts
+++ b/packages/boltz-swaps/src/statusSource/websocket.ts
@@ -83,13 +83,16 @@ export const createWebSocketStatusSource = (
     const fallback = options.fallback;
     const connectTimeoutMs = options.connectTimeoutMs ?? 15_000;
     const pingIntervalMs = options.pingIntervalMs ?? 15_000;
+    const constructor: WebSocketConstructor | null =
+        options.webSocketImpl ??
+        (globalThis as { WebSocket?: WebSocketConstructor }).WebSocket ??
+        null;
 
     const subscribers = new Map<string, Set<StatusUpdateHandler>>();
     const errorHandlers = new Map<string, Set<StatusErrorHandler>>();
     const lastUpdate = new Map<string, SwapUpdate>();
     const fallbackUnsubs = new Map<string, Unsubscribe>();
 
-    let constructor: WebSocketConstructor | null | undefined;
     let ws: WebSocketLike | undefined;
     let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
     let openTimer: ReturnType<typeof setTimeout> | undefined;
@@ -98,17 +101,6 @@ export const createWebSocketStatusSource = (
     let attempt = 0;
     let fallbackActive = false;
     let sourceClosed = false;
-
-    const resolveConstructor = (): WebSocketConstructor | null => {
-        if (constructor === undefined) {
-            constructor =
-                options.webSocketImpl ??
-                (globalThis as { WebSocket?: WebSocketConstructor })
-                    .WebSocket ??
-                null;
-        }
-        return constructor;
-    };
 
     const dispatch = (update: SwapUpdate): void => {
         const handlers = subscribers.get(update.id);
@@ -301,7 +293,7 @@ export const createWebSocketStatusSource = (
         ) {
             return;
         }
-        const ctor = resolveConstructor();
+        const ctor = constructor;
         if (ctor === null) {
             activateFallback();
             return;
@@ -376,7 +368,7 @@ export const createWebSocketStatusSource = (
             if (sourceClosed) {
                 return () => {};
             }
-            if (resolveConstructor() === null && fallback === undefined) {
+            if (constructor === null && fallback === undefined) {
                 throw new Error(
                     "No WebSocket implementation available. Pass `webSocketImpl` " +
                         "(e.g. `(await import('ws')).default`) or use createPollingStatusSource.",

--- a/packages/boltz-swaps/src/statusSource/websocket.ts
+++ b/packages/boltz-swaps/src/statusSource/websocket.ts
@@ -30,6 +30,9 @@ export type ReconnectOptions = {
     jitter?: number;
     // Activate the polling fallback after this many failed connects. Default 3.
     fallbackAfterAttempts?: number;
+    // A frame arriving this long after open proves the socket stable,
+    // resetting the backoff and disengaging the fallback. Default 10000.
+    stableResetMs?: number;
 };
 
 export type WebSocketStatusSourceOptions = {
@@ -70,6 +73,7 @@ const resolveReconnect = (
         factor: 2,
         jitter: 0.5,
         fallbackAfterAttempts: 3,
+        stableResetMs: 10_000,
         ...(reconnect ?? {}),
     };
 };
@@ -99,6 +103,7 @@ export const createWebSocketStatusSource = (
     let pingTimer: ReturnType<typeof setInterval> | undefined;
     let awaitingPong = false;
     let attempt = 0;
+    let openedAt = 0;
     let fallbackActive = false;
     let sourceClosed = false;
 
@@ -253,6 +258,7 @@ export const createWebSocketStatusSource = (
         clearOpenTimer();
         stopPinging();
         ws = undefined;
+        openedAt = 0;
         if (reconnect === false) {
             // Not reconnecting: degrade to the fallback (if any) for good
             // rather than going silently dark.
@@ -315,8 +321,11 @@ export const createWebSocketStatusSource = (
                 return;
             }
             clearOpenTimer();
-            attempt = 0;
-            deactivateFallback();
+            if (reconnect === false) {
+                deactivateFallback();
+            } else {
+                openedAt = Date.now();
+            }
             send("subscribe", Array.from(subscribers.keys()));
             startPinging(socket);
         };
@@ -326,6 +335,17 @@ export const createWebSocketStatusSource = (
             }
             // Any inbound frame proves the connection is alive.
             awaitingPong = false;
+            if (
+                reconnect !== false &&
+                openedAt !== 0 &&
+                Date.now() - openedAt >= reconnect.stableResetMs
+            ) {
+                // Frames past the threshold prove stability; mere openness
+                // (e.g. a half-open socket) never earns this reset.
+                openedAt = 0;
+                attempt = 0;
+                deactivateFallback();
+            }
             handleMessage(event.data);
         };
         socket.onerror = (event): void => {
@@ -352,6 +372,7 @@ export const createWebSocketStatusSource = (
             // fresh rather than inheriting a stale high backoff / degraded flag.
             deactivateFallback();
             attempt = 0;
+            openedAt = 0;
             if (reconnectTimer !== undefined) {
                 clearTimeout(reconnectTimer);
                 reconnectTimer = undefined;

--- a/packages/boltz-swaps/tests/client.spec.ts
+++ b/packages/boltz-swaps/tests/client.spec.ts
@@ -1,4 +1,8 @@
-import { quoteDexAmountIn, quoteDexAmountOut } from "boltz-swaps/client";
+import {
+    getSwapStatuses,
+    quoteDexAmountIn,
+    quoteDexAmountOut,
+} from "boltz-swaps/client";
 
 import type * as FetcherModule from "../src/http/fetcher.ts";
 
@@ -48,5 +52,76 @@ describe("boltzClient DEX quotes", () => {
         );
         expect(result.map(({ quote }) => quote)).toEqual(["5", "10", "25"]);
         expect(quotes.map(({ quote }) => quote)).toEqual(["10", "25", "5"]);
+    });
+});
+
+describe("getSwapStatuses", () => {
+    beforeEach(() => {
+        fetcherMock.mockReset();
+    });
+
+    test("returns an empty map without a request for no ids", async () => {
+        const result = await getSwapStatuses([]);
+        expect(result).toEqual({});
+        expect(fetcherMock).not.toHaveBeenCalled();
+    });
+
+    test("builds the ids query and returns the status map", async () => {
+        fetcherMock.mockResolvedValue({ a: { status: "swap.created" } });
+
+        const result = await getSwapStatuses(["a", "b"]);
+
+        expect(fetcherMock).toHaveBeenCalledWith("/v2/swap/status?ids=a&ids=b");
+        expect(result).toEqual({ a: { status: "swap.created" } });
+    });
+
+    test("url-encodes ids", async () => {
+        fetcherMock.mockResolvedValue({});
+        await getSwapStatuses(["a b", "c/d"]);
+        expect(fetcherMock).toHaveBeenCalledWith(
+            "/v2/swap/status?ids=a%20b&ids=c%2Fd",
+        );
+    });
+
+    test("chunks at 64 ids per request and merges the results", async () => {
+        const ids = Array.from({ length: 65 }, (_, i) => `id${i}`);
+        fetcherMock
+            .mockResolvedValueOnce({ [ids[0]]: { status: "a" } })
+            .mockResolvedValueOnce({ [ids[64]]: { status: "b" } });
+
+        const result = await getSwapStatuses(ids);
+
+        expect(fetcherMock).toHaveBeenCalledTimes(2);
+        const firstUrl = fetcherMock.mock.calls[0][0] as string;
+        expect(firstUrl.split("ids=").length - 1).toBe(64);
+        expect(fetcherMock.mock.calls[1][0]).toBe("/v2/swap/status?ids=id64");
+        expect(result).toEqual({
+            id0: { status: "a" },
+            id64: { status: "b" },
+        });
+    });
+
+    test("sends exactly one request for the 64-id boundary", async () => {
+        const ids = Array.from({ length: 64 }, (_, i) => `id${i}`);
+        fetcherMock.mockResolvedValue(
+            Object.fromEntries(ids.map((id) => [id, { status: "ok" }])),
+        );
+
+        const result = await getSwapStatuses(ids);
+
+        expect(fetcherMock).toHaveBeenCalledTimes(1);
+        expect(Object.keys(result)).toHaveLength(64);
+    });
+
+    test("rejects the whole call when any chunk fails (all-or-nothing)", async () => {
+        const ids = Array.from({ length: 65 }, (_, i) => `id${i}`);
+        fetcherMock
+            .mockResolvedValueOnce({ id0: { status: "a" } })
+            .mockRejectedValueOnce(new Error("could not find swap"));
+
+        await expect(getSwapStatuses(ids)).rejects.toThrow(
+            "could not find swap",
+        );
+        expect(fetcherMock).toHaveBeenCalledTimes(2);
     });
 });

--- a/packages/boltz-swaps/tests/config.spec.ts
+++ b/packages/boltz-swaps/tests/config.spec.ts
@@ -25,4 +25,17 @@ describe("boltz-swaps config defaults", () => {
             "https://solburn.example",
         );
     });
+
+    test("round-trips a configured statusSource", () => {
+        const statusSource = { subscribe: () => () => {}, close: () => {} };
+        setBoltzSwapsConfig({ statusSource });
+
+        expect(getBoltzSwapsConfig().statusSource).toBe(statusSource);
+    });
+
+    test("exposes an undefined statusSource when unset", () => {
+        setBoltzSwapsConfig({});
+
+        expect(getBoltzSwapsConfig().statusSource).toBeUndefined();
+    });
 });

--- a/packages/boltz-swaps/tests/errors.spec.ts
+++ b/packages/boltz-swaps/tests/errors.spec.ts
@@ -1,0 +1,27 @@
+import { toError } from "../src/errors.ts";
+
+describe("toError", () => {
+    test("returns the same Error instance unchanged", () => {
+        const err = new Error("original");
+        expect(toError(err)).toBe(err);
+    });
+
+    test("preserves an Error subclass", () => {
+        class CustomError extends Error {}
+        const err = new CustomError("custom");
+        expect(toError(err)).toBe(err);
+        expect(toError(err)).toBeInstanceOf(CustomError);
+    });
+
+    test("wraps a string in an Error with that message", () => {
+        const result = toError("boom");
+        expect(result).toBeInstanceOf(Error);
+        expect(result.message).toBe("boom");
+    });
+
+    test("wraps a non-Error object using its formatted message", () => {
+        const result = toError({ error: "backend failed" });
+        expect(result).toBeInstanceOf(Error);
+        expect(result.message).toBe("backend failed");
+    });
+});

--- a/packages/boltz-swaps/tests/sdk.statusSource.spec.ts
+++ b/packages/boltz-swaps/tests/sdk.statusSource.spec.ts
@@ -1,0 +1,132 @@
+import { createBoltzClient } from "boltz-swaps";
+import { vi } from "vitest";
+
+import type { StatusSource, SwapUpdate } from "../src/statusSource/index.ts";
+
+const mocks = vi.hoisted(() => ({
+    getSwapStatuses: vi.fn(),
+    createDefaultStatusSource: vi.fn(),
+}));
+
+vi.mock("../src/client.ts", async (importActual) => ({
+    ...(await importActual<typeof import("../src/client.ts")>()),
+    getSwapStatuses: mocks.getSwapStatuses,
+}));
+
+vi.mock("../src/statusSource/index.ts", async (importActual) => ({
+    ...(await importActual<typeof import("../src/statusSource/index.ts")>()),
+    createDefaultStatusSource: mocks.createDefaultStatusSource,
+}));
+
+const flush = (): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+    mocks.getSwapStatuses.mockReset();
+    mocks.createDefaultStatusSource
+        .mockReset()
+        .mockReturnValue({ subscribe: () => () => {} } as StatusSource);
+});
+
+const makeClient = (statusSource?: StatusSource) =>
+    createBoltzClient({
+        boltzApiUrl: "https://test.boltz.exchange",
+        ...(statusSource ? { statusSource } : {}),
+    });
+
+describe("createBoltzClient: swap.statuses", () => {
+    test("delegates to getSwapStatuses and returns its result", async () => {
+        mocks.getSwapStatuses.mockResolvedValue({
+            id1: { status: "swap.created" },
+        });
+
+        const result = await makeClient().swap.statuses(["id1", "id2"]);
+
+        expect(mocks.getSwapStatuses).toHaveBeenCalledWith(["id1", "id2"]);
+        expect(result).toEqual({ id1: { status: "swap.created" } });
+    });
+});
+
+describe("createBoltzClient: swap.subscribe / swap.watch", () => {
+    test("subscribe forwards to the injected status source and returns its unsubscribe", () => {
+        const unsubscribe = vi.fn();
+        const subscribe = vi.fn(() => unsubscribe);
+        const onUpdate = vi.fn();
+        const onError = vi.fn();
+
+        const client = makeClient({ subscribe });
+        const off = client.swap.subscribe("id1", onUpdate, onError);
+
+        expect(subscribe).toHaveBeenCalledWith("id1", onUpdate, onError);
+        expect(mocks.createDefaultStatusSource).not.toHaveBeenCalled();
+
+        off();
+        expect(unsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    test("watch yields updates streamed from the injected status source", async () => {
+        let handler: ((update: SwapUpdate) => void) | undefined;
+        const subscribe = vi.fn((_id, onUpdate) => {
+            handler = onUpdate;
+            return () => {};
+        });
+
+        const client = makeClient({ subscribe });
+        const updates: SwapUpdate[] = [];
+        const controller = new AbortController();
+        const run = (async () => {
+            for await (const update of client.swap.watch("id1", {
+                signal: controller.signal,
+            })) {
+                updates.push(update);
+                controller.abort();
+            }
+        })();
+
+        await flush();
+        handler?.({ id: "id1", status: "swap.created" });
+        await run;
+
+        expect(subscribe).toHaveBeenCalledWith(
+            "id1",
+            expect.any(Function),
+            expect.any(Function),
+        );
+        expect(updates).toEqual([{ id: "id1", status: "swap.created" }]);
+    });
+
+    test("creates the default status source lazily, once per client, and reuses it", () => {
+        const subscribe = vi.fn(() => () => {});
+        mocks.createDefaultStatusSource.mockReturnValue({ subscribe });
+
+        const client = makeClient();
+        // Not created until the first subscribe/watch call.
+        expect(mocks.createDefaultStatusSource).not.toHaveBeenCalled();
+
+        client.swap.subscribe("a", () => {});
+        client.swap.subscribe("b", () => {});
+
+        // One source per client, reused across calls.
+        expect(mocks.createDefaultStatusSource).toHaveBeenCalledTimes(1);
+        expect(subscribe).toHaveBeenCalledTimes(2);
+    });
+
+    test("each client gets its own default status source", () => {
+        const sources = [
+            { subscribe: vi.fn(() => () => {}) },
+            { subscribe: vi.fn(() => () => {}) },
+        ];
+        mocks.createDefaultStatusSource
+            .mockReturnValueOnce(sources[0])
+            .mockReturnValueOnce(sources[1]);
+
+        const first = makeClient();
+        const second = makeClient();
+        first.swap.subscribe("a", () => {});
+        second.swap.subscribe("b", () => {});
+
+        expect(mocks.createDefaultStatusSource).toHaveBeenCalledTimes(2);
+        expect(sources[0].subscribe).toHaveBeenCalledTimes(1);
+        expect(sources[1].subscribe).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/boltz-swaps/tests/statusSource/default.spec.ts
+++ b/packages/boltz-swaps/tests/statusSource/default.spec.ts
@@ -1,0 +1,201 @@
+import { vi } from "vitest";
+
+import {
+    type SwapUpdate,
+    createDefaultStatusSource,
+} from "../../src/statusSource/index.ts";
+
+const mocks = vi.hoisted(() => ({
+    getSwapStatuses: vi.fn(),
+    getSwapStatus: vi.fn(),
+}));
+
+vi.mock("../../src/client.ts", async (importActual) => ({
+    ...(await importActual<typeof import("../../src/client.ts")>()),
+    getSwapStatuses: mocks.getSwapStatuses,
+    getSwapStatus: mocks.getSwapStatus,
+}));
+
+class FakeWebSocket {
+    static instances: FakeWebSocket[] = [];
+
+    public readyState = 0;
+    public readonly sent: string[] = [];
+    public onopen: ((event: unknown) => void) | null = null;
+    public onmessage: ((event: { data: unknown }) => void) | null = null;
+    public onclose: ((event: { wasClean?: boolean }) => void) | null = null;
+    public onerror: ((event: unknown) => void) | null = null;
+
+    constructor(public readonly url: string) {
+        FakeWebSocket.instances.push(this);
+    }
+
+    public send(data: string): void {
+        this.sent.push(data);
+    }
+
+    public close(): void {
+        this.readyState = 3;
+        this.onclose?.({ wasClean: true });
+    }
+
+    public open(): void {
+        this.readyState = 1;
+        this.onopen?.({});
+    }
+
+    public recv(message: unknown): void {
+        this.onmessage?.({ data: JSON.stringify(message) });
+    }
+
+    public drop(): void {
+        this.readyState = 3;
+        this.onclose?.({ wasClean: false });
+    }
+}
+
+const WebSocketImpl = FakeWebSocket as unknown as new (
+    url: string,
+) => FakeWebSocket;
+
+const reconnect = {
+    initialDelayMs: 100,
+    maxDelayMs: 10_000,
+    factor: 2,
+    jitter: 0,
+    fallbackAfterAttempts: 3,
+};
+
+beforeEach(() => {
+    mocks.getSwapStatuses.mockReset();
+    mocks.getSwapStatus.mockReset();
+    FakeWebSocket.instances = [];
+});
+
+describe("createDefaultStatusSource", () => {
+    test("streams over the WebSocket while connected, without polling", () => {
+        const source = createDefaultStatusSource({
+            webSocketImpl: WebSocketImpl,
+            reconnect,
+        });
+        const seen: SwapUpdate[] = [];
+        source.subscribe("a", (update) => seen.push(update));
+
+        FakeWebSocket.instances[0].open();
+        FakeWebSocket.instances[0].recv({
+            event: "update",
+            channel: "swap.update",
+            args: [{ id: "a", status: "invoice.set" }],
+        });
+
+        expect(seen).toEqual([{ id: "a", status: "invoice.set" }]);
+        expect(mocks.getSwapStatuses).not.toHaveBeenCalled();
+
+        source.close?.();
+    });
+
+    test("degrades to REST polling on persistent WS failure, then resumes WS", async () => {
+        vi.useFakeTimers();
+        try {
+            mocks.getSwapStatuses.mockResolvedValue({
+                a: { status: "transaction.mempool" },
+            });
+            const source = createDefaultStatusSource({
+                webSocketImpl: WebSocketImpl,
+                reconnect,
+                pollIntervalMs: 50,
+            });
+            const seen: SwapUpdate[] = [];
+            source.subscribe("a", (update) => seen.push(update));
+
+            FakeWebSocket.instances[0].drop();
+            await vi.advanceTimersByTimeAsync(100);
+            FakeWebSocket.instances[1].drop();
+            await vi.advanceTimersByTimeAsync(200);
+            FakeWebSocket.instances[2].drop();
+            await vi.advanceTimersByTimeAsync(400);
+
+            // polling fallback delivers the current status (once, since the
+            // polling source de-dups unchanged statuses)
+            expect(mocks.getSwapStatuses).toHaveBeenCalledWith(["a"]);
+            expect(seen.length).toBeGreaterThan(0);
+            expect(seen.every((u) => u.status === "transaction.mempool")).toBe(
+                true,
+            );
+
+            // socket recovers → fallback dropped, WS resumes
+            const recovered =
+                FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+            recovered.open();
+            recovered.recv({
+                event: "update",
+                channel: "swap.update",
+                args: [{ id: "a", status: "transaction.confirmed" }],
+            });
+
+            expect(seen[seen.length - 1].status).toBe("transaction.confirmed");
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("falls back to polling when no WebSocket implementation is available", async () => {
+        vi.useFakeTimers();
+        vi.stubGlobal("WebSocket", undefined);
+        try {
+            mocks.getSwapStatuses.mockResolvedValue({
+                a: { status: "swap.created" },
+            });
+            const source = createDefaultStatusSource({
+                reconnect,
+                pollIntervalMs: 50,
+            });
+            const seen: SwapUpdate[] = [];
+            source.subscribe("a", (update) => seen.push(update));
+
+            await vi.advanceTimersByTimeAsync(0);
+
+            expect(FakeWebSocket.instances).toHaveLength(0);
+            expect(mocks.getSwapStatuses).toHaveBeenCalledWith(["a"]);
+            expect(seen.some((u) => u.status === "swap.created")).toBe(true);
+        } finally {
+            vi.unstubAllGlobals();
+            vi.useRealTimers();
+        }
+    });
+
+    test("polls every subscribed id in one batch during fallback", async () => {
+        vi.useFakeTimers();
+        try {
+            mocks.getSwapStatuses.mockResolvedValue({
+                x: { status: "swap.created" },
+                y: { status: "invoice.set" },
+                z: { status: "transaction.mempool" },
+            });
+            const source = createDefaultStatusSource({
+                webSocketImpl: WebSocketImpl,
+                reconnect,
+                pollIntervalMs: 50,
+            });
+            const seen: SwapUpdate[] = [];
+            source.subscribe("x", (update) => seen.push(update));
+            source.subscribe("y", (update) => seen.push(update));
+            source.subscribe("z", (update) => seen.push(update));
+
+            // 3 failed connects → fallback for every multiplexed id
+            FakeWebSocket.instances[0].drop();
+            await vi.advanceTimersByTimeAsync(100);
+            FakeWebSocket.instances[1].drop();
+            await vi.advanceTimersByTimeAsync(200);
+            FakeWebSocket.instances[2].drop();
+            await vi.advanceTimersByTimeAsync(400);
+
+            expect(mocks.getSwapStatuses).toHaveBeenCalledWith(["x", "y", "z"]);
+            expect(new Set(seen.map((u) => u.id))).toEqual(
+                new Set(["x", "y", "z"]),
+            );
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/packages/boltz-swaps/tests/statusSource/polling.spec.ts
+++ b/packages/boltz-swaps/tests/statusSource/polling.spec.ts
@@ -1,0 +1,388 @@
+import { vi } from "vitest";
+
+import {
+    type SwapUpdate,
+    createPollingStatusSource,
+} from "../../src/statusSource/index.ts";
+
+const mocks = vi.hoisted(() => ({
+    getSwapStatuses: vi.fn(),
+    getSwapStatus: vi.fn(),
+}));
+
+vi.mock("../../src/client.ts", async (importActual) => ({
+    ...(await importActual<typeof import("../../src/client.ts")>()),
+    getSwapStatuses: mocks.getSwapStatuses,
+    getSwapStatus: mocks.getSwapStatus,
+}));
+
+const statuses = (updates: SwapUpdate[]): string[] =>
+    updates.map((update) => update.status);
+
+beforeEach(() => {
+    mocks.getSwapStatuses.mockReset();
+    mocks.getSwapStatus.mockReset();
+    vi.useFakeTimers();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe("createPollingStatusSource", () => {
+    test("emits immediately and only re-emits on a status change", async () => {
+        mocks.getSwapStatuses
+            .mockResolvedValueOnce({ a: { status: "swap.created" } })
+            .mockResolvedValueOnce({ a: { status: "swap.created" } })
+            .mockResolvedValueOnce({ a: { status: "transaction.mempool" } });
+
+        const source = createPollingStatusSource({ intervalMs: 1_000 });
+        const seen: SwapUpdate[] = [];
+        source.subscribe("a", (update) => seen.push(update));
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(seen).toEqual([{ id: "a", status: "swap.created" }]);
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(statuses(seen)).toEqual(["swap.created"]);
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(statuses(seen)).toEqual(["swap.created", "transaction.mempool"]);
+    });
+
+    test("keeps polling every interval but emits only on change", async () => {
+        mocks.getSwapStatuses.mockResolvedValue({
+            a: { status: "transaction.mempool" },
+        });
+
+        const source = createPollingStatusSource({ intervalMs: 1_000 });
+        const seen: SwapUpdate[] = [];
+        source.subscribe("a", (u) => seen.push(u));
+
+        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(1_000);
+        await vi.advanceTimersByTimeAsync(1_000);
+
+        expect(mocks.getSwapStatuses.mock.calls.length).toBeGreaterThanOrEqual(
+            3,
+        );
+        expect(seen).toEqual([{ id: "a", status: "transaction.mempool" }]);
+
+        source.close?.();
+    });
+
+    test("re-emits to a fresh subscribe after the previous one unsubscribed", async () => {
+        mocks.getSwapStatuses.mockResolvedValue({
+            a: { status: "transaction.mempool" },
+        });
+
+        const source = createPollingStatusSource({ intervalMs: 1_000 });
+        const first: SwapUpdate[] = [];
+        const unsubscribe = source.subscribe("a", (u) => first.push(u));
+
+        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(first).toHaveLength(1);
+
+        unsubscribe();
+
+        const second: SwapUpdate[] = [];
+        source.subscribe("a", (u) => second.push(u));
+        await vi.advanceTimersByTimeAsync(0);
+        expect(second).toEqual([{ id: "a", status: "transaction.mempool" }]);
+
+        source.close?.();
+    });
+
+    test("re-subscribing the same handler does not replay the current status", async () => {
+        mocks.getSwapStatuses.mockResolvedValue({
+            a: { status: "transaction.mempool" },
+        });
+
+        const source = createPollingStatusSource({ intervalMs: 1_000 });
+        const seen: SwapUpdate[] = [];
+        const handler = (u: SwapUpdate): void => {
+            seen.push(u);
+        };
+        source.subscribe("a", handler);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(seen).toHaveLength(1);
+
+        source.subscribe("a", handler);
+        expect(seen).toHaveLength(1);
+
+        source.close?.();
+    });
+
+    test("fetches every tracked id in a single bulk request", async () => {
+        mocks.getSwapStatuses.mockResolvedValue({
+            a: { status: "swap.created" },
+            b: { status: "invoice.set" },
+        });
+
+        const source = createPollingStatusSource({ intervalMs: 1_000 });
+        const a: SwapUpdate[] = [];
+        const b: SwapUpdate[] = [];
+        source.subscribe("a", (u) => a.push(u));
+        source.subscribe("b", (u) => b.push(u));
+
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(mocks.getSwapStatuses).toHaveBeenCalledTimes(1);
+        expect(mocks.getSwapStatuses).toHaveBeenCalledWith(["a", "b"]);
+        expect(mocks.getSwapStatus).not.toHaveBeenCalled();
+        expect(a).toEqual([{ id: "a", status: "swap.created" }]);
+        expect(b).toEqual([{ id: "b", status: "invoice.set" }]);
+    });
+
+    test("falls back to per-id fetches when the bulk request fails", async () => {
+        mocks.getSwapStatuses.mockRejectedValue(
+            new Error("could not find swap with id: b"),
+        );
+        mocks.getSwapStatus.mockImplementation(async (id: string) => {
+            if (id === "b") {
+                throw new Error("not found");
+            }
+            return { status: "swap.created" };
+        });
+
+        const source = createPollingStatusSource({ intervalMs: 1_000 });
+        const a: SwapUpdate[] = [];
+        const bErrors: unknown[] = [];
+        source.subscribe("a", (u) => a.push(u));
+        source.subscribe(
+            "b",
+            () => {},
+            (error) => bErrors.push(error),
+        );
+
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(a).toEqual([{ id: "a", status: "swap.created" }]);
+        expect(bErrors).toHaveLength(1);
+    });
+
+    test("replays current status to a late joiner and stops on last unsubscribe", async () => {
+        mocks.getSwapStatuses.mockResolvedValue({
+            x: { status: "invoice.set" },
+        });
+
+        const source = createPollingStatusSource({ intervalMs: 1_000 });
+        const first: SwapUpdate[] = [];
+        const second: SwapUpdate[] = [];
+        const unsubscribeFirst = source.subscribe("x", (u) => first.push(u));
+        await vi.advanceTimersByTimeAsync(0);
+
+        const unsubscribeSecond = source.subscribe("x", (u) => second.push(u));
+        expect(second).toEqual([{ id: "x", status: "invoice.set" }]);
+
+        const callsAfterJoin = mocks.getSwapStatuses.mock.calls.length;
+        unsubscribeFirst();
+        unsubscribeSecond();
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(mocks.getSwapStatuses.mock.calls.length).toBe(callsAfterJoin);
+    });
+
+    test("a subscribe after close() is a no-op and never revives the loop", async () => {
+        mocks.getSwapStatuses.mockResolvedValue({
+            a: { status: "swap.created" },
+        });
+        const source = createPollingStatusSource({ intervalMs: 1_000 });
+        source.close?.();
+
+        const seen: SwapUpdate[] = [];
+        source.subscribe("a", (u) => seen.push(u));
+        await vi.advanceTimersByTimeAsync(5_000);
+
+        expect(mocks.getSwapStatuses).not.toHaveBeenCalled();
+        expect(seen).toEqual([]);
+    });
+
+    test("coalesces a subscribe that lands while a poll is in flight", async () => {
+        let resolveFirst: (
+            value: Record<string, { status: string }>,
+        ) => void = () => {};
+        mocks.getSwapStatuses
+            .mockImplementationOnce(
+                () =>
+                    new Promise((resolve) => {
+                        resolveFirst = resolve;
+                    }),
+            )
+            .mockResolvedValue({ a: { status: "x" }, b: { status: "y" } });
+
+        const source = createPollingStatusSource({ intervalMs: 1_000 });
+        source.subscribe("a", () => {});
+        await vi.advanceTimersByTimeAsync(0);
+        expect(mocks.getSwapStatuses).toHaveBeenCalledTimes(1);
+        expect(mocks.getSwapStatuses).toHaveBeenNthCalledWith(1, ["a"]);
+
+        source.subscribe("b", () => {});
+        resolveFirst({ a: { status: "x" } });
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(mocks.getSwapStatuses).toHaveBeenCalledTimes(2);
+        expect(mocks.getSwapStatuses).toHaveBeenNthCalledWith(2, ["a", "b"]);
+    });
+
+    test("fans every poll out to all handlers of an id", async () => {
+        mocks.getSwapStatuses.mockResolvedValue({
+            a: { status: "swap.created" },
+        });
+        const source = createPollingStatusSource({ intervalMs: 1_000 });
+        const h1: SwapUpdate[] = [];
+        const h2: SwapUpdate[] = [];
+        source.subscribe("a", (u) => h1.push(u));
+        source.subscribe("a", (u) => h2.push(u));
+
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(h1).toEqual([{ id: "a", status: "swap.created" }]);
+        expect(h2).toEqual([{ id: "a", status: "swap.created" }]);
+    });
+
+    test("isolates a throwing handler so the others still receive the poll", async () => {
+        mocks.getSwapStatuses.mockResolvedValue({
+            a: { status: "swap.created" },
+        });
+        const source = createPollingStatusSource({ intervalMs: 1_000 });
+        const good: SwapUpdate[] = [];
+        source.subscribe("a", () => {
+            throw new Error("boom");
+        });
+        source.subscribe("a", (u) => good.push(u));
+
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(good).toEqual([{ id: "a", status: "swap.created" }]);
+    });
+
+    test("skips an id absent from a successful bulk response (no update, no error)", async () => {
+        mocks.getSwapStatuses.mockResolvedValue({
+            a: { status: "swap.created" },
+        });
+        const source = createPollingStatusSource({ intervalMs: 1_000 });
+        const a: SwapUpdate[] = [];
+        const b: SwapUpdate[] = [];
+        const bErrors: unknown[] = [];
+        source.subscribe("a", (u) => a.push(u));
+        source.subscribe(
+            "b",
+            (u) => b.push(u),
+            (error) => bErrors.push(error),
+        );
+
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(a).toEqual([{ id: "a", status: "swap.created" }]);
+        expect(b).toEqual([]);
+        expect(bErrors).toEqual([]);
+    });
+
+    test("re-emits when a non-status field changes but the status does not", async () => {
+        mocks.getSwapStatuses
+            .mockResolvedValueOnce({
+                a: {
+                    status: "transaction.mempool",
+                    transaction: { id: "tx1" },
+                },
+            })
+            .mockResolvedValueOnce({
+                a: {
+                    status: "transaction.mempool",
+                    transaction: { id: "tx2" },
+                },
+            });
+
+        const source = createPollingStatusSource({ intervalMs: 1_000 });
+        const seen: SwapUpdate[] = [];
+        source.subscribe("a", (u) => seen.push(u));
+
+        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(1_000);
+
+        expect(seen).toEqual([
+            {
+                id: "a",
+                status: "transaction.mempool",
+                transaction: { id: "tx1" },
+            },
+            {
+                id: "a",
+                status: "transaction.mempool",
+                transaction: { id: "tx2" },
+            },
+        ]);
+
+        source.close?.();
+    });
+
+    test("re-subscribing the same handler still delivers a later update only once", async () => {
+        mocks.getSwapStatuses
+            .mockResolvedValueOnce({ a: { status: "swap.created" } })
+            .mockResolvedValue({ a: { status: "transaction.mempool" } });
+
+        const source = createPollingStatusSource({ intervalMs: 1_000 });
+        const seen: SwapUpdate[] = [];
+        const handler = (u: SwapUpdate): void => {
+            seen.push(u);
+        };
+        source.subscribe("a", handler);
+        await vi.advanceTimersByTimeAsync(0);
+        source.subscribe("a", handler);
+
+        await vi.advanceTimersByTimeAsync(1_000);
+
+        expect(statuses(seen)).toEqual(["swap.created", "transaction.mempool"]);
+
+        source.close?.();
+    });
+
+    test("normalizes a non-Error rejection into an Error for onError", async () => {
+        mocks.getSwapStatuses.mockRejectedValue("bulk down");
+        mocks.getSwapStatus.mockRejectedValue("string failure");
+
+        const source = createPollingStatusSource({ intervalMs: 1_000 });
+        const errors: unknown[] = [];
+        source.subscribe(
+            "a",
+            () => {},
+            (error) => errors.push(error),
+        );
+
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toBeInstanceOf(Error);
+        expect((errors[0] as Error).message).toBe("string failure");
+
+        source.close?.();
+    });
+
+    test("isolates a throwing error handler so the others still receive the error", async () => {
+        mocks.getSwapStatuses.mockRejectedValue(new Error("bulk down"));
+        mocks.getSwapStatus.mockRejectedValue(new Error("boom"));
+
+        const source = createPollingStatusSource({ intervalMs: 1_000 });
+        const good: unknown[] = [];
+        source.subscribe(
+            "a",
+            () => {},
+            () => {
+                throw new Error("handler exploded");
+            },
+        );
+        source.subscribe(
+            "a",
+            () => {},
+            (error) => good.push(error),
+        );
+
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(good).toHaveLength(1);
+        expect(good[0]).toBeInstanceOf(Error);
+
+        source.close?.();
+    });
+});

--- a/packages/boltz-swaps/tests/statusSource/watch.spec.ts
+++ b/packages/boltz-swaps/tests/statusSource/watch.spec.ts
@@ -1,0 +1,294 @@
+import { vi } from "vitest";
+
+import {
+    type StatusErrorHandler,
+    type StatusSource,
+    type StatusUpdateHandler,
+    type SwapUpdate,
+    watchStatus,
+} from "../../src/statusSource/index.ts";
+
+const flush = (): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("watchStatus", () => {
+    test("is a no-op when the signal is already aborted (never subscribes)", async () => {
+        const controller = new AbortController();
+        controller.abort();
+        const subscribe = vi.fn(() => () => {});
+        const source: StatusSource = { subscribe };
+
+        const iterator = watchStatus(source, "a", {
+            signal: controller.signal,
+        });
+        const first = await iterator.next();
+
+        expect(first.done).toBe(true);
+        expect(subscribe).not.toHaveBeenCalled();
+    });
+
+    test("does not register an abort listener when subscribe throws", async () => {
+        const signal = new AbortController().signal;
+        const addSpy = vi.spyOn(signal, "addEventListener");
+        const source: StatusSource = {
+            subscribe: () => {
+                throw new Error("no ws");
+            },
+        };
+
+        const iterator = watchStatus(source, "a", { signal });
+        await expect(iterator.next()).rejects.toThrow("no ws");
+        expect(addSpy).not.toHaveBeenCalled();
+    });
+
+    test("drains queued updates before surfacing an error", async () => {
+        let onUpdate: StatusUpdateHandler | undefined;
+        let onError: StatusErrorHandler | undefined;
+        const source: StatusSource = {
+            subscribe: (_id, update, error) => {
+                onUpdate = update;
+                onError = error;
+                return () => {};
+            },
+        };
+
+        const iterator = watchStatus(source, "a", { throwOnError: true });
+        const firstPending = iterator.next();
+        await flush();
+
+        onUpdate?.({ id: "a", status: "swap.created" });
+        onError?.(new Error("boom"), "a");
+
+        const first = await firstPending;
+        expect(first.done).toBe(false);
+        expect((first.value as SwapUpdate).status).toBe("swap.created");
+        await expect(iterator.next()).rejects.toThrow("boom");
+    });
+
+    test("yields updates and unsubscribes when aborted", async () => {
+        const controller = new AbortController();
+        let onUpdate: StatusUpdateHandler | undefined;
+        let unsubscribed = false;
+        const source: StatusSource = {
+            subscribe: (_id, update) => {
+                onUpdate = update;
+                return () => {
+                    unsubscribed = true;
+                };
+            },
+        };
+
+        const seen: SwapUpdate[] = [];
+        const run = (async () => {
+            for await (const update of watchStatus(source, "a", {
+                signal: controller.signal,
+            })) {
+                seen.push(update);
+            }
+        })();
+
+        await flush();
+        onUpdate?.({ id: "a", status: "swap.created" });
+        await flush();
+        controller.abort();
+        await run;
+
+        expect(seen.map((u) => u.status)).toEqual(["swap.created"]);
+        expect(unsubscribed).toBe(true);
+    });
+
+    test("swallows source errors by default and keeps streaming", async () => {
+        let onUpdate: StatusUpdateHandler | undefined;
+        let onError: StatusErrorHandler | undefined;
+        const source: StatusSource = {
+            subscribe: (_id, update, error) => {
+                onUpdate = update;
+                onError = error;
+                return () => {};
+            },
+        };
+
+        const iterator = watchStatus(source, "a"); // throwOnError defaults false
+        const firstPending = iterator.next();
+        await flush();
+
+        onError?.(new Error("boom"), "a"); // must not surface
+        onUpdate?.({ id: "a", status: "swap.created" });
+
+        const first = await firstPending;
+        expect(first.done).toBe(false);
+        expect((first.value as SwapUpdate).status).toBe("swap.created");
+    });
+
+    test("unsubscribes when the consumer breaks out of the loop", async () => {
+        let onUpdate: StatusUpdateHandler | undefined;
+        let unsubscribed = false;
+        const source: StatusSource = {
+            subscribe: (_id, update) => {
+                onUpdate = update;
+                return () => {
+                    unsubscribed = true;
+                };
+            },
+        };
+
+        const seen: SwapUpdate[] = [];
+        const run = (async () => {
+            for await (const update of watchStatus(source, "a")) {
+                seen.push(update);
+                break;
+            }
+        })();
+
+        await flush();
+        onUpdate?.({ id: "a", status: "swap.created" });
+        await run;
+
+        expect(seen.map((u) => u.status)).toEqual(["swap.created"]);
+        expect(unsubscribed).toBe(true);
+    });
+
+    test("tears down on abort even while parked at a yield (consumer not pulling)", async () => {
+        const controller = new AbortController();
+        let onUpdate: StatusUpdateHandler | undefined;
+        let unsubscribed = false;
+        const source: StatusSource = {
+            subscribe: (_id, update) => {
+                onUpdate = update;
+                return () => {
+                    unsubscribed = true;
+                };
+            },
+        };
+
+        const iterator = watchStatus(source, "a", {
+            signal: controller.signal,
+        });
+        const pending = iterator.next();
+        await flush();
+        onUpdate?.({ id: "a", status: "swap.created" });
+        const first = await pending;
+        expect((first.value as SwapUpdate).status).toBe("swap.created");
+
+        expect(unsubscribed).toBe(false);
+
+        controller.abort();
+        await flush();
+        expect(unsubscribed).toBe(true);
+
+        await iterator.return(undefined);
+    });
+
+    test("drains every buffered update in order before an abort stops iteration", async () => {
+        const controller = new AbortController();
+        let onUpdate: StatusUpdateHandler | undefined;
+        let unsubCount = 0;
+        const source: StatusSource = {
+            subscribe: (_id, update) => {
+                onUpdate = update;
+                return () => {
+                    unsubCount += 1;
+                };
+            },
+        };
+
+        const seen: SwapUpdate[] = [];
+        const run = (async () => {
+            for await (const update of watchStatus(source, "a", {
+                signal: controller.signal,
+            })) {
+                seen.push(update);
+            }
+        })();
+
+        await flush();
+        onUpdate?.({ id: "a", status: "swap.created" });
+        onUpdate?.({ id: "a", status: "transaction.mempool" });
+        onUpdate?.({ id: "a", status: "transaction.confirmed" });
+        controller.abort();
+        await run;
+
+        expect(seen.map((u) => u.status)).toEqual([
+            "swap.created",
+            "transaction.mempool",
+            "transaction.confirmed",
+        ]);
+        expect(unsubCount).toBe(1);
+    });
+
+    test("unsubscribes on a terminal status even if the consumer stops pulling", async () => {
+        let onUpdate: StatusUpdateHandler | undefined;
+        let unsubscribed = false;
+        const source: StatusSource = {
+            subscribe: (_id, update) => {
+                onUpdate = update;
+                return () => {
+                    unsubscribed = true;
+                };
+            },
+        };
+
+        const iterator = watchStatus(source, "a");
+        const pending = iterator.next();
+        await flush();
+
+        onUpdate?.({ id: "a", status: "transaction.claimed" });
+        const first = await pending;
+        expect((first.value as SwapUpdate).status).toBe("transaction.claimed");
+
+        expect(unsubscribed).toBe(true);
+
+        const second = await iterator.next();
+        expect(second.done).toBe(true);
+    });
+
+    test("handles a terminal status replayed synchronously during subscribe", async () => {
+        let unsubscribed = false;
+        const source: StatusSource = {
+            subscribe: (_id, update) => {
+                update({ id: "a", status: "transaction.claimed" });
+                return () => {
+                    unsubscribed = true;
+                };
+            },
+        };
+
+        const seen: SwapUpdate[] = [];
+        for await (const update of watchStatus(source, "a")) {
+            seen.push(update);
+        }
+
+        expect(seen.map((u) => u.status)).toEqual(["transaction.claimed"]);
+        expect(unsubscribed).toBe(true);
+    });
+
+    test("stopOnFinal:false keeps the subscription open past a terminal status", async () => {
+        let onUpdate: StatusUpdateHandler | undefined;
+        let unsubscribed = false;
+        const source: StatusSource = {
+            subscribe: (_id, update) => {
+                onUpdate = update;
+                return () => {
+                    unsubscribed = true;
+                };
+            },
+        };
+
+        const iterator = watchStatus(source, "a", { stopOnFinal: false });
+        const pending = iterator.next();
+        await flush();
+
+        onUpdate?.({ id: "a", status: "transaction.claimed" });
+        const first = await pending;
+        expect((first.value as SwapUpdate).status).toBe("transaction.claimed");
+
+        expect(unsubscribed).toBe(false);
+        const nextPending = iterator.next();
+        onUpdate?.({ id: "a", status: "invoice.settled" });
+        const second = await nextPending;
+        expect((second.value as SwapUpdate).status).toBe("invoice.settled");
+
+        await iterator.return(undefined);
+        expect(unsubscribed).toBe(true);
+    });
+});

--- a/packages/boltz-swaps/tests/statusSource/websocket.spec.ts
+++ b/packages/boltz-swaps/tests/statusSource/websocket.spec.ts
@@ -1,0 +1,905 @@
+import { vi } from "vitest";
+
+import {
+    type StatusErrorHandler,
+    type StatusSource,
+    type StatusUpdateHandler,
+    type SwapUpdate,
+    createWebSocketStatusSource,
+} from "../../src/statusSource/index.ts";
+
+class FakeWebSocket {
+    static instances: FakeWebSocket[] = [];
+
+    public readyState = 0;
+    public readonly sent: string[] = [];
+    public onopen: ((event: unknown) => void) | null = null;
+    public onmessage: ((event: { data: unknown }) => void) | null = null;
+    public onclose: ((event: { wasClean?: boolean }) => void) | null = null;
+    public onerror: ((event: unknown) => void) | null = null;
+
+    constructor(public readonly url: string) {
+        FakeWebSocket.instances.push(this);
+    }
+
+    public send(data: string): void {
+        this.sent.push(data);
+    }
+
+    public close(): void {
+        this.readyState = 3;
+        this.onclose?.({ wasClean: true });
+    }
+
+    public open(): void {
+        this.readyState = 1;
+        this.onopen?.({});
+    }
+
+    public recv(message: unknown): void {
+        this.onmessage?.({ data: JSON.stringify(message) });
+    }
+
+    public recvRaw(data: unknown): void {
+        this.onmessage?.({ data });
+    }
+
+    public drop(): void {
+        this.readyState = 3;
+        this.onclose?.({ wasClean: false });
+    }
+
+    public lastSent(): unknown {
+        return JSON.parse(this.sent[this.sent.length - 1]);
+    }
+}
+
+const WebSocketImpl = FakeWebSocket as unknown as new (
+    url: string,
+) => FakeWebSocket;
+
+const update = (id: string, status: string): SwapUpdate => ({ id, status });
+const noJitter = {
+    initialDelayMs: 100,
+    maxDelayMs: 10_000,
+    factor: 2,
+    jitter: 0,
+    fallbackAfterAttempts: 3,
+};
+
+beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.useFakeTimers();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe("createWebSocketStatusSource", () => {
+    test("defers the subscribe message until the socket opens", () => {
+        const source = createWebSocketStatusSource({
+            webSocketImpl: WebSocketImpl,
+        });
+        source.subscribe("a", () => {});
+
+        const ws = FakeWebSocket.instances[0];
+        expect(ws.sent).toHaveLength(0);
+
+        ws.open();
+        expect(ws.lastSent()).toEqual({
+            op: "subscribe",
+            channel: "swap.update",
+            args: ["a"],
+        });
+    });
+
+    test("routes updates to the matching id only, across many consumers", () => {
+        const source = createWebSocketStatusSource({
+            webSocketImpl: WebSocketImpl,
+        });
+        const a1: SwapUpdate[] = [];
+        const a2: SwapUpdate[] = [];
+        const b: SwapUpdate[] = [];
+        source.subscribe("a", (u) => a1.push(u));
+        source.subscribe("a", (u) => a2.push(u));
+        source.subscribe("b", (u) => b.push(u));
+
+        expect(FakeWebSocket.instances).toHaveLength(1);
+        const ws = FakeWebSocket.instances[0];
+        ws.open();
+
+        ws.recv({
+            event: "update",
+            channel: "swap.update",
+            args: [update("a", "transaction.mempool")],
+        });
+
+        expect(a1).toEqual([update("a", "transaction.mempool")]);
+        expect(a2).toEqual([update("a", "transaction.mempool")]);
+        expect(b).toEqual([]);
+    });
+
+    test("re-delivers identical updates (no de-dup), so retries keep firing", () => {
+        const source = createWebSocketStatusSource({
+            webSocketImpl: WebSocketImpl,
+        });
+        const seen: SwapUpdate[] = [];
+        source.subscribe("a", (u) => seen.push(u));
+        const ws = FakeWebSocket.instances[0];
+        ws.open();
+
+        const frame = {
+            event: "update",
+            channel: "swap.update",
+            args: [update("a", "transaction.mempool")],
+        };
+        ws.recv(frame);
+        ws.recv(frame);
+
+        expect(seen.map((u) => u.status)).toEqual([
+            "transaction.mempool",
+            "transaction.mempool",
+        ]);
+    });
+
+    test("re-delivers the current status to handlers after a reconnect", async () => {
+        vi.useFakeTimers();
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                reconnect: noJitter,
+            });
+            const seen: SwapUpdate[] = [];
+            source.subscribe("a", (u) => seen.push(u));
+            FakeWebSocket.instances[0].open();
+            FakeWebSocket.instances[0].recv({
+                event: "update",
+                channel: "swap.update",
+                args: [update("a", "transaction.confirmed")],
+            });
+            expect(seen).toHaveLength(1);
+
+            FakeWebSocket.instances[0].drop();
+            await vi.advanceTimersByTimeAsync(100);
+            const reconnected = FakeWebSocket.instances[1];
+            reconnected.open();
+            reconnected.recv({
+                event: "update",
+                channel: "swap.update",
+                args: [update("a", "transaction.confirmed")],
+            });
+
+            expect(seen.map((u) => u.status)).toEqual([
+                "transaction.confirmed",
+                "transaction.confirmed",
+            ]);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("replays the current status to a late joiner without a redundant subscribe", () => {
+        const source = createWebSocketStatusSource({
+            webSocketImpl: WebSocketImpl,
+        });
+        const first: SwapUpdate[] = [];
+        source.subscribe("a", (u) => first.push(u));
+        const ws = FakeWebSocket.instances[0];
+        ws.open();
+        ws.recv({
+            event: "update",
+            channel: "swap.update",
+            args: [update("a", "transaction.mempool")],
+        });
+        expect(first).toHaveLength(1);
+
+        const sentBefore = ws.sent.length;
+        const late: SwapUpdate[] = [];
+        source.subscribe("a", (u) => late.push(u));
+
+        expect(late).toEqual([update("a", "transaction.mempool")]);
+        expect(ws.sent.length).toBe(sentBefore);
+    });
+
+    test("re-subscribing the same handler is a no-op (no replay, no frame)", () => {
+        const source = createWebSocketStatusSource({
+            webSocketImpl: WebSocketImpl,
+        });
+        const seen: SwapUpdate[] = [];
+        const handler = (u: SwapUpdate): void => {
+            seen.push(u);
+        };
+        source.subscribe("a", handler);
+        const ws = FakeWebSocket.instances[0];
+        ws.open();
+        ws.recv({
+            event: "update",
+            channel: "swap.update",
+            args: [update("a", "transaction.mempool")],
+        });
+        expect(seen).toHaveLength(1);
+
+        const sentBefore = ws.sent.length;
+        source.subscribe("a", handler);
+
+        expect(FakeWebSocket.instances).toHaveLength(1);
+        expect(ws.sent.length).toBe(sentBefore);
+        expect(seen).toHaveLength(1);
+    });
+
+    test("ignores ping/pong frames and tolerates a non-string frame", () => {
+        const source = createWebSocketStatusSource({
+            webSocketImpl: WebSocketImpl,
+        });
+        const seen: SwapUpdate[] = [];
+        source.subscribe("a", (u) => seen.push(u));
+        const ws = FakeWebSocket.instances[0];
+        ws.open();
+
+        ws.recv({ event: "ping" });
+        ws.recv({ event: "pong" });
+        ws.recvRaw({
+            toString: () =>
+                JSON.stringify({
+                    event: "update",
+                    channel: "swap.update",
+                    args: [update("a", "invoice.set")],
+                }),
+        });
+
+        expect(seen).toEqual([update("a", "invoice.set")]);
+    });
+
+    test("drops a frame whose status is missing", () => {
+        const source = createWebSocketStatusSource({
+            webSocketImpl: WebSocketImpl,
+        });
+        const seen: SwapUpdate[] = [];
+        source.subscribe("a", (u) => seen.push(u));
+        const ws = FakeWebSocket.instances[0];
+        ws.open();
+
+        ws.recv({
+            event: "update",
+            channel: "swap.update",
+            args: [{ id: "a" }],
+        });
+        ws.recv({
+            event: "update",
+            channel: "swap.update",
+            args: [update("a", "invoice.set")],
+        });
+
+        expect(seen.map((u) => u.status)).toEqual(["invoice.set"]);
+    });
+
+    test("isolates a throwing subscriber from the others", () => {
+        const source = createWebSocketStatusSource({
+            webSocketImpl: WebSocketImpl,
+        });
+        const good: SwapUpdate[] = [];
+        source.subscribe("a", () => {
+            throw new Error("boom");
+        });
+        source.subscribe("a", (u) => good.push(u));
+        const ws = FakeWebSocket.instances[0];
+        ws.open();
+
+        ws.recv({
+            event: "update",
+            channel: "swap.update",
+            args: [update("a", "invoice.set")],
+        });
+
+        expect(good).toEqual([update("a", "invoice.set")]);
+    });
+
+    test("reconnects with growing backoff and re-subscribes all ids", async () => {
+        vi.useFakeTimers();
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                reconnect: noJitter,
+            });
+            source.subscribe("a", () => {});
+            source.subscribe("b", () => {});
+            FakeWebSocket.instances[0].open();
+            expect(FakeWebSocket.instances).toHaveLength(1);
+
+            FakeWebSocket.instances[0].drop();
+            await vi.advanceTimersByTimeAsync(100);
+            expect(FakeWebSocket.instances).toHaveLength(2);
+
+            FakeWebSocket.instances[1].drop();
+            await vi.advanceTimersByTimeAsync(199);
+            expect(FakeWebSocket.instances).toHaveLength(2);
+            await vi.advanceTimersByTimeAsync(1);
+            expect(FakeWebSocket.instances).toHaveLength(3);
+
+            FakeWebSocket.instances[2].open();
+            expect(FakeWebSocket.instances[2].lastSent()).toEqual({
+                op: "subscribe",
+                channel: "swap.update",
+                args: ["a", "b"],
+            });
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("unsubscribes the id and closes the socket when the last id leaves", () => {
+        const source = createWebSocketStatusSource({
+            webSocketImpl: WebSocketImpl,
+        });
+        const unsubscribe = source.subscribe("a", () => {});
+        const ws = FakeWebSocket.instances[0];
+        ws.open();
+
+        unsubscribe();
+
+        expect(ws.lastSent()).toEqual({
+            op: "unsubscribe",
+            channel: "swap.update",
+            args: ["a"],
+        });
+        expect(ws.readyState).toBe(3);
+    });
+
+    test("force-reconnects a socket that never opens (connect timeout)", async () => {
+        vi.useFakeTimers();
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                reconnect: noJitter,
+                connectTimeoutMs: 5_000,
+            });
+            source.subscribe("a", () => {});
+            expect(FakeWebSocket.instances).toHaveLength(1);
+
+            await vi.advanceTimersByTimeAsync(5_000);
+            expect(FakeWebSocket.instances[0].readyState).toBe(3);
+            await vi.advanceTimersByTimeAsync(100);
+            expect(FakeWebSocket.instances).toHaveLength(2);
+
+            source.close?.();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("ignores late events from a socket the connect timeout abandoned", async () => {
+        vi.useFakeTimers();
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                reconnect: noJitter,
+                connectTimeoutMs: 5_000,
+            });
+            const seen: SwapUpdate[] = [];
+            source.subscribe("a", (u) => seen.push(u));
+
+            const stale = FakeWebSocket.instances[0];
+            await vi.advanceTimersByTimeAsync(5_000);
+            await vi.advanceTimersByTimeAsync(100);
+            expect(FakeWebSocket.instances).toHaveLength(2);
+
+            stale.open();
+            stale.recv({
+                event: "update",
+                channel: "swap.update",
+                args: [update("a", "transaction.mempool")],
+            });
+            expect(seen).toEqual([]);
+
+            await vi.advanceTimersByTimeAsync(5_000);
+            expect(FakeWebSocket.instances[1].readyState).toBe(3);
+
+            source.close?.();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("degrades to the fallback on disconnect when reconnect is disabled", () => {
+        const fallbackSubs: { id: string; onUpdate: StatusUpdateHandler }[] =
+            [];
+        const fallback: StatusSource = {
+            subscribe: vi.fn((id, onUpdate) => {
+                const entry = { id, onUpdate };
+                fallbackSubs.push(entry);
+                return () => {
+                    const i = fallbackSubs.indexOf(entry);
+                    if (i >= 0) fallbackSubs.splice(i, 1);
+                };
+            }),
+        };
+
+        const source = createWebSocketStatusSource({
+            webSocketImpl: WebSocketImpl,
+            reconnect: false,
+            fallback,
+        });
+        const seen: SwapUpdate[] = [];
+        source.subscribe("a", (u) => seen.push(u));
+        const ws = FakeWebSocket.instances[0];
+        ws.open();
+        ws.drop();
+
+        expect(fallbackSubs.map((s) => s.id)).toEqual(["a"]);
+        fallbackSubs[0].onUpdate(update("a", "transaction.mempool"));
+        expect(seen).toEqual([update("a", "transaction.mempool")]);
+    });
+
+    test("throws when no WebSocket is available and no fallback is given", () => {
+        const source = createWebSocketStatusSource({});
+        vi.stubGlobal("WebSocket", undefined);
+        try {
+            expect(() => source.subscribe("a", () => {})).toThrow(
+                /No WebSocket implementation/,
+            );
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
+    test("a subscribe after close() is a no-op (no socket, no dead handler)", () => {
+        const source = createWebSocketStatusSource({
+            webSocketImpl: WebSocketImpl,
+        });
+        source.close?.();
+
+        const seen: SwapUpdate[] = [];
+        const unsubscribe = source.subscribe("a", (u) => seen.push(u));
+
+        expect(FakeWebSocket.instances).toHaveLength(0);
+        expect(seen).toEqual([]);
+        expect(unsubscribe).not.toThrow();
+    });
+
+    test("delegates to the fallback when no WebSocket is available", () => {
+        const fallbackSubs: { id: string; onUpdate: StatusUpdateHandler }[] =
+            [];
+        const fallback: StatusSource = {
+            subscribe: vi.fn((id, onUpdate) => {
+                const entry = { id, onUpdate };
+                fallbackSubs.push(entry);
+                return () => {
+                    const i = fallbackSubs.indexOf(entry);
+                    if (i >= 0) fallbackSubs.splice(i, 1);
+                };
+            }),
+        };
+
+        vi.stubGlobal("WebSocket", undefined);
+        try {
+            const source = createWebSocketStatusSource({ fallback });
+            const seen: SwapUpdate[] = [];
+            source.subscribe("a", (u) => seen.push(u));
+
+            expect(FakeWebSocket.instances).toHaveLength(0);
+            expect(fallbackSubs.map((s) => s.id)).toEqual(["a"]);
+
+            fallbackSubs[0].onUpdate(update("a", "transaction.mempool"));
+            expect(seen).toEqual([update("a", "transaction.mempool")]);
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
+    test("falls back to polling after persistent connect failures, then recovers", async () => {
+        vi.useFakeTimers();
+        const fallbackSubs: { id: string; onUpdate: StatusUpdateHandler }[] =
+            [];
+        const fallback: StatusSource = {
+            subscribe: vi.fn((id, onUpdate) => {
+                const entry = { id, onUpdate };
+                fallbackSubs.push(entry);
+                return () => {
+                    const i = fallbackSubs.indexOf(entry);
+                    if (i >= 0) fallbackSubs.splice(i, 1);
+                };
+            }),
+        };
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                reconnect: noJitter,
+                fallback,
+            });
+            const seen: SwapUpdate[] = [];
+            source.subscribe("a", (u) => seen.push(u));
+
+            FakeWebSocket.instances[0].drop();
+            await vi.advanceTimersByTimeAsync(100);
+            FakeWebSocket.instances[1].drop();
+            await vi.advanceTimersByTimeAsync(200);
+            FakeWebSocket.instances[2].drop();
+            await vi.advanceTimersByTimeAsync(400);
+            expect(fallbackSubs.map((s) => s.id)).toEqual(["a"]);
+
+            fallbackSubs[0].onUpdate(update("a", "transaction.mempool"));
+            expect(seen).toEqual([update("a", "transaction.mempool")]);
+
+            const recovered =
+                FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+            recovered.open();
+            expect(fallbackSubs).toHaveLength(0);
+            recovered.recv({
+                event: "update",
+                channel: "swap.update",
+                args: [update("a", "transaction.confirmed")],
+            });
+            expect(seen.map((u) => u.status)).toEqual([
+                "transaction.mempool",
+                "transaction.confirmed",
+            ]);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("surfaces fallback errors to the subscriber's onError handler", async () => {
+        vi.useFakeTimers();
+        const fallbackErr: { id: string; onError?: StatusErrorHandler }[] = [];
+        const fallback: StatusSource = {
+            subscribe: vi.fn((id, _onUpdate, onError) => {
+                fallbackErr.push({ id, onError });
+                return () => {};
+            }),
+        };
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                reconnect: noJitter,
+                fallback,
+            });
+            const errors: unknown[] = [];
+            source.subscribe(
+                "a",
+                () => {},
+                (error) => errors.push(error),
+            );
+
+            FakeWebSocket.instances[0].drop();
+            await vi.advanceTimersByTimeAsync(100);
+            FakeWebSocket.instances[1].drop();
+            await vi.advanceTimersByTimeAsync(200);
+            FakeWebSocket.instances[2].drop();
+            await vi.advanceTimersByTimeAsync(400);
+
+            fallbackErr[0].onError?.(new Error("poll failed"), "a");
+
+            expect(errors).toHaveLength(1);
+            expect((errors[0] as Error).message).toBe("poll failed");
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("dispatches every update in a multi-update frame", () => {
+        const source = createWebSocketStatusSource({
+            webSocketImpl: WebSocketImpl,
+        });
+        const a: SwapUpdate[] = [];
+        const b: SwapUpdate[] = [];
+        source.subscribe("a", (u) => a.push(u));
+        source.subscribe("b", (u) => b.push(u));
+        const ws = FakeWebSocket.instances[0];
+        ws.open();
+
+        ws.recv({
+            event: "update",
+            channel: "swap.update",
+            args: [
+                update("a", "invoice.set"),
+                update("b", "transaction.mempool"),
+            ],
+        });
+
+        expect(a).toEqual([update("a", "invoice.set")]);
+        expect(b).toEqual([update("b", "transaction.mempool")]);
+    });
+
+    test("ignores frames with the wrong event, channel, or non-array args", () => {
+        const source = createWebSocketStatusSource({
+            webSocketImpl: WebSocketImpl,
+        });
+        const seen: SwapUpdate[] = [];
+        source.subscribe("a", (u) => seen.push(u));
+        const ws = FakeWebSocket.instances[0];
+        ws.open();
+
+        ws.recv({
+            event: "snapshot",
+            channel: "swap.update",
+            args: [update("a", "x")],
+        });
+        ws.recv({
+            event: "update",
+            channel: "other.channel",
+            args: [update("a", "x")],
+        });
+        ws.recv({ event: "update", channel: "swap.update", args: { id: "a" } });
+
+        expect(seen).toEqual([]);
+    });
+
+    test("skips malformed args but keeps the valid ones in the same frame", () => {
+        const source = createWebSocketStatusSource({
+            webSocketImpl: WebSocketImpl,
+        });
+        const seen: SwapUpdate[] = [];
+        source.subscribe("a", (u) => seen.push(u));
+        const ws = FakeWebSocket.instances[0];
+        ws.open();
+
+        ws.recv({
+            event: "update",
+            channel: "swap.update",
+            args: [
+                null,
+                "not-an-object",
+                { id: 1, status: "s" },
+                { id: "a", status: 2 },
+                update("a", "invoice.set"),
+            ],
+        });
+
+        expect(seen).toEqual([update("a", "invoice.set")]);
+    });
+
+    test("preserves optional update fields through dispatch", () => {
+        const source = createWebSocketStatusSource({
+            webSocketImpl: WebSocketImpl,
+        });
+        const seen: SwapUpdate[] = [];
+        source.subscribe("a", (u) => seen.push(u));
+        const ws = FakeWebSocket.instances[0];
+        ws.open();
+
+        const full = {
+            id: "a",
+            status: "transaction.lockupFailed",
+            failureReason: "timeout",
+            zeroConfRejected: true,
+            transaction: { id: "tx1", hex: "deadbeef" },
+        };
+        ws.recv({
+            event: "update",
+            channel: "swap.update",
+            args: [full],
+        });
+
+        expect(seen).toEqual([full]);
+    });
+
+    test("resets reconnect backoff after the last subscriber leaves", async () => {
+        vi.useFakeTimers();
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                reconnect: noJitter,
+            });
+            const unsubscribe = source.subscribe("a", () => {});
+            FakeWebSocket.instances[0].open();
+            FakeWebSocket.instances[0].drop();
+            await vi.advanceTimersByTimeAsync(100);
+            expect(FakeWebSocket.instances).toHaveLength(2);
+            FakeWebSocket.instances[1].drop();
+            await vi.advanceTimersByTimeAsync(200);
+            expect(FakeWebSocket.instances).toHaveLength(3);
+
+            unsubscribe();
+            source.subscribe("a", () => {});
+            const fresh =
+                FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+            fresh.drop();
+            const before = FakeWebSocket.instances.length;
+
+            await vi.advanceTimersByTimeAsync(100);
+            expect(FakeWebSocket.instances).toHaveLength(before + 1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});
+
+describe("createWebSocketStatusSource ping heartbeat", () => {
+    const pingCount = (ws: FakeWebSocket): number =>
+        ws.sent.filter((s) => s === JSON.stringify({ op: "ping" })).length;
+
+    test("sends a ping on the first interval after the socket opens", async () => {
+        vi.useFakeTimers();
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                pingIntervalMs: 15_000,
+            });
+            source.subscribe("a", () => {});
+            const ws = FakeWebSocket.instances[0];
+            ws.open();
+
+            expect(pingCount(ws)).toBe(0);
+            await vi.advanceTimersByTimeAsync(15_000);
+            expect(pingCount(ws)).toBe(1);
+
+            source.close?.();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("force-reconnects when no traffic answers the ping", async () => {
+        vi.useFakeTimers();
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                reconnect: noJitter,
+                pingIntervalMs: 15_000,
+            });
+            source.subscribe("a", () => {});
+            const ws = FakeWebSocket.instances[0];
+            ws.open();
+
+            await vi.advanceTimersByTimeAsync(15_000);
+            expect(pingCount(ws)).toBe(1);
+            expect(FakeWebSocket.instances).toHaveLength(1);
+
+            await vi.advanceTimersByTimeAsync(15_000);
+            expect(ws.readyState).toBe(3);
+            await vi.advanceTimersByTimeAsync(100);
+            expect(FakeWebSocket.instances).toHaveLength(2);
+
+            source.close?.();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("does not reconnect when a pong answers within the interval", async () => {
+        vi.useFakeTimers();
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                reconnect: noJitter,
+                pingIntervalMs: 15_000,
+            });
+            source.subscribe("a", () => {});
+            const ws = FakeWebSocket.instances[0];
+            ws.open();
+
+            await vi.advanceTimersByTimeAsync(15_000);
+            ws.recv({ event: "pong" });
+            await vi.advanceTimersByTimeAsync(15_000);
+
+            expect(FakeWebSocket.instances).toHaveLength(1);
+            expect(pingCount(ws)).toBe(2);
+
+            source.close?.();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("treats any inbound frame as liveness, not only pongs", async () => {
+        vi.useFakeTimers();
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                reconnect: noJitter,
+                pingIntervalMs: 15_000,
+            });
+            const seen: SwapUpdate[] = [];
+            source.subscribe("a", (u) => seen.push(u));
+            const ws = FakeWebSocket.instances[0];
+            ws.open();
+
+            await vi.advanceTimersByTimeAsync(15_000);
+            ws.recv({
+                event: "update",
+                channel: "swap.update",
+                args: [update("a", "transaction.mempool")],
+            });
+            expect(seen).toHaveLength(1);
+
+            await vi.advanceTimersByTimeAsync(15_000);
+            expect(FakeWebSocket.instances).toHaveLength(1);
+
+            source.close?.();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("pings the recreated socket after a reconnect", async () => {
+        vi.useFakeTimers();
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                reconnect: noJitter,
+                pingIntervalMs: 15_000,
+            });
+            source.subscribe("a", () => {});
+            FakeWebSocket.instances[0].open();
+            FakeWebSocket.instances[0].drop();
+            await vi.advanceTimersByTimeAsync(100);
+            const recreated = FakeWebSocket.instances[1];
+            recreated.open();
+
+            await vi.advanceTimersByTimeAsync(15_000);
+            expect(pingCount(recreated)).toBe(1);
+
+            source.close?.();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("does not ping or recreate while the socket is not OPEN", async () => {
+        vi.useFakeTimers();
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                reconnect: noJitter,
+                pingIntervalMs: 15_000,
+            });
+            source.subscribe("a", () => {});
+            const ws = FakeWebSocket.instances[0];
+            ws.open();
+
+            await vi.advanceTimersByTimeAsync(15_000);
+            expect(pingCount(ws)).toBe(1);
+
+            ws.readyState = 2;
+            await vi.advanceTimersByTimeAsync(15_000);
+            expect(pingCount(ws)).toBe(1);
+            expect(FakeWebSocket.instances).toHaveLength(1);
+
+            source.close?.();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("stops pinging after close()", async () => {
+        vi.useFakeTimers();
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                pingIntervalMs: 15_000,
+            });
+            source.subscribe("a", () => {});
+            const ws = FakeWebSocket.instances[0];
+            ws.open();
+
+            source.close?.();
+            await vi.advanceTimersByTimeAsync(60_000);
+
+            expect(pingCount(ws)).toBe(0);
+            expect(FakeWebSocket.instances).toHaveLength(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("can be disabled with pingIntervalMs: 0", async () => {
+        vi.useFakeTimers();
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                pingIntervalMs: 0,
+            });
+            source.subscribe("a", () => {});
+            const ws = FakeWebSocket.instances[0];
+            ws.open();
+
+            await vi.advanceTimersByTimeAsync(60_000);
+            expect(pingCount(ws)).toBe(0);
+
+            source.close?.();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/packages/boltz-swaps/tests/statusSource/websocket.spec.ts
+++ b/packages/boltz-swaps/tests/statusSource/websocket.spec.ts
@@ -432,9 +432,9 @@ describe("createWebSocketStatusSource", () => {
     });
 
     test("throws when no WebSocket is available and no fallback is given", () => {
-        const source = createWebSocketStatusSource({});
         vi.stubGlobal("WebSocket", undefined);
         try {
+            const source = createWebSocketStatusSource({});
             expect(() => source.subscribe("a", () => {})).toThrow(
                 /No WebSocket implementation/,
             );

--- a/packages/boltz-swaps/tests/statusSource/websocket.spec.ts
+++ b/packages/boltz-swaps/tests/statusSource/websocket.spec.ts
@@ -328,6 +328,114 @@ describe("createWebSocketStatusSource", () => {
         }
     });
 
+    test("keeps backing off and degrades when the socket drops right after opening", async () => {
+        vi.useFakeTimers();
+        const fallbackUnsubscribe = vi.fn();
+        const fallbackSubscribe = vi.fn<StatusSource["subscribe"]>(
+            () => fallbackUnsubscribe,
+        );
+        const fallback: StatusSource = { subscribe: fallbackSubscribe };
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                reconnect: noJitter,
+                fallback,
+            });
+            source.subscribe("a", () => {});
+
+            // Each socket opens then drops in the same instant, so the backoff
+            // must keep climbing instead of resetting on every open.
+            FakeWebSocket.instances[0].open();
+            FakeWebSocket.instances[0].drop();
+            await vi.advanceTimersByTimeAsync(100);
+            FakeWebSocket.instances[1].open();
+            FakeWebSocket.instances[1].drop();
+            await vi.advanceTimersByTimeAsync(200);
+            FakeWebSocket.instances[2].open();
+            FakeWebSocket.instances[2].drop();
+            await vi.advanceTimersByTimeAsync(400);
+
+            expect(FakeWebSocket.instances).toHaveLength(4);
+            expect(fallbackSubscribe.mock.calls.map((c) => c[0])).toEqual([
+                "a",
+            ]);
+
+            // Another doomed open must not tear the fallback down.
+            FakeWebSocket.instances[3].open();
+            expect(fallbackUnsubscribe).not.toHaveBeenCalled();
+            expect(fallbackSubscribe).toHaveBeenCalledTimes(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("resets the backoff once a frame arrives past the stable threshold", async () => {
+        vi.useFakeTimers();
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                reconnect: noJitter,
+            });
+            source.subscribe("a", () => {});
+
+            FakeWebSocket.instances[0].drop();
+            await vi.advanceTimersByTimeAsync(100);
+            FakeWebSocket.instances[1].drop();
+            await vi.advanceTimersByTimeAsync(200);
+            expect(FakeWebSocket.instances).toHaveLength(3);
+
+            FakeWebSocket.instances[2].open();
+            await vi.advanceTimersByTimeAsync(10_000);
+            FakeWebSocket.instances[2].recv({ event: "pong" });
+            FakeWebSocket.instances[2].drop();
+
+            // Staying alive cleared the backoff: the next retry is the initial delay.
+            await vi.advanceTimersByTimeAsync(99);
+            expect(FakeWebSocket.instances).toHaveLength(3);
+            await vi.advanceTimersByTimeAsync(1);
+            expect(FakeWebSocket.instances).toHaveLength(4);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("a half-open socket that delivers no frames never counts as stable", async () => {
+        vi.useFakeTimers();
+        const fallbackSubscribe = vi.fn<StatusSource["subscribe"]>(
+            () => () => {},
+        );
+        const fallback: StatusSource = { subscribe: fallbackSubscribe };
+        try {
+            const source = createWebSocketStatusSource({
+                webSocketImpl: WebSocketImpl,
+                reconnect: noJitter,
+                pingIntervalMs: 15_000,
+                fallback,
+            });
+            source.subscribe("a", () => {});
+
+            // Silent sockets die by ping timeout at 30s — past stableResetMs.
+            FakeWebSocket.instances[0].open();
+            await vi.advanceTimersByTimeAsync(30_000);
+            expect(fallbackSubscribe).not.toHaveBeenCalled();
+            await vi.advanceTimersByTimeAsync(100);
+            FakeWebSocket.instances[1].open();
+            await vi.advanceTimersByTimeAsync(30_000);
+            expect(fallbackSubscribe).not.toHaveBeenCalled();
+            await vi.advanceTimersByTimeAsync(200);
+            FakeWebSocket.instances[2].open();
+            await vi.advanceTimersByTimeAsync(30_000);
+
+            expect(fallbackSubscribe.mock.calls.map((c) => c[0])).toEqual([
+                "a",
+            ]);
+
+            source.close?.();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     test("unsubscribes the id and closes the socket when the last id leaves", () => {
         const source = createWebSocketStatusSource({
             webSocketImpl: WebSocketImpl,
@@ -524,12 +632,15 @@ describe("createWebSocketStatusSource", () => {
             const recovered =
                 FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
             recovered.open();
-            expect(fallbackSubs).toHaveLength(0);
+            // Polling keeps covering until the socket proves stable.
+            expect(fallbackSubs.map((s) => s.id)).toEqual(["a"]);
+            await vi.advanceTimersByTimeAsync(10_000);
             recovered.recv({
                 event: "update",
                 channel: "swap.update",
                 args: [update("a", "transaction.confirmed")],
             });
+            expect(fallbackSubs).toHaveLength(0);
             expect(seen.map((u) => u.status)).toEqual([
                 "transaction.mempool",
                 "transaction.confirmed",

--- a/src/components/SwapChecker.tsx
+++ b/src/components/SwapChecker.tsx
@@ -1,3 +1,7 @@
+import {
+    type SwapUpdate,
+    createDefaultStatusSource,
+} from "boltz-swaps/statusSource";
 import { SwapType } from "boltz-swaps/types";
 import log from "loglevel";
 import { createEffect, onCleanup, onMount } from "solid-js";
@@ -10,190 +14,9 @@ import {
     swapStatusSuccess,
 } from "../consts/SwapStatus";
 import { useGlobalContext } from "../context/Global";
-import { type SwapStatusTransaction, usePayContext } from "../context/Pay";
-import { formatError } from "../utils/errors";
-import { getApiUrl } from "../utils/helper";
+import { usePayContext } from "../context/Pay";
 import { useParentNotifier } from "../utils/notifyParent";
 import type { SomeSwap } from "../utils/swapCreator";
-
-type SwapStatus = {
-    id: string;
-    status: string;
-
-    failureReason?: string;
-    transaction?: SwapStatusTransaction;
-};
-
-const reconnectInterval = 5_000;
-const pingInterval = 15_000;
-
-export class BoltzWebSocket {
-    private ws?: WebSocket;
-    private reconnectTimeout?: ReturnType<typeof setTimeout>;
-    private isClosed: boolean = false;
-    private pingTimer?: ReturnType<typeof setInterval>;
-    private awaitingPong: boolean = false;
-
-    constructor(
-        private readonly url: string,
-        private readonly relevantIds: Set<string>,
-        private readonly prepareSwap: (id: string, status: SwapStatus) => void,
-        private readonly claimSwap: (
-            id: string,
-            status: SwapStatus,
-        ) => Promise<void>,
-    ) {}
-
-    public connect = () => {
-        log.debug("Opening WebSocket");
-        void this.openWebSocket(`${this.url}/v2/ws`).catch(() => {});
-    };
-
-    public close = () => {
-        this.isClosed = true;
-        if (this.reconnectTimeout) {
-            clearTimeout(this.reconnectTimeout);
-        }
-
-        this.stopPinging();
-        this.ws?.close();
-    };
-
-    // "force" skips the check if we already subscribed to all the ids
-    public subscribeUpdates = (ids: string[], force = false) => {
-        if (!force && ids.every((id) => this.relevantIds.has(id))) {
-            return;
-        }
-
-        ids.forEach((id) => this.relevantIds.add(id));
-        if (this.ws === undefined || this.ws.readyState !== WebSocket.OPEN) {
-            log.debug("WebSocket subscription deferred", {
-                swapIds: ids,
-                readyState: this.ws?.readyState,
-                force,
-            });
-            return;
-        }
-
-        log.debug("Sending WebSocket subscription", {
-            swapIds: ids,
-            readyState: this.ws.readyState,
-            force,
-        });
-        this.ws.send(
-            JSON.stringify({
-                op: "subscribe",
-                channel: "swap.update",
-                args: ids,
-            }),
-        );
-    };
-
-    private openWebSocket = (url: string) => {
-        this.isClosed = false;
-        clearTimeout(this.reconnectTimeout);
-        this.stopPinging();
-
-        if (this.ws !== undefined) {
-            this.ws.onopen = null;
-            this.ws.onerror = null;
-            this.ws.onclose = null;
-            this.ws.onmessage = null;
-            this.ws.close();
-        }
-
-        return new Promise<void>((resolve, reject) => {
-            this.ws = new WebSocket(BoltzWebSocket.formatWsUrl(url));
-
-            this.ws.onopen = () => {
-                log.debug("WebSocket opened");
-                this.subscribeUpdates(
-                    Array.from(this.relevantIds.values()),
-                    true,
-                );
-                this.startPinging();
-            };
-            this.ws.onerror = (error) => {
-                log.error("WebSocket error", error);
-            };
-            this.ws.onclose = (error) => {
-                log.warn("WebSocket closed", error);
-                this.stopPinging();
-                this.handleClose();
-
-                if (error.wasClean) {
-                    resolve();
-                } else {
-                    reject(new Error(formatError(error)));
-                }
-            };
-            this.ws.onmessage = async (msg) => {
-                // Any inbound frame proves the connection is alive
-                this.awaitingPong = false;
-
-                const data = JSON.parse(msg.data);
-                if (data.event === "pong" || data.event === "ping") {
-                    return;
-                }
-
-                log.debug(`WebSocket message:`, data);
-
-                if (data.event === "update" && data.channel === "swap.update") {
-                    const swapUpdates = data.args as SwapStatus[];
-                    for (const status of swapUpdates) {
-                        this.relevantIds.add(status.id);
-                        this.prepareSwap(status.id, status);
-                        await navigator.locks.request(
-                            "swapCheckerClaim",
-                            async () => {
-                                await this.claimSwap(status.id, status);
-                            },
-                        );
-                    }
-                }
-            };
-        });
-    };
-
-    private handleClose = () => {
-        // Don't reconnect when it has been closed manually
-        if (this.isClosed) {
-            return;
-        }
-
-        this.reconnectTimeout = setTimeout(
-            () => this.connect(),
-            reconnectInterval,
-        );
-    };
-
-    private startPinging = () => {
-        this.stopPinging();
-        this.pingTimer = setInterval(() => {
-            if (this.ws?.readyState !== WebSocket.OPEN) {
-                return;
-            }
-
-            if (this.awaitingPong) {
-                log.warn("WebSocket ping timed out; recreating connection");
-                this.connect();
-                return;
-            }
-
-            this.awaitingPong = true;
-            this.ws.send(JSON.stringify({ op: "ping" }));
-        }, pingInterval);
-    };
-
-    private stopPinging = () => {
-        clearInterval(this.pingTimer);
-        this.pingTimer = undefined;
-        this.awaitingPong = false;
-    };
-
-    private static formatWsUrl = (url: string) =>
-        url.replace("http://", "ws://").replace("https://", "wss://");
-}
 
 export const SwapChecker = () => {
     const {
@@ -208,11 +31,11 @@ export const SwapChecker = () => {
     const { updateSwapStatus, getSwap, getSwaps } = useGlobalContext();
     const { notifyParent } = useParentNotifier();
 
-    let ws: BoltzWebSocket | undefined = undefined;
+    const statusSource = createDefaultStatusSource();
 
     const [pendingSwaps, setPendingSwaps] = createStore<string[]>([]);
 
-    const updatePendingSwaps = (swap: SomeSwap, data: SwapStatus) => {
+    const updatePendingSwaps = (swap: SomeSwap, data: SwapUpdate) => {
         if (![SwapType.Chain, SwapType.Reverse].includes(swap.type)) {
             return;
         }
@@ -232,7 +55,10 @@ export const SwapChecker = () => {
         }
     };
 
-    const prepareSwap = async (swapId: string, data: SwapStatus) => {
+    const prepareSwap = async (
+        swapId: string,
+        data: SwapUpdate,
+    ): Promise<void> => {
         const currentSwap = await getSwap(swapId);
         if (currentSwap === null) {
             log.warn(`prepareSwap: swap ${swapId} not found`);
@@ -265,6 +91,22 @@ export const SwapChecker = () => {
         }
     };
 
+    // The source emits only on an actual status change, so prepareSwap runs per update
+    const handleUpdate = (data: SwapUpdate): void => {
+        void prepareSwap(data.id, data).catch((error) =>
+            log.error(`prepareSwap failed for swap ${data.id}`, error),
+        );
+        void navigator.locks
+            .request("swapCheckerClaim", () => claimSwap(data.id, data))
+            .catch((error) =>
+                log.error(`claimSwap failed for swap ${data.id}`, error),
+            );
+    };
+
+    const subscribeSwap = (id: string): void => {
+        statusSource.subscribe(id, handleUpdate);
+    };
+
     onMount(async () => {
         const swapsToCheck = (await getSwaps()).filter(
             (s) =>
@@ -276,19 +118,13 @@ export const SwapChecker = () => {
                     s.claimTx === undefined),
         );
 
-        ws = new BoltzWebSocket(
-            getApiUrl(),
-            new Set<string>(swapsToCheck.map((s) => s.id)),
-            prepareSwap,
-            claimSwap,
-        );
-        ws.connect();
+        for (const s of swapsToCheck) {
+            subscribeSwap(s.id);
+        }
     });
 
     onCleanup(() => {
-        if (ws !== undefined) {
-            ws.close();
-        }
+        statusSource.close?.();
     });
 
     createEffect(() => {
@@ -296,10 +132,7 @@ export const SwapChecker = () => {
         if (activeSwap === undefined || activeSwap === null) {
             return;
         }
-        // on page reload assetWebsocket might not be initialized yet
-        if (ws !== undefined) {
-            ws.subscribeUpdates([activeSwap.id]);
-        }
+        subscribeSwap(activeSwap.id);
     });
 
     window.onbeforeunload = (event: BeforeUnloadEvent) => {

--- a/tests/components/SwapChecker.spec.tsx
+++ b/tests/components/SwapChecker.spec.tsx
@@ -1,109 +1,80 @@
-import { cleanup, render } from "@solidjs/testing-library";
+import { render, waitFor } from "@solidjs/testing-library";
+import { SwapType } from "boltz-swaps/types";
+import log from "loglevel";
+import { vi } from "vitest";
 
-import { BoltzWebSocket, SwapChecker } from "../../src/components/SwapChecker";
-
-vi.mock("../../src/context/Pay", () => ({
-    usePayContext: () => ({
-        swap: () => null,
+const h = vi.hoisted(() => {
+    const handlers = new Map<string, (update: unknown) => void>();
+    const unsubscribe = vi.fn();
+    const close = vi.fn();
+    const subscribe = vi.fn(
+        (id: string, onUpdate: (update: unknown) => void) => {
+            handlers.set(id, onUpdate);
+            return unsubscribe;
+        },
+    );
+    return {
+        handlers,
+        unsubscribe,
+        close,
+        subscribe,
+        getSwap: vi.fn(),
+        getSwaps: vi.fn(),
+        updateSwapStatus: vi.fn(),
+        claimSwap: vi.fn(),
         setSwap: vi.fn(),
-        claimSwap: vi.fn().mockResolvedValue(undefined),
         setSwapStatus: vi.fn(),
         setSwapStatusTransaction: vi.fn(),
         setFailureReason: vi.fn(),
-        shouldIgnoreBackendStatus: () => false,
+        shouldIgnoreBackendStatus: vi.fn(() => false),
+        swap: vi.fn(() => null),
+        notifyParent: vi.fn(),
+    };
+});
+
+vi.mock("boltz-swaps/statusSource", () => ({
+    createDefaultStatusSource: () => ({
+        subscribe: h.subscribe,
+        close: h.close,
     }),
 }));
 
 vi.mock("../../src/context/Global", () => ({
     useGlobalContext: () => ({
-        updateSwapStatus: vi.fn().mockResolvedValue(undefined),
-        getSwap: vi.fn().mockResolvedValue(null),
-        getSwaps: vi.fn().mockResolvedValue([]),
+        getSwap: h.getSwap,
+        getSwaps: h.getSwaps,
+        updateSwapStatus: h.updateSwapStatus,
+    }),
+}));
+
+vi.mock("../../src/context/Pay", () => ({
+    usePayContext: () => ({
+        swap: h.swap,
+        setSwap: h.setSwap,
+        claimSwap: h.claimSwap,
+        setSwapStatus: h.setSwapStatus,
+        setSwapStatusTransaction: h.setSwapStatusTransaction,
+        setFailureReason: h.setFailureReason,
+        shouldIgnoreBackendStatus: h.shouldIgnoreBackendStatus,
     }),
 }));
 
 vi.mock("../../src/utils/notifyParent", () => ({
-    useParentNotifier: () => ({ notifyParent: vi.fn() }),
+    useParentNotifier: () => ({ notifyParent: h.notifyParent }),
 }));
 
-type CloseEvent = { wasClean: boolean; code?: number; reason?: string };
+const { SwapChecker } = await import("../../src/components/SwapChecker");
 
-class FakeWebSocket {
-    static readonly CONNECTING = 0;
-    static readonly OPEN = 1;
-    static readonly CLOSING = 2;
-    static readonly CLOSED = 3;
+const swapA = { id: "A", type: SwapType.Reverse, status: "swap.created" };
 
-    static instances: FakeWebSocket[] = [];
-
-    readonly url: string;
-    readyState: number = FakeWebSocket.CONNECTING;
-
-    onopen: (() => void) | null = null;
-    onerror: ((ev?: unknown) => void) | null = null;
-    onclose: ((ev: CloseEvent) => void) | null = null;
-    onmessage: ((ev: { data: string }) => void | Promise<void>) | null = null;
-
-    send = vi.fn();
-    // Does not fire onclose; tests drive close events via triggerClose()
-    close = vi.fn(() => {
-        this.readyState = FakeWebSocket.CLOSING;
-    });
-
-    constructor(url: string) {
-        this.url = url;
-        FakeWebSocket.instances.push(this);
-    }
-
-    open() {
-        this.readyState = FakeWebSocket.OPEN;
-        this.onopen?.();
-    }
-
-    message(data: unknown) {
-        return this.onmessage?.({ data: JSON.stringify(data) });
-    }
-
-    triggerClose(wasClean = false) {
-        this.readyState = FakeWebSocket.CLOSED;
-        this.onclose?.({ wasClean, code: wasClean ? 1000 : 1006, reason: "" });
-    }
-
-    get pingCount() {
-        return this.send.mock.calls.filter(
-            (call) => call[0] === JSON.stringify({ op: "ping" }),
-        ).length;
-    }
-
-    get subscriptions(): Record<string, unknown>[] {
-        return this.send.mock.calls
-            .map(
-                (call) =>
-                    JSON.parse(call[0] as string) as Record<string, unknown>,
-            )
-            .filter((msg) => msg.op === "subscribe");
-    }
-}
-
-const connectWs = (ids: string[] = []) => {
-    const prepareSwap = vi.fn();
-    const claimSwap = vi.fn().mockResolvedValue(undefined);
-    const ws = new BoltzWebSocket(
-        "http://api.test",
-        new Set(ids),
-        prepareSwap,
-        claimSwap,
-    );
-    ws.connect();
-    const socket = FakeWebSocket.instances[0];
-    return { ws, socket, prepareSwap, claimSwap };
-};
-
-describe("BoltzWebSocket heartbeat", () => {
+describe("SwapChecker", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
-        FakeWebSocket.instances = [];
-        vi.stubGlobal("WebSocket", FakeWebSocket);
+        vi.clearAllMocks();
+        h.handlers.clear();
+        h.swap.mockReturnValue(null);
+        h.shouldIgnoreBackendStatus.mockReturnValue(false);
+        h.updateSwapStatus.mockResolvedValue(undefined);
+        h.claimSwap.mockResolvedValue(undefined);
         Object.defineProperty(window.navigator, "locks", {
             configurable: true,
             value: {
@@ -115,149 +86,85 @@ describe("BoltzWebSocket heartbeat", () => {
         });
     });
 
-    afterEach(() => {
-        cleanup();
-        vi.useRealTimers();
-        vi.unstubAllGlobals();
-    });
+    test("retries prepareSwap on a later delivery when the swap was not yet persisted", async () => {
+        h.getSwaps.mockResolvedValue([swapA]);
+        h.getSwap.mockResolvedValue(null);
 
-    test("sends an application ping on the first interval after the socket opens", async () => {
-        const { socket } = connectWs();
-        socket.open();
-
-        expect(socket.pingCount).toBe(0);
-        await vi.advanceTimersByTimeAsync(15_000);
-        expect(socket.pingCount).toBe(1);
-    });
-
-    test("recreates the socket when no traffic answers the ping before the next interval", async () => {
-        const { socket } = connectWs();
-        socket.open();
-
-        await vi.advanceTimersByTimeAsync(15_000);
-        expect(socket.pingCount).toBe(1);
-        expect(FakeWebSocket.instances).toHaveLength(1);
-
-        await vi.advanceTimersByTimeAsync(15_000);
-        expect(socket.close).toHaveBeenCalled();
-        expect(FakeWebSocket.instances).toHaveLength(2);
-    });
-
-    test("does not recreate when a pong arrives within the interval", async () => {
-        const { socket } = connectWs();
-        socket.open();
-
-        await vi.advanceTimersByTimeAsync(15_000);
-        await socket.message({ event: "pong" });
-        await vi.advanceTimersByTimeAsync(15_000);
-
-        expect(FakeWebSocket.instances).toHaveLength(1);
-        expect(socket.pingCount).toBe(2);
-    });
-
-    test("treats any inbound message as liveness, not only pongs", async () => {
-        const { socket, prepareSwap } = connectWs();
-        socket.open();
-
-        await vi.advanceTimersByTimeAsync(15_000);
-        await socket.message({
-            event: "update",
-            channel: "swap.update",
-            args: [{ id: "swap-a", status: "transaction.mempool" }],
-        });
-        expect(prepareSwap).toHaveBeenCalledWith(
-            "swap-a",
-            expect.objectContaining({ id: "swap-a" }),
-        );
-
-        await vi.advanceTimersByTimeAsync(15_000);
-        expect(FakeWebSocket.instances).toHaveLength(1);
-    });
-
-    test("stops pinging after close()", async () => {
-        const { ws, socket } = connectWs();
-        socket.open();
-
-        ws.close();
-        await vi.advanceTimersByTimeAsync(60_000);
-
-        expect(socket.pingCount).toBe(0);
-        expect(socket.close).toHaveBeenCalled();
-        expect(FakeWebSocket.instances).toHaveLength(1);
-    });
-
-    test("does not schedule a reconnect from the superseded socket after a recreate", async () => {
-        const { socket } = connectWs();
-        socket.open();
-
-        await vi.advanceTimersByTimeAsync(30_000);
-        expect(FakeWebSocket.instances).toHaveLength(2);
-
-        socket.triggerClose(false);
-        await vi.advanceTimersByTimeAsync(5_000);
-        expect(FakeWebSocket.instances).toHaveLength(2);
-    });
-
-    test("runs exactly one heartbeat on the recreated socket", async () => {
-        const { socket } = connectWs();
-        socket.open();
-
-        await vi.advanceTimersByTimeAsync(30_000);
-        expect(FakeWebSocket.instances).toHaveLength(2);
-
-        const recreated = FakeWebSocket.instances[1];
-        recreated.open();
-        await vi.advanceTimersByTimeAsync(15_000);
-        expect(recreated.pingCount).toBe(1);
-    });
-
-    test("does not ping or recreate while the socket is not OPEN", async () => {
-        const { socket } = connectWs();
-        socket.open();
-
-        await vi.advanceTimersByTimeAsync(15_000);
-        socket.readyState = FakeWebSocket.CLOSING;
-        await vi.advanceTimersByTimeAsync(15_000);
-
-        expect(FakeWebSocket.instances).toHaveLength(1);
-        expect(socket.pingCount).toBe(1);
-    });
-
-    test("re-subscribes the relevant swap ids on the recreated socket", async () => {
-        const { socket } = connectWs(["swap-x"]);
-        socket.open();
-        expect(socket.subscriptions).toContainEqual(
-            expect.objectContaining({
-                op: "subscribe",
-                channel: "swap.update",
-                args: ["swap-x"],
-            }),
-        );
-
-        await vi.advanceTimersByTimeAsync(30_000);
-        const recreated = FakeWebSocket.instances[1];
-        recreated.open();
-        expect(recreated.subscriptions).toContainEqual(
-            expect.objectContaining({
-                op: "subscribe",
-                channel: "swap.update",
-                args: ["swap-x"],
-            }),
-        );
-    });
-
-    test("tears down the heartbeat when the SwapChecker unmounts", async () => {
         render(() => <SwapChecker />);
-        await vi.advanceTimersByTimeAsync(0);
-        expect(FakeWebSocket.instances).toHaveLength(1);
+        await waitFor(() =>
+            expect(h.subscribe).toHaveBeenCalledWith("A", expect.any(Function)),
+        );
+        const handler = h.handlers.get("A")!;
 
-        const socket = FakeWebSocket.instances[0];
-        socket.open();
+        const update = { id: "A", status: "transaction.mempool" };
+        handler(update);
 
-        cleanup();
-        await vi.advanceTimersByTimeAsync(60_000);
+        await waitFor(() => expect(h.claimSwap).toHaveBeenCalledTimes(1));
+        expect(h.updateSwapStatus).not.toHaveBeenCalled();
 
-        expect(socket.pingCount).toBe(0);
-        expect(FakeWebSocket.instances).toHaveLength(1);
+        h.getSwap.mockResolvedValue(swapA);
+        handler(update);
+
+        await waitFor(() =>
+            expect(h.updateSwapStatus).toHaveBeenCalledWith(
+                "A",
+                "transaction.mempool",
+            ),
+        );
+        expect(h.claimSwap).toHaveBeenCalledTimes(2);
+    });
+
+    test("runs prepareSwap and claims on every delivery (de-dup is the source's job)", async () => {
+        h.getSwaps.mockResolvedValue([swapA]);
+        h.getSwap.mockResolvedValue(swapA);
+
+        render(() => <SwapChecker />);
+        await waitFor(() => expect(h.subscribe).toHaveBeenCalled());
+        const handler = h.handlers.get("A")!;
+
+        handler({ id: "A", status: "transaction.mempool" });
+        await waitFor(() =>
+            expect(h.updateSwapStatus).toHaveBeenCalledTimes(1),
+        );
+        expect(h.claimSwap).toHaveBeenCalledTimes(1);
+
+        handler({ id: "A", status: "transaction.mempool" });
+        await waitFor(() =>
+            expect(h.updateSwapStatus).toHaveBeenCalledTimes(2),
+        );
+        expect(h.claimSwap).toHaveBeenCalledTimes(2);
+    });
+
+    test("closes the source on cleanup", async () => {
+        h.getSwaps.mockResolvedValue([swapA]);
+        h.getSwap.mockResolvedValue(swapA);
+
+        const { unmount } = render(() => <SwapChecker />);
+        await waitFor(() => expect(h.subscribe).toHaveBeenCalledTimes(1));
+
+        unmount();
+
+        expect(h.close).toHaveBeenCalledTimes(1);
+        expect(h.unsubscribe).not.toHaveBeenCalled();
+    });
+
+    test("logs a rejected claimSwap instead of leaking an unhandled rejection", async () => {
+        const errorSpy = vi.spyOn(log, "error").mockImplementation(() => {});
+        h.getSwaps.mockResolvedValue([swapA]);
+        h.getSwap.mockResolvedValue(swapA);
+        h.claimSwap.mockRejectedValue(new Error("claim boom"));
+
+        render(() => <SwapChecker />);
+        await waitFor(() => expect(h.subscribe).toHaveBeenCalled());
+
+        h.handlers.get("A")!({ id: "A", status: "transaction.mempool" });
+
+        await waitFor(() =>
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.stringContaining("claimSwap failed for swap A"),
+                expect.any(Error),
+            ),
+        );
+        errorSpy.mockRestore();
     });
 });


### PR DESCRIPTION
Depends on https://github.com/BoltzExchange/boltz-backend/pull/1451

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added real-time swap status streaming and callback subscriptions via `statusSource`, including async `watch` and batched status lookup (`swap.statuses`).
  * Introduced a configurable `statusSource` with automatic WebSocket-to-REST fallback, terminal-state stopping options, and new public `statusSource` package entry.
* **Bug Fixes**
  * Updated swap examples and SwapChecker to use streamed status updates instead of fixed-interval polling.
* **Tests**
  * Added/expanded unit and integration coverage for batch queries, streaming semantics, polling/WebSocket fallback behavior, and updated SwapChecker logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->