### PR TITLE
fix: refunds self-heal against stale lockup txs

### DIFF
--- a/e2e/rescue/refund.spec.ts
+++ b/e2e/rescue/refund.spec.ts
@@ -552,4 +552,80 @@ test.describe("Refund", () => {
             ).toBeVisible({ timeout: 5_000 });
         });
     });
+
+    const explorerUtxoApiDown = /\/address\/[^/]+\/utxo/;
+
+    test("still refunds via the backend lockup when the explorer UTXO API is down", async ({
+        page,
+    }) => {
+        test.setTimeout(60_000);
+
+        const { swapId, address } = await setupSwapWithMultipleUTXOs(
+            page,
+            0.005,
+            1,
+        );
+        await setFailedToPay(swapId);
+
+        await page.route(explorerUtxoApiDown, (route) =>
+            route.fulfill({ status: 500, body: "explorer down" }),
+        );
+
+        await page.reload();
+        await performRefundAction(page, "invoice.failedToPay");
+        await validateRefundTransaction(page, LBTC, address);
+    });
+
+    test("recovers when the backend reports a bogus lockup tx", async ({
+        page,
+    }) => {
+        test.setTimeout(60_000);
+
+        const { swapId, address } = await setupSwapWithMultipleUTXOs(
+            page,
+            0.005,
+            1,
+        );
+        await setFailedToPay(swapId);
+
+        const cors = { "access-control-allow-origin": "*" };
+
+        await page.route(
+            /\/v2\/swap\/submarine\/[^/]+\/transaction/,
+            (route) =>
+                route.request().method() === "OPTIONS"
+                    ? route.fulfill({
+                          status: 204,
+                          headers: {
+                              ...cors,
+                              "access-control-allow-methods": "GET, OPTIONS",
+                              "access-control-allow-headers": "referral",
+                          },
+                      })
+                    : route.fulfill({
+                          status: 200,
+                          contentType: "application/json",
+                          headers: cors,
+                          body: JSON.stringify({
+                              id: "f".repeat(64),
+                              hex: "bogus",
+                              timeoutBlockHeight: 1,
+                          }),
+                      }),
+        );
+
+        let explorerUp = false;
+        await page.route(explorerUtxoApiDown, (route) =>
+            explorerUp
+                ? route.continue()
+                : route.fulfill({ status: 500, headers: cors, body: "down" }),
+        );
+
+        await page.reload();
+        await expect(page.getByTestId("refundAddress")).toBeVisible();
+        explorerUp = true;
+
+        await performRefundAction(page, "invoice.failedToPay");
+        await validateRefundTransaction(page, LBTC, address);
+    });
 });

--- a/src/components/RefundButton.tsx
+++ b/src/components/RefundButton.tsx
@@ -67,6 +67,7 @@ import { type deriveKeyFn, useGlobalContext } from "../context/Global";
 import { usePayContext } from "../context/Pay";
 import { type Signer, useWeb3Signer } from "../context/Web3";
 import { useModifySwap } from "../hooks/useModifySwap";
+import { getSwapUTXOs } from "../utils/blockchain";
 import { validateAddress } from "../utils/compat";
 import { formatError } from "../utils/errors";
 import { sendPopulatedTransaction } from "../utils/evmTransaction";
@@ -896,7 +897,8 @@ export const RefundBtc = (props: {
 }) => {
     const { setRefundAddress, refundAddress, notify, t, deriveKey } =
         useGlobalContext();
-    const { refundableUTXOs, failureReason } = usePayContext();
+    const { refundableUTXOs, setRefundableUTXOs, failureReason } =
+        usePayContext();
 
     const [timeoutEta, setTimeoutEta] = createSignal<number>(0);
     const [timeoutBlockheight, setTimeoutBlockheight] = createSignal<number>(0);
@@ -932,7 +934,30 @@ export const RefundBtc = (props: {
         setValid(validateAddress(asset, address));
     };
 
-    const refundAction = async () => {
+    // Re-read the real outpoint from the explorer; true if it changed.
+    const refetchRefundableUTXOs = async (): Promise<boolean> => {
+        try {
+            const fresh = await getSwapUTXOs(props.swap());
+            if (fresh.length === 0) {
+                return false;
+            }
+            const idsOf = (utxos: { id?: string }[]) =>
+                utxos
+                    .map((u) => u.id ?? "")
+                    .sort()
+                    .join(",");
+            if (idsOf(fresh) === idsOf(refundableUTXOs())) {
+                return false;
+            }
+            setRefundableUTXOs(fresh);
+            return true;
+        } catch (e) {
+            log.warn("failed to refetch refundable UTXOs for self-heal", e);
+            return false;
+        }
+    };
+
+    const refundAction = async (isRetry = false) => {
         setRefundRunning(true);
 
         try {
@@ -955,10 +980,19 @@ export const RefundBtc = (props: {
             setRefundAddress("");
         } catch (error) {
             log.warn("refund failed", error);
+
+            // The cached lockup tx may be wrong (e.g. the backend reported a
+            // stale or invalid lockup tx). Refetch the real address UTXOs and
+            // retry once if they changed.
+            if (!isRetry && (await refetchRefundableUTXOs())) {
+                return refundAction(true);
+            }
+
             if (typeof error === "string") {
                 let msg = error;
                 if (
-                    msg === "bad-txns-inputs-missingorspent" ||
+                    msg.includes("bad-txns-inputs-missingorspent") ||
+                    msg.includes("Inputs missing or spent") ||
                     msg === "Transaction already in block chain" ||
                     msg.startsWith("insufficient fee")
                 ) {

--- a/tests/components/RefundButton.spec.tsx
+++ b/tests/components/RefundButton.spec.tsx
@@ -1,14 +1,66 @@
-import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { OutputType } from "boltz-core";
 import { SwapType } from "boltz-swaps/types";
 import { type Accessor, type Setter, createSignal } from "solid-js";
 
 import RefundButton from "../../src/components/RefundButton";
 import { BTC, LN } from "../../src/consts/Assets";
+import { getSwapUTXOs } from "../../src/utils/blockchain";
+import { refund } from "../../src/utils/rescue";
 import type { ChainSwap, SubmarineSwap } from "../../src/utils/swapCreator";
-import { TestComponent, contextWrapper, payContext } from "../helper";
+import {
+    TestComponent,
+    contextWrapper,
+    globalSignals,
+    payContext,
+} from "../helper";
+
+vi.mock("../../src/utils/rescue", async () => {
+    const actual = await vi.importActual("../../src/utils/rescue");
+    return { ...actual, refund: vi.fn() };
+});
+vi.mock("../../src/utils/blockchain", async () => {
+    const actual = await vi.importActual("../../src/utils/blockchain");
+    return { ...actual, getSwapUTXOs: vi.fn() };
+});
+
+const mockRefund = vi.mocked(refund);
+const mockGetSwapUTXOs = vi.mocked(getSwapUTXOs);
+
+const validAddress = "2N4Q5FhU2497BryFfUgbqkAJE87aKHUhXMp";
+
+const renderRefundButton = (swap: SubmarineSwap | ChainSwap) => {
+    const [swapAccessor] = createSignal<SubmarineSwap | ChainSwap>(swap);
+    render(
+        () => (
+            <>
+                <TestComponent />
+                <RefundButton
+                    swap={swapAccessor}
+                    setRefundTxId={(() => "") as Setter<string>}
+                />
+            </>
+        ),
+        { wrapper: contextWrapper },
+    );
+};
+
+const submitRefund = async () => {
+    const input = (await screen.findByTestId(
+        "refundAddress",
+    )) as HTMLInputElement;
+    fireEvent.input(input, { target: { value: validAddress } });
+    const button = (await screen.findByTestId(
+        "refundButton",
+    )) as HTMLButtonElement;
+    fireEvent.click(button);
+};
 
 describe("RefundButton", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
     test("should render RefundButton", () => {
         const [swap] = createSignal<SubmarineSwap | ChainSwap | null>(null);
         render(
@@ -152,5 +204,84 @@ describe("RefundButton", () => {
         });
 
         expect(button.disabled).toBeTruthy();
+    });
+
+    test("self-heals a stale lockup outpoint and retries the refund once", async () => {
+        mockRefund
+            .mockRejectedValueOnce(
+                "No such mempool or blockchain transaction. ID: phantom",
+            )
+            .mockRejectedValueOnce(
+                "No such mempool or blockchain transaction. ID: real",
+            );
+        mockGetSwapUTXOs.mockResolvedValue([
+            { id: "real-utxo", hex: "real-hex" },
+        ]);
+
+        renderRefundButton({
+            version: OutputType.Taproot,
+            id: "swap",
+            assetSend: BTC,
+            assetReceive: LN,
+            type: SwapType.Submarine,
+        } as SubmarineSwap);
+        payContext.setRefundableUTXOs([{ id: "stale-utxo", hex: "stale-hex" }]);
+
+        await submitRefund();
+
+        await waitFor(() => expect(mockRefund).toHaveBeenCalledTimes(2));
+        expect(mockGetSwapUTXOs).toHaveBeenCalledTimes(1);
+        expect(payContext.refundableUTXOs()).toEqual([
+            { id: "real-utxo", hex: "real-hex" },
+        ]);
+    });
+
+    test("does not retry when the explorer returns the same outpoint", async () => {
+        mockRefund.mockRejectedValue(
+            "No such mempool or blockchain transaction. ID: stale",
+        );
+        mockGetSwapUTXOs.mockResolvedValue([
+            { id: "stale-utxo", hex: "fresh-hex" },
+        ]);
+
+        renderRefundButton({
+            version: OutputType.Taproot,
+            id: "swap",
+            assetSend: BTC,
+            assetReceive: LN,
+            type: SwapType.Submarine,
+        } as SubmarineSwap);
+        payContext.setRefundableUTXOs([{ id: "stale-utxo", hex: "stale-hex" }]);
+
+        await submitRefund();
+
+        await waitFor(() =>
+            expect(globalSignals.notificationType()).toBe("error"),
+        );
+        expect(mockRefund).toHaveBeenCalledTimes(1);
+        expect(mockGetSwapUTXOs).toHaveBeenCalledTimes(1);
+    });
+
+    test("self-heals on a non-string refund error (bogus lockup tx)", async () => {
+        mockRefund.mockRejectedValue(new Error("invalid lockup tx hex"));
+        mockGetSwapUTXOs.mockResolvedValue([
+            { id: "real-utxo", hex: "real-hex" },
+        ]);
+
+        renderRefundButton({
+            version: OutputType.Taproot,
+            id: "swap",
+            assetSend: BTC,
+            assetReceive: LN,
+            type: SwapType.Submarine,
+        } as SubmarineSwap);
+        payContext.setRefundableUTXOs([{ id: "bogus", hex: "bogus" }]);
+
+        await submitRefund();
+
+        await waitFor(() => expect(mockRefund).toHaveBeenCalledTimes(2));
+        expect(payContext.refundableUTXOs()).toEqual([
+            { id: "real-utxo", hex: "real-hex" },
+        ]);
     });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refunds are now more resilient when external UTXO data is temporarily unavailable or returns inconsistent results.
  * If a refund fails due to stale on-chain information, the app refreshes refundable UTXOs and automatically retries once when appropriate.
  * Improved handling of common refund failure scenarios involving missing/spent or otherwise invalid transaction inputs.
* **Tests**
  * Added coverage for explorer outages and malformed backend lockup-transaction responses, including retry/self-healing flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->