### PR TITLE
chore: revert USDT0 Polygon extra gas

### DIFF
--- a/packages/boltz-swaps/src/oft/oft.ts
+++ b/packages/boltz-swaps/src/oft/oft.ts
@@ -410,8 +410,6 @@ const appendExecutorOption = (
         option,
     );
 
-const polygonLzReceiveGasBump = 30_000n;
-
 const buildOftExtraOptions = (
     destinationAsset: string,
     nativeDrop: OftNativeDrop | undefined,
@@ -424,16 +422,6 @@ const buildOftExtraOptions = (
             options,
             optionTypeLzReceive,
             encodeSolanaAtaCreationOption(),
-        );
-    }
-
-    // TODO: temporary workaround for failed txs on Polygon; remove once the
-    // OFT options are bumped on-chain.
-    if (destinationAsset === "USDT0-POL") {
-        options = appendExecutorOption(
-            options,
-            optionTypeLzReceive,
-            encodePacked(["uint128", "uint128"], [polygonLzReceiveGasBump, 0n]),
         );
     }
 


### PR DESCRIPTION
Undoes #1500 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a Polygon-specific gas adjustment from OFT transfer options, so destination handling now follows the standard option flow.
  * Simplified extra option building by skipping an unnecessary receive-gas add-on for a specific destination asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->