### PR TITLE
feat: store swap metadata on commitment swaps

### DIFF
--- a/src/components/SwapExecutionWorker.tsx
+++ b/src/components/SwapExecutionWorker.tsx
@@ -1555,9 +1555,12 @@ export const SwapExecutionWorker = () => {
                     throw error;
                 }
 
-                await modifySwap(storedSwap.id, (s) => {
+                const latestSwap = await modifySwap(storedSwap.id, (s) => {
                     s.commitmentSignatureSubmitted = true;
                 });
+                if (latestSwap !== null) {
+                    await patchEncryptedSwapMetadata(latestSwap, rescueFile());
+                }
                 log.info(
                     "Swap execution marked commitment signature submitted",
                     getSwapExecutionLogContext(storedSwap.id, {

--- a/tests/utils/swapMetadata.spec.ts
+++ b/tests/utils/swapMetadata.spec.ts
@@ -328,6 +328,30 @@ describe("patchEncryptedSwapMetadata", () => {
         ).rejects.toThrow(/bound to a different swap/);
     });
 
+    test("patches routed commitment metadata bound to the backend swap id", async () => {
+        await patchEncryptedSwapMetadata(
+            {
+                type: SwapType.Submarine,
+                id: "backend-swap-id",
+                commitmentLockupTxHash: "0xcommitment",
+                dex: samplePayload.dex,
+                bridge: samplePayload.bridge,
+            } as never,
+            rescueFile,
+        );
+
+        expect(mocks.patchSwapMetadata).toHaveBeenCalledOnce();
+        const [patchedSwapId, metadata] = mocks.patchSwapMetadata.mock.calls[0];
+        expect(patchedSwapId).toBe("backend-swap-id");
+        await expect(
+            decryptSwapMetadata(mnemonic, "backend-swap-id", metadata),
+        ).resolves.toEqual({
+            commitmentLockupTxHash: "0xcommitment",
+            dex: samplePayload.dex,
+            bridge: samplePayload.bridge,
+        });
+    });
+
     test("does not patch tx identity without route metadata", async () => {
         await patchEncryptedSwapMetadata(
             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap commitment handling so encrypted swap details are updated after commitment signatures are submitted.
  * Ensures routed commitment metadata stays correctly tied to the backend swap record, helping prevent mismatched or stale swap information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->