### PR TITLE
fix: blocked non-renegotiable hop lockup shortfalls

### DIFF
--- a/src/components/LockupEvm.tsx
+++ b/src/components/LockupEvm.tsx
@@ -1,5 +1,6 @@
 import type { RouterCall } from "boltz-swaps/bridge";
 import {
+    type Pairs,
     type QuoteData,
     encodeDexQuote,
     getCommitmentLockupDetails,
@@ -55,6 +56,7 @@ import { formatAssetAmountForLog } from "../utils/denomination";
 import { getNativeEvmLockupSpendableBalance } from "../utils/evmLockup";
 import { sendPopulatedTransaction } from "../utils/evmTransaction";
 import type { HardwareSigner } from "../utils/hardware/HardwareSigner";
+import { hopShortfallIsRenegotiable } from "../utils/hopLockup";
 import { estimateFeesPerGas } from "../utils/provider";
 import type { RescueFile } from "../utils/rescueFile";
 import {
@@ -285,6 +287,8 @@ const lockupWithHops = async (
     getSwap: (id: string) => Promise<SomeSwap | null>,
     modifySwap: ReturnType<typeof useModifySwap>,
     rescueFile: RescueFile | null,
+    pairs: Accessor<Pairs | undefined>,
+    fetchPairs: () => Promise<void>,
     hopInputAmount?: bigint,
 ): Promise<string> => {
     const transactionSigner = getSignerForGasAbstraction(
@@ -321,6 +325,47 @@ const lockupWithHops = async (
             ),
             quoteData: quote.data,
         });
+
+        // The exact-input quote can fall below the swap's expected amount if the
+        // rate moved; block a non-renegotiable shortfall before signing rather
+        // than locking into an "insufficient amount" rejection.
+        if (hopInputAmount !== undefined) {
+            const quotedLockupAmount = BigInt(quote.quote);
+            if (
+                quotedLockupAmount <
+                calculateAmountOutMin(lockupAmount, slippage)
+            ) {
+                const swap = await getSwap(swapId);
+                if (
+                    swap === null ||
+                    !(await hopShortfallIsRenegotiable(
+                        swap,
+                        quotedLockupAmount,
+                        slippage,
+                        pairs,
+                        fetchPairs,
+                    ))
+                ) {
+                    throw new Error(
+                        "hop lockup quote is below the swap's required amount",
+                    );
+                }
+                log.warn(
+                    "Locking hop quote below required amount; lockup clears renegotiation minimum",
+                    {
+                        swapId,
+                        quotedLockupAmount: formatAssetAmountForLog(
+                            quotedLockupAmount,
+                            hop.to,
+                        ),
+                        requiredAmount: formatAssetAmountForLog(
+                            lockupAmount,
+                            hop.to,
+                        ),
+                    },
+                );
+            }
+        }
 
         const router = createRouterContract(hop.from, transactionSigner);
         const calldata = await encodeDexQuote(
@@ -482,7 +527,8 @@ const LockupTransaction = (props: {
     hops?: EncodedHop[];
     hopInputAmount?: bigint;
 }) => {
-    const { t, slippage, getSwap, rescueFile } = useGlobalContext();
+    const { t, slippage, getSwap, rescueFile, pairs, fetchPairs } =
+        useGlobalContext();
     const {
         getErc20Swap,
         getEtherSwap,
@@ -543,6 +589,8 @@ const LockupTransaction = (props: {
                             getSwap,
                             modifySwap,
                             rescueFile(),
+                            pairs,
+                            fetchPairs,
                             props.hopInputAmount,
                         );
                     } else if (

--- a/src/components/SwapExecutionWorker.tsx
+++ b/src/components/SwapExecutionWorker.tsx
@@ -14,7 +14,6 @@ import {
 import { encodeDexQuote, getCommitmentLockupDetails } from "boltz-swaps/client";
 import {
     type AlchemyCall,
-    assetAmountToSats,
     createAssetProvider,
     prefix0x,
     satsToAssetAmount,
@@ -70,6 +69,7 @@ import { useModifySwap } from "../hooks/useModifySwap";
 import { formatAssetAmountForLog } from "../utils/denomination";
 import { formatError } from "../utils/errors";
 import { sendPopulatedTransaction } from "../utils/evmTransaction";
+import { hopShortfallIsRenegotiable } from "../utils/hopLockup";
 import { type ClaimQuote, fetchDexQuote } from "../utils/quoter";
 import {
     type BridgeDetail,
@@ -353,33 +353,6 @@ export const SwapExecutionWorker = () => {
         });
     };
 
-    // A pre-bridge quote below the slippage threshold can still be locked when
-    // the backend is able to renegotiate the shortfall. That is only possible
-    // for chain swaps whose lockup amount still clears the pair minimum;
-    // otherwise locking is pointless and the swap should block for a refund.
-    const shouldLockBelowThresholdQuote = async (
-        swap: SomeSwap,
-        quoteAmountOut: bigint,
-    ): Promise<boolean> => {
-        if (swap.type !== SwapType.Chain) {
-            return false;
-        }
-
-        const chainSwap = swap as ChainSwap;
-        const lockupAmount = calculateAmountOutMin(quoteAmountOut, slippage());
-        await fetchPairs();
-        const minimal =
-            pairs()?.[SwapType.Chain]?.[chainSwap.assetSend]?.[
-                chainSwap.assetReceive
-            ]?.limits.minimal;
-
-        return (
-            minimal === undefined ||
-            assetAmountToSats(lockupAmount, chainSwap.assetSend) >=
-                BigInt(minimal)
-        );
-    };
-
     const fetchPreBridgeDexQuote = async ({
         swap,
         swapId,
@@ -439,7 +412,13 @@ export const SwapExecutionWorker = () => {
             // threshold. If locking the shortfall is still viable, do it now
             // instead of burning the remaining attempts.
             if (
-                await shouldLockBelowThresholdQuote(swap, quote.trade.amountOut)
+                await hopShortfallIsRenegotiable(
+                    swap,
+                    quote.trade.amountOut,
+                    slippage(),
+                    pairs,
+                    fetchPairs,
+                )
             ) {
                 log.info(
                     "Swap execution locking pre-bridge quote below threshold; lockup clears renegotiation minimum",

--- a/src/utils/hopLockup.ts
+++ b/src/utils/hopLockup.ts
@@ -1,0 +1,36 @@
+import type { Pairs } from "boltz-swaps/client";
+import { assetAmountToSats } from "boltz-swaps/evm";
+import { calculateAmountOutMin } from "boltz-swaps/helper";
+import { SwapType } from "boltz-swaps/types";
+import type { Accessor } from "solid-js";
+
+import type { ChainSwap, SomeSwap } from "./swapCreator";
+
+// A shortfall is only lockable for chain swaps whose lockup still clears the
+// pair minimum (the backend renegotiates those); otherwise it is rejected as
+// "insufficient amount" and must block. Assumes the caller already checked the
+// quote is below the required amount.
+export const hopShortfallIsRenegotiable = async (
+    swap: SomeSwap,
+    quoteAmountOut: bigint,
+    slippage: number,
+    pairs: Accessor<Pairs | undefined>,
+    fetchPairs: () => Promise<void>,
+): Promise<boolean> => {
+    if (swap.type !== SwapType.Chain) {
+        return false;
+    }
+
+    const chainSwap = swap as ChainSwap;
+    const lockupAmount = calculateAmountOutMin(quoteAmountOut, slippage);
+    await fetchPairs();
+    const minimal =
+        pairs()?.[SwapType.Chain]?.[chainSwap.assetSend]?.[
+            chainSwap.assetReceive
+        ]?.limits.minimal;
+
+    return (
+        minimal === undefined ||
+        assetAmountToSats(lockupAmount, chainSwap.assetSend) >= BigInt(minimal)
+    );
+};

--- a/tests/utils/hopLockup.spec.ts
+++ b/tests/utils/hopLockup.spec.ts
@@ -1,0 +1,89 @@
+import { SwapType } from "boltz-swaps/types";
+import { describe, expect, test, vi } from "vitest";
+
+import { hopShortfallIsRenegotiable } from "../../src/utils/hopLockup";
+import type { SomeSwap } from "../../src/utils/swapCreator";
+
+// 1:1 sats conversion so the tests can use raw numbers.
+vi.mock("boltz-swaps/evm", () => ({
+    assetAmountToSats: (amount: bigint) => amount,
+}));
+
+describe("hopShortfallIsRenegotiable", () => {
+    const slippage = 0.01;
+    const quoteAmountOut = 1_000n;
+    // calculateAmountOutMin(1000, 0.01) === 990
+    const lockupAmount = 990n;
+
+    const chainSwap = {
+        type: SwapType.Chain,
+        assetSend: "RBTC",
+        assetReceive: "BTC",
+    } as unknown as SomeSwap;
+
+    const pairsWith = (minimal?: number) => () =>
+        ({
+            [SwapType.Chain]: {
+                RBTC: {
+                    BTC: {
+                        limits: minimal === undefined ? {} : { minimal },
+                    },
+                },
+            },
+        }) as never;
+
+    test.each([SwapType.Submarine, SwapType.Reverse, SwapType.Commitment])(
+        "blocks a %s swap shortfall (never renegotiable) without fetching pairs",
+        async (type) => {
+            const fetchPairs = vi.fn().mockResolvedValue(undefined);
+            const result = await hopShortfallIsRenegotiable(
+                { type } as unknown as SomeSwap,
+                quoteAmountOut,
+                slippage,
+                pairsWith(100),
+                fetchPairs,
+            );
+
+            expect(result).toBe(false);
+            expect(fetchPairs).not.toHaveBeenCalled();
+        },
+    );
+
+    test("locks a chain swap shortfall when the pair has no minimum", async () => {
+        const fetchPairs = vi.fn().mockResolvedValue(undefined);
+        const result = await hopShortfallIsRenegotiable(
+            chainSwap,
+            quoteAmountOut,
+            slippage,
+            pairsWith(undefined),
+            fetchPairs,
+        );
+
+        expect(result).toBe(true);
+        expect(fetchPairs).toHaveBeenCalledOnce();
+    });
+
+    test("locks a chain swap shortfall that still clears the pair minimum", async () => {
+        const result = await hopShortfallIsRenegotiable(
+            chainSwap,
+            quoteAmountOut,
+            slippage,
+            pairsWith(Number(lockupAmount)),
+            vi.fn().mockResolvedValue(undefined),
+        );
+
+        expect(result).toBe(true);
+    });
+
+    test("blocks a chain swap shortfall that falls below the pair minimum", async () => {
+        const result = await hopShortfallIsRenegotiable(
+            chainSwap,
+            quoteAmountOut,
+            slippage,
+            pairsWith(Number(lockupAmount) + 1),
+            vi.fn().mockResolvedValue(undefined),
+        );
+
+        expect(result).toBe(false);
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for checking whether a lower-than-expected hop quote can still be locked for execution.
  * Improved quote handling so valid quotes can proceed even when they fall short of the initial threshold, when permitted.

* **Bug Fixes**
  * Prevented signing/locking transactions when a quote is below the required minimum and cannot be safely accepted.
  * Updated retry behavior to avoid unnecessary locking attempts for quotes that are not recoverable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->