### PR TITLE
feat: offer refund when commitment is rejected

### DIFF
--- a/e2e/arbitrum/lbtcUsdt0.spec.ts
+++ b/e2e/arbitrum/lbtcUsdt0.spec.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test";
 import { oftAbi } from "boltz-swaps/oft";
 import {
     type Address,
+    type Chain,
     type Hex,
     type PublicClient,
     createPublicClient,
@@ -453,6 +454,101 @@ const expectOftSendTx = async (
     expect(sent.args.amountReceivedLD).toBeGreaterThan(0n);
 };
 
+// Whale holding USD₮0 on the Arbitrum fork; impersonated to fund the test
+// wallet so it can send a native USDT0 (Arbitrum) commitment swap.
+const usdt0FundingSource = getAddress(
+    "0xF977814e90dA44bFA03b6295A0616a897441aceC",
+);
+const usdt0FundingAmount = parseUnits("500", 6);
+
+type ArbitrumE2e = { chain: Chain; publicClient: PublicClient; rpcUrl: string };
+
+const arbWalletAccountIndex = 3;
+
+const getArbWalletAddress = async (
+    publicClient: PublicClient,
+): Promise<Address> => {
+    const accounts = (await publicClient.request({
+        method: "eth_accounts",
+        params: [],
+    } as never)) as Address[];
+    const walletAddress = accounts[arbWalletAccountIndex];
+    if (walletAddress === undefined) {
+        throw new Error(
+            `Arbitrum account #${arbWalletAccountIndex} is not available in Anvil`,
+        );
+    }
+    return getAddress(walletAddress);
+};
+
+const clearEoaDelegation = async (
+    publicClient: PublicClient,
+    account: Address,
+) => {
+    await publicClient.request({
+        method: "anvil_setCode" as never,
+        params: [account, "0x"] as never,
+    });
+};
+
+const fundArbUsdt0Wallet = async (arbitrum: ArbitrumE2e, wallet: Address) => {
+    const token = getRegtestTokenAddress("USDT0");
+    if (
+        (await getTokenBalance(arbitrum.publicClient, token, wallet)) >=
+        parseUnits(usdt0EthSendAmount, 6)
+    ) {
+        return;
+    }
+
+    await arbitrum.publicClient.request({
+        method: "anvil_setBalance" as never,
+        params: [
+            usdt0FundingSource,
+            `0x${parseEther("1").toString(16)}`,
+        ] as never,
+    });
+    await arbitrum.publicClient.request({
+        method: "anvil_impersonateAccount" as never,
+        params: [usdt0FundingSource] as never,
+    });
+
+    try {
+        const walletClient = createWalletClient({
+            account: usdt0FundingSource,
+            chain: arbitrum.chain,
+            transport: http(arbitrum.rpcUrl, { timeout: actionTimeout }),
+        });
+        const hash = await walletClient.writeContract({
+            address: token,
+            abi: erc20Abi,
+            functionName: "transfer",
+            args: [wallet, usdt0FundingAmount],
+        });
+        await arbitrum.publicClient.waitForTransactionReceipt({ hash });
+    } finally {
+        await arbitrum.publicClient.request({
+            method: "anvil_stopImpersonatingAccount" as never,
+            params: [usdt0FundingSource] as never,
+        });
+    }
+};
+
+const lockupCommitment = async (page: Page, walletAddress: Address) => {
+    await connectWallet(page, walletAddress);
+
+    const approve = page.getByRole("button", { name: /^approve$/i });
+    const send = page.getByRole("button", { name: /^send$/i });
+
+    await expect(send.or(approve)).toBeVisible({ timeout: actionTimeout });
+    if (await approve.isVisible().catch(() => false)) {
+        await approve.click();
+        await expect(approve).toBeHidden({ timeout: actionTimeout });
+    }
+
+    await expect(send).toBeEnabled({ timeout: actionTimeout });
+    await send.click();
+};
+
 describeArbitrumE2e("Arbitrum stablecoin e2e", () => {
     test.describe.configure({ mode: "serial" });
 
@@ -565,5 +661,105 @@ describeArbitrumE2e("Arbitrum stablecoin e2e", () => {
             await waitForBridgeTxHash(page, swapId),
             walletAddress,
         );
+    });
+
+    test("offers a source-asset refund when the backend rejects the commitment", async ({
+        arbitrum,
+        page,
+    }) => {
+        test.setTimeout(testTimeout);
+
+        const walletAddress = await getArbWalletAddress(arbitrum.publicClient);
+        await clearEoaDelegation(arbitrum.publicClient, walletAddress);
+        await fundArbUsdt0Wallet(arbitrum, walletAddress);
+        await injectWalletProvider({
+            page,
+            publicClient: arbitrum.publicClient,
+            walletClient: createWalletClient({
+                account: walletAddress,
+                chain: arbitrum.chain,
+                transport: http(arbitrum.rpcUrl, { timeout: actionTimeout }),
+            }),
+            chain: arbitrum.chain,
+        });
+
+        await waitForDexQuote({
+            tokenIn: getRegtestTokenAddress("USDT0"),
+            tokenOut: getRegtestTokenAddress("TBTC"),
+            amountIn: parseUnits("39.996", 6),
+            label: "USDT0 -> TBTC",
+        });
+
+        // Force the backend to permanently reject the commitment post.
+        let commitmentPosts = 0;
+        await page.route("**/v2/commitment/*", async (route, request) => {
+            const isRefund = new URL(request.url()).pathname.endsWith(
+                "/refund",
+            );
+            if (request.method() !== "POST" || isRefund) {
+                await route.continue();
+                return;
+            }
+
+            commitmentPosts += 1;
+            await route.fulfill({
+                status: 400,
+                contentType: "application/json",
+                body: JSON.stringify({
+                    error: "insufficient amount: 16643 < 16650",
+                }),
+            });
+        });
+
+        await createSwap(
+            page,
+            "USDT0",
+            "L-BTC",
+            await getLiquidAddress(),
+            usdt0EthSendAmount,
+            { walletAddress },
+        );
+        await lockupCommitment(page, walletAddress);
+
+        await expect(
+            page.getByText(dict.en.commitment_rejected_line),
+        ).toBeVisible({ timeout: testTimeout });
+
+        await expect(
+            page.getByRole("button", {
+                name: new RegExp(`^${dict.en.refund}$`, "i"),
+            }),
+        ).toBeVisible({ timeout: actionTimeout });
+
+        expect(commitmentPosts).toBeGreaterThan(0);
+        const postsAtRejection = commitmentPosts;
+        await page.waitForTimeout(7_000);
+        expect(commitmentPosts).toBe(postsAtRejection);
+
+        const usdt0 = getRegtestTokenAddress("USDT0");
+        const usdt0BeforeRefund = await getTokenBalance(
+            arbitrum.publicClient,
+            usdt0,
+            walletAddress,
+        );
+        await page
+            .getByRole("button", {
+                name: new RegExp(`^${dict.en.refund}$`, "i"),
+            })
+            .click();
+        await expect
+            .poll(
+                () =>
+                    getTokenBalance(
+                        arbitrum.publicClient,
+                        usdt0,
+                        walletAddress,
+                    ),
+                {
+                    timeout: actionTimeout,
+                    message: "cooperative refund returns USDT0 to the wallet",
+                },
+            )
+            .toBeGreaterThan(usdt0BeforeRefund);
     });
 });

--- a/src/components/SwapExecutionWorker.tsx
+++ b/src/components/SwapExecutionWorker.tsx
@@ -67,6 +67,7 @@ import { usePayContext } from "../context/Pay";
 import { useWeb3Signer } from "../context/Web3";
 import { useModifySwap } from "../hooks/useModifySwap";
 import { formatAssetAmountForLog } from "../utils/denomination";
+import { formatError } from "../utils/errors";
 import { sendPopulatedTransaction } from "../utils/evmTransaction";
 import { type ClaimQuote, fetchDexQuote } from "../utils/quoter";
 import {
@@ -84,6 +85,13 @@ const retryIntervalMs = 1_000;
 const taskRetryIntervalMs = 3_000;
 const preBridgeDexQuoteAttempts = 3;
 const preBridgeDexQuoteRetryDelayMs = 5_000;
+
+// The backend rejects a commitment whose locked amount is below the swap's
+// expected amount with "insufficient amount: <actual> < <expected>". The
+// on-chain lockup is immutable, so this can never succeed on retry; treat it as
+// terminal and offer a refund instead of looping forever.
+const isInsufficientCommitmentAmountError = (error: unknown): boolean =>
+    /insufficient amount/i.test(formatError(error));
 
 const sleep = (ms: number) =>
     new Promise((resolve) => window.setTimeout(resolve, ms));
@@ -168,6 +176,7 @@ const needsCommitmentPost = (
     swap !== null &&
     swap.commitmentLockupTxHash !== undefined &&
     !swap.commitmentSignatureSubmitted &&
+    swap.commitmentRejection === undefined &&
     isPendingCommitmentStatus(swap.status);
 
 type TaskStage = "pre-bridge" | "commitment";
@@ -1452,15 +1461,35 @@ export const SwapExecutionWorker = () => {
                             storedSwap.commitmentLockupTxHash,
                     }),
                 );
-                await postCommitmentSignatureForTransaction({
-                    asset: storedSwap.assetSend,
-                    commitmentAsset,
-                    swapId: storedSwap.id,
-                    preimageHash: getSwapPreimageHash(storedSwap),
-                    commitmentTxHash: storedSwap.commitmentLockupTxHash as Hash,
-                    erc20Swap: getErc20Swap(commitmentAsset),
-                    signer: transactionSigner,
-                });
+                try {
+                    await postCommitmentSignatureForTransaction({
+                        asset: storedSwap.assetSend,
+                        commitmentAsset,
+                        swapId: storedSwap.id,
+                        preimageHash: getSwapPreimageHash(storedSwap),
+                        commitmentTxHash:
+                            storedSwap.commitmentLockupTxHash as Hash,
+                        erc20Swap: getErc20Swap(commitmentAsset),
+                        signer: transactionSigner,
+                    });
+                } catch (error) {
+                    if (isInsufficientCommitmentAmountError(error)) {
+                        const reason = formatError(error);
+                        await modifySwap(storedSwap.id, (s) => {
+                            s.commitmentRejection = { reason };
+                        });
+                        log.warn(
+                            "Swap execution commitment permanently rejected; offering refund",
+                            getSwapExecutionLogContext(storedSwap.id, {
+                                reason,
+                                commitmentLockupTxHash:
+                                    storedSwap.commitmentLockupTxHash,
+                            }),
+                        );
+                        return;
+                    }
+                    throw error;
+                }
 
                 await modifySwap(storedSwap.id, (s) => {
                     s.commitmentSignatureSubmitted = true;

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -240,6 +240,8 @@ const dict = {
         oft_transfer_in_progress: "Transfer in progress",
         waiting_for_bridge: "Waiting for {{ symbol }} bridge",
         dex_quote_changed: "DEX quote has changed",
+        commitment_rejected_line:
+            "The locked amount came up short, so this swap can't be completed. You can refund your funds back to your original address.",
         pre_bridge_dex_quote_blocked: "Quote has changed",
         pre_bridge_dex_quote_blocked_line:
             "Prices changed while your funds were bridging, so the quote is no longer enough to complete the swap. Please try again or refund your funds.",
@@ -787,6 +789,8 @@ const dict = {
         oft_transfer_in_progress: "Übertragung läuft",
         waiting_for_bridge: "Warte auf {{ symbol }}-Bridge",
         dex_quote_changed: "DEX-Kurs hat sich geändert",
+        commitment_rejected_line:
+            "Der Betrag war zu gering, daher kann dieser Swap nicht abgeschlossen werden. Du kannst deine Gelder an deine ursprüngliche Adresse zurückerstatten.",
         pre_bridge_dex_quote_blocked: "Der Kurs hat sich geändert",
         pre_bridge_dex_quote_blocked_line:
             "Die Preise haben sich während der Bridge-Übertragung geändert, daher reicht der Kurs nicht mehr aus, um den Swap abzuschließen. Bitte versuche es erneut oder lass dir dein Guthaben erstatten.",
@@ -1345,6 +1349,8 @@ const dict = {
         oft_transfer_in_progress: "Transferencia en curso",
         waiting_for_bridge: "Esperando el puente {{ symbol }}",
         dex_quote_changed: "La cotización de DEX ha cambiado",
+        commitment_rejected_line:
+            "El monto bloqueado se quedó corto, por lo que este intercambio no se puede completar. Puedes reembolsar tus fondos a tu dirección original.",
         pre_bridge_dex_quote_blocked: "La cotización ha cambiado",
         pre_bridge_dex_quote_blocked_line:
             "Los precios cambiaron mientras tus fondos se transferían por el puente, por lo que la cotización ya no es suficiente para completar el swap. Inténtalo de nuevo o reembolsa tus fondos.",
@@ -1896,6 +1902,8 @@ const dict = {
         oft_transfer_in_progress: "Transferência em andamento",
         waiting_for_bridge: "Aguardando a ponte {{ symbol }}",
         dex_quote_changed: "A cotação da DEX mudou",
+        commitment_rejected_line:
+            "O valor bloqueado ficou aquém, portanto este swap não pode ser concluído. Você pode reembolsar seus fundos para o seu endereço original.",
         pre_bridge_dex_quote_blocked: "A cotação mudou",
         pre_bridge_dex_quote_blocked_line:
             "Os preços mudaram enquanto seus fundos eram transferidos pela ponte, então a cotação não é mais suficiente para completar o swap. Tente novamente ou reembolse seus fundos.",
@@ -2422,6 +2430,8 @@ const dict = {
         oft_transfer_in_progress: "转账进行中",
         waiting_for_bridge: "等待 {{ symbol }} 桥接",
         dex_quote_changed: "DEX 报价已变更",
+        commitment_rejected_line:
+            "锁定的金额不足，因此无法完成此次兑换。您可以将资金退款到您的原始地址。",
         pre_bridge_dex_quote_blocked: "报价已变更",
         pre_bridge_dex_quote_blocked_line:
             "您的资金在桥接期间价格发生了变动，因此报价已不足以完成兑换。请重试，或退还您的资金。",
@@ -2941,6 +2951,8 @@ const dict = {
         oft_transfer_in_progress: "転送中",
         waiting_for_bridge: "{{ symbol }}ブリッジを待機中",
         dex_quote_changed: "DEXのクオートが変更されました",
+        commitment_rejected_line:
+            "ロックされた金額が不足しているため、このスワップを完了できません。資金を元のアドレスに返金できます。",
         pre_bridge_dex_quote_blocked: "見積もりが変更されました",
         pre_bridge_dex_quote_blocked_line:
             "ブリッジ中に価格が変動したため、見積もりではスワップを完了できなくなりました。もう一度お試しいただくか、資金を返金してください。",

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1350,7 +1350,7 @@ const dict = {
         waiting_for_bridge: "Esperando el puente {{ symbol }}",
         dex_quote_changed: "La cotización de DEX ha cambiado",
         commitment_rejected_line:
-            "El monto bloqueado se quedó corto, por lo que este intercambio no se puede completar. Puedes reembolsar tus fondos a tu dirección original.",
+            "El monto enviado se quedó corto, por lo que este intercambio no se puede completar. Puedes reembolsar tus fondos a tu dirección original.",
         pre_bridge_dex_quote_blocked: "La cotización ha cambiado",
         pre_bridge_dex_quote_blocked_line:
             "Los precios cambiaron mientras tus fondos se transferían por el puente, por lo que la cotización ya no es suficiente para completar el swap. Inténtalo de nuevo o reembolsa tus fondos.",
@@ -1903,7 +1903,7 @@ const dict = {
         waiting_for_bridge: "Aguardando a ponte {{ symbol }}",
         dex_quote_changed: "A cotação da DEX mudou",
         commitment_rejected_line:
-            "O valor bloqueado ficou aquém, portanto este swap não pode ser concluído. Você pode reembolsar seus fundos para o seu endereço original.",
+            "O valor enviado ficou insuficiente, portanto esta troca não pode ser concluída. Você pode reembolsar seus fundos para o seu endereço original.",
         pre_bridge_dex_quote_blocked: "A cotação mudou",
         pre_bridge_dex_quote_blocked_line:
             "Os preços mudaram enquanto seus fundos eram transferidos pela ponte, então a cotação não é mais suficiente para completar o swap. Tente novamente ou reembolse seus fundos.",

--- a/src/pages/Pay.tsx
+++ b/src/pages/Pay.tsx
@@ -43,6 +43,7 @@ import {
 } from "../consts/SwapStatus";
 import { useGlobalContext } from "../context/Global";
 import { usePayContext } from "../context/Pay";
+import CommitmentRejected from "../status/CommitmentRejected";
 import InvoiceExpired from "../status/InvoiceExpired";
 import InvoiceFailedToPay from "../status/InvoiceFailedToPay";
 import InvoicePending from "../status/InvoicePending";
@@ -598,6 +599,13 @@ const Pay = () => {
                                     </>
                                 }>
                                 <Switch>
+                                    <Match
+                                        when={
+                                            swap()?.commitmentRejection !==
+                                            undefined
+                                        }>
+                                        <CommitmentRejected />
+                                    </Match>
                                     <Match
                                         when={
                                             swap()?.bridge?.recovery !==

--- a/src/status/CommitmentRejected.tsx
+++ b/src/status/CommitmentRejected.tsx
@@ -1,0 +1,21 @@
+import type { Accessor } from "solid-js";
+
+import RefundButton from "../components/RefundButton";
+import { useGlobalContext } from "../context/Global";
+import { usePayContext } from "../context/Pay";
+import type { ChainSwap, SubmarineSwap } from "../utils/swapCreator";
+
+const CommitmentRejected = () => {
+    const { swap } = usePayContext();
+    const { t } = useGlobalContext();
+
+    return (
+        <div>
+            <p>{t("commitment_rejected_line")}</p>
+            <hr />
+            <RefundButton swap={swap as Accessor<SubmarineSwap | ChainSwap>} />
+        </div>
+    );
+};
+
+export default CommitmentRejected;

--- a/src/utils/swapCreator.ts
+++ b/src/utils/swapCreator.ts
@@ -110,6 +110,11 @@ export type SwapBase = {
     commitmentLockupCallId?: string;
     commitmentSignatureSubmitted?: boolean;
 
+    // Set when the backend permanently rejected the commitment post (e.g.
+    // "insufficient amount"). The on-chain lockup is immutable, so retrying can
+    // never succeed; this stops the retry loop and offers the user a refund.
+    commitmentRejection?: { reason: string };
+
     gasAbstraction: GasAbstraction;
     signer?: string;
     // Set for hardware wallet signers

--- a/tests/components/SwapExecutionWorker.spec.tsx
+++ b/tests/components/SwapExecutionWorker.spec.tsx
@@ -580,6 +580,48 @@ describe("SwapExecutionWorker", () => {
         });
     });
 
+    test("should flag the swap for refund and stop retrying when the commitment is rejected for insufficient amount", async () => {
+        mockPostCommitmentSignatureForTransaction
+            .mockReset()
+            .mockRejectedValue("insufficient amount: 49 < 50");
+
+        render(() => <SwapExecutionWorker />);
+
+        await waitFor(() => {
+            expect(currentSwap.commitmentRejection).toEqual({
+                reason: "insufficient amount: 49 < 50",
+            });
+        });
+
+        await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
+        expect(mockPostCommitmentSignatureForTransaction).toHaveBeenCalledTimes(
+            1,
+        );
+        expect(currentSwap.commitmentSignatureSubmitted).toBe(false);
+    });
+
+    test("should still retry the commitment post on a transient error", async () => {
+        vi.useFakeTimers();
+        try {
+            mockPostCommitmentSignatureForTransaction
+                .mockReset()
+                .mockRejectedValueOnce("network error")
+                .mockResolvedValue(undefined);
+
+            render(() => <SwapExecutionWorker />);
+
+            await vi.runAllTimersAsync();
+
+            expect(
+                mockPostCommitmentSignatureForTransaction,
+            ).toHaveBeenCalledTimes(2);
+            expect(currentSwap.commitmentSignatureSubmitted).toEqual(true);
+            expect(currentSwap.commitmentRejection).toBeUndefined();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     test("should persist a blocked pre-bridge state when DEX quote stays below the lockup amount", async () => {
         vi.useFakeTimers();
         try {

--- a/tests/status/CommitmentRejected.spec.tsx
+++ b/tests/status/CommitmentRejected.spec.tsx
@@ -1,0 +1,63 @@
+import { render, screen, waitFor } from "@solidjs/testing-library";
+import { createEffect, createSignal } from "solid-js";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { SomeSwap } from "../../src/utils/swapCreator";
+
+const [swap, setSwapSignal] = createSignal<SomeSwap | null>(null, {
+    equals: false,
+});
+const refundButton = vi.fn<(swap: SomeSwap | null) => void>();
+
+vi.mock("../../src/context/Global", () => ({
+    useGlobalContext: () => ({
+        t: (key: string) => key,
+    }),
+}));
+
+vi.mock("../../src/context/Pay", () => ({
+    usePayContext: () => ({
+        swap,
+    }),
+}));
+
+vi.mock("../../src/components/RefundButton", () => ({
+    default: (props: { swap: () => SomeSwap | null }) => {
+        createEffect(() => refundButton(props.swap()));
+        return <div data-testid="refund-button" />;
+    },
+}));
+
+const { default: CommitmentRejected } =
+    await import("../../src/status/CommitmentRejected");
+
+const makeSwap = (): SomeSwap =>
+    ({
+        id: "swap-1",
+        assetSend: "TBTC",
+        commitmentRejection: { reason: "insufficient amount: 16643 < 16650" },
+    }) as SomeSwap;
+
+describe("CommitmentRejected", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        setSwapSignal(makeSwap());
+    });
+
+    test("renders the explanation and the reused RefundButton", () => {
+        render(() => <CommitmentRejected />);
+
+        expect(screen.getByText("commitment_rejected_line")).toBeTruthy();
+        expect(screen.getByTestId("refund-button")).toBeTruthy();
+    });
+
+    test("hands the rejected swap to RefundButton", async () => {
+        render(() => <CommitmentRejected />);
+
+        await waitFor(() =>
+            expect(refundButton).toHaveBeenCalledWith(
+                expect.objectContaining({ id: "swap-1" }),
+            ),
+        );
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “commitment rejected” swap status with a localized explanation and a refund button.
  * Extended the payment flow to display this status when the backend permanently rejects a commitment.
* **Bug Fixes**
  * Improved commitment-post handling: permanent “insufficient amount” failures now stop retries and record the rejection reason for user-facing messaging.
* **Tests**
  * Added unit and end-to-end coverage to verify UI rendering, retry behavior, and refunding after a rejected commitment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->