### PR TITLE
feat: add generic key-value storage to SDK

### DIFF
--- a/packages/boltz-swaps/package.json
+++ b/packages/boltz-swaps/package.json
@@ -180,6 +180,11 @@
             "types": "./dist/tron/index.d.ts",
             "default": "./dist/tron/index.js"
         },
+        "./storage": {
+            "source": "./src/storage/index.ts",
+            "types": "./dist/storage/index.d.ts",
+            "default": "./dist/storage/index.js"
+        },
         "./lazy": {
             "source": "./src/lazy.ts",
             "types": "./dist/lazy.d.ts",

--- a/packages/boltz-swaps/src/index.ts
+++ b/packages/boltz-swaps/src/index.ts
@@ -22,4 +22,5 @@ export * as cctp from "./cctp/index.ts";
 export * as evm from "./evm/index.ts";
 export * as oft from "./oft/index.ts";
 export * as solana from "./solana/index.ts";
+export * as storage from "./storage/index.ts";
 export * as tron from "./tron/index.ts";

--- a/packages/boltz-swaps/src/storage/index.ts
+++ b/packages/boltz-swaps/src/storage/index.ts
@@ -1,0 +1,5 @@
+export type { KeyValueStore } from "./types.ts";
+export { MemoryKeyValueStore } from "./memory.ts";
+export type { MemoryKeyValueStoreOptions } from "./memory.ts";
+export { LocalStorageKeyValueStore } from "./localStorage.ts";
+export type { LocalStorageKeyValueStoreOptions } from "./localStorage.ts";

--- a/packages/boltz-swaps/src/storage/localStorage.ts
+++ b/packages/boltz-swaps/src/storage/localStorage.ts
@@ -1,0 +1,101 @@
+/* eslint-disable require-await, @typescript-eslint/require-await --
+   the methods are async so sync failures (e.g. QuotaExceededError from
+   setItem) reject instead of throwing past callers' .catch handlers */
+import { getLogger } from "../logger.ts";
+import type { KeyValueStore } from "./types.ts";
+
+export type LocalStorageKeyValueStoreOptions = {
+    // The Web Storage instance to use. Defaults to `globalThis.localStorage`;
+    // the constructor throws when neither is available. Inject a `Storage` in
+    // tests.
+    storage?: Storage;
+    // Namespaces every key so multiple stores can share one `Storage` without
+    // colliding. Transparent to callers: `get`/`set`/`remove`/`entries` all
+    // operate on the logical (unprefixed) key.
+    prefix?: string;
+};
+
+// Browser `localStorage`-backed `KeyValueStore`. Values are JSON-serialized, so
+// only JSON-safe values may be stored. `localStorage` is synchronous; the async
+// interface is honored by resolving immediately.
+export class LocalStorageKeyValueStore implements KeyValueStore {
+    private readonly storage: Storage;
+    private readonly namespace: string;
+
+    public constructor(options: LocalStorageKeyValueStoreOptions = {}) {
+        const storage = options.storage ?? globalThis.localStorage;
+        if (storage === undefined || storage === null) {
+            throw new Error(
+                "LocalStorageKeyValueStore: no Storage available — pass `storage` or run in a browser",
+            );
+        }
+        this.storage = storage;
+        const prefix = options.prefix ?? "";
+        // Encoding the prefix length makes the namespace/key boundary
+        // unambiguous. For example, ("a", "bc") and ("ab", "c") become
+        // "1:abc" and "2:abc" instead of both mapping to "abc".
+        this.namespace = `${prefix.length}:${prefix}`;
+    }
+
+    // Parse a stored value, tolerating corruption: a single unparseable entry
+    // (a partial write, or a value written by other code sharing the Storage)
+    // must not throw and abort a whole `get`/`entries` — the watcher relies on
+    // `entries` to enumerate resumable deposits.
+    private parse<T>(physicalKey: string, raw: string): T | undefined {
+        try {
+            return JSON.parse(raw) as T;
+        } catch (error) {
+            getLogger().warn(
+                "LocalStorageKeyValueStore: skipping corrupt value",
+                { key: physicalKey, error },
+            );
+            return undefined;
+        }
+    }
+
+    public get = async <T>(key: string): Promise<T | undefined> => {
+        const physical = this.namespace + key;
+        const raw = this.storage.getItem(physical);
+        return raw === null ? undefined : this.parse<T>(physical, raw);
+    };
+
+    public set = async <T>(key: string, value: T): Promise<void> => {
+        // `undefined` is the absent sentinel and is not JSON-round-trippable
+        // (`JSON.stringify(undefined)` is `undefined`, which `setItem` coerces
+        // to the string "undefined" and later poisons the key). Treat it as a
+        // removal so both stores agree that "set undefined" ≡ "absent".
+        if (value === undefined) {
+            return this.remove(key);
+        }
+        this.storage.setItem(this.namespace + key, JSON.stringify(value));
+    };
+
+    public remove = async (key: string): Promise<void> => {
+        this.storage.removeItem(this.namespace + key);
+    };
+
+    public entries = async <T>(
+        prefix?: string,
+    ): Promise<Array<[string, T]>> => {
+        const result: Array<[string, T]> = [];
+        for (let i = 0; i < this.storage.length; i++) {
+            const physical = this.storage.key(i);
+            if (physical === null || !physical.startsWith(this.namespace)) {
+                continue;
+            }
+            const logical = physical.slice(this.namespace.length);
+            if (prefix !== undefined && !logical.startsWith(prefix)) {
+                continue;
+            }
+            const raw = this.storage.getItem(physical);
+            if (raw === null) {
+                continue;
+            }
+            const value = this.parse<T>(physical, raw);
+            if (value !== undefined) {
+                result.push([logical, value]);
+            }
+        }
+        return result;
+    };
+}

--- a/packages/boltz-swaps/src/storage/memory.ts
+++ b/packages/boltz-swaps/src/storage/memory.ts
@@ -1,0 +1,69 @@
+import { LocalStorageKeyValueStore } from "./localStorage.ts";
+import type { KeyValueStore } from "./types.ts";
+
+export type MemoryKeyValueStoreOptions = {
+    // Required, self-documenting acknowledgment that this store is in-memory and
+    // its data is lost on every restart. There is no safe production use for a
+    // resumable workflow: e.g. as the deposit-watcher store it cannot recover
+    // in-flight deposits after a restart, which can strand bridged/locked funds.
+    // Set `true` only for tests / intentional ephemeral use; otherwise use a
+    // durable `KeyValueStore` (e.g. `LocalStorageKeyValueStore`).
+    inMemoryStorageShouldNeverBeUsedInProduction: boolean;
+};
+
+// Coerces like real Web Storage so the shared engine behaves identically.
+// Also serves as the injectable `Storage` double in tests.
+export const createMapStorage = (): Storage => {
+    const map = new Map<string, string>();
+    return {
+        get length() {
+            return map.size;
+        },
+        clear: () => map.clear(),
+        getItem: (key: string) => map.get(String(key)) ?? null,
+        key: (index: number) => [...map.keys()][index] ?? null,
+        removeItem: (key: string) => {
+            map.delete(String(key));
+        },
+        setItem: (key: string, value: string) => {
+            map.set(String(key), String(value));
+        },
+    } as Storage;
+};
+
+// In-memory `KeyValueStore` that delegates to `LocalStorageKeyValueStore` over
+// a Map-backed `Storage`, so the two stores share one JSON engine and cannot
+// diverge (a value that fails to round-trip durably fails here too). State is
+// lost on restart — see the required acknowledgment.
+export class MemoryKeyValueStore implements KeyValueStore {
+    private readonly inner: LocalStorageKeyValueStore;
+
+    public constructor(options: MemoryKeyValueStoreOptions) {
+        // Optional chaining defends against JS callers (no types) omitting the
+        // argument entirely — they get this message, not a raw TypeError.
+        if (options?.inMemoryStorageShouldNeverBeUsedInProduction !== true) {
+            throw new Error(
+                "MemoryKeyValueStore is in-memory and its data is lost on every restart. " +
+                    "As a resumable-workflow store (e.g. the deposit watcher) this can strand " +
+                    "funds — in-flight deposits cannot be recovered after a restart. Pass " +
+                    "{ inMemoryStorageShouldNeverBeUsedInProduction: true } to acknowledge " +
+                    "intentional ephemeral/test use, or use a durable KeyValueStore such as " +
+                    "LocalStorageKeyValueStore.",
+            );
+        }
+        this.inner = new LocalStorageKeyValueStore({
+            storage: createMapStorage(),
+        });
+    }
+
+    public get = <T>(key: string): Promise<T | undefined> =>
+        this.inner.get<T>(key);
+
+    public set = <T>(key: string, value: T): Promise<void> =>
+        this.inner.set(key, value);
+
+    public remove = (key: string): Promise<void> => this.inner.remove(key);
+
+    public entries = <T>(prefix?: string): Promise<Array<[string, T]>> =>
+        this.inner.entries<T>(prefix);
+}

--- a/packages/boltz-swaps/src/storage/types.ts
+++ b/packages/boltz-swaps/src/storage/types.ts
@@ -1,0 +1,14 @@
+// A generic async key-value store, reusable across the SDK (e.g. the deposit
+// watcher persists through it). All methods are async so an implementation can
+// be backed by localStorage, IndexedDB, a file, or a remote DB. Values must be
+// JSON-serializable so persistent backends can round-trip them.
+export interface KeyValueStore {
+    // Resolves to the stored value, or `undefined` when the key is absent. A
+    // stored falsy value (e.g. `0`) round-trips as itself, never as `undefined`.
+    get<T>(key: string): Promise<T | undefined>;
+    set<T>(key: string, value: T): Promise<void>;
+    remove(key: string): Promise<void>;
+    // All `[key, value]` pairs, optionally restricted to keys starting with
+    // `prefix` — the enumeration primitive for collection-style reads.
+    entries<T>(prefix?: string): Promise<Array<[key: string, value: T]>>;
+}

--- a/packages/boltz-swaps/tests/storage/localStorage.spec.ts
+++ b/packages/boltz-swaps/tests/storage/localStorage.spec.ts
@@ -1,0 +1,168 @@
+import { LocalStorageKeyValueStore } from "boltz-swaps/storage";
+import { describe, expect, it, vi } from "vitest";
+
+import { setLogger } from "../../src/logger.ts";
+import { createMapStorage } from "../../src/storage/memory.ts";
+
+const physicalKey = (prefix: string, key: string) =>
+    `${prefix.length}:${prefix}${key}`;
+
+// The shared behavioral contract lives in parity.spec.ts; here only the
+// Storage-specific behavior.
+describe("LocalStorageKeyValueStore", () => {
+    it("tolerates a corrupt value: get returns undefined and entries skips it", async () => {
+        const storage = createMapStorage();
+        const kv = new LocalStorageKeyValueStore({ storage, prefix: "boltz." });
+        await kv.set("good", { ok: true });
+        storage.setItem(physicalKey("boltz.", "bad"), "{not valid json"); // partial write
+        expect(await kv.get("bad")).toBeUndefined();
+        expect((await kv.entries()).map(([k]) => k)).toEqual(["good"]);
+    });
+
+    it("enumerates entries by logical prefix, stripping the store prefix", async () => {
+        const kv = new LocalStorageKeyValueStore({
+            storage: createMapStorage(),
+            prefix: "boltz.deposit.",
+        });
+        await kv.set("deposit.1", { id: 1 });
+        await kv.set("deposit.2", { id: 2 });
+        await kv.set("watermark.POL", 10);
+        const deposits = await kv.entries<{ id: number }>("deposit.");
+        expect(deposits.map(([k]) => k).sort()).toEqual([
+            "deposit.1",
+            "deposit.2",
+        ]);
+    });
+
+    it("combines corrupt-skip and logical-prefix filter in one entries() call", async () => {
+        const storage = createMapStorage();
+        const kv = new LocalStorageKeyValueStore({ storage, prefix: "boltz." });
+        await kv.set("deposit.1", { id: 1 });
+        await kv.set("deposit.2", { id: 2 });
+        await kv.set("watermark.POL", 10);
+        storage.setItem(physicalKey("boltz.", "deposit.bad"), "{not json");
+        const e = await kv.entries<{ id: number }>("deposit.");
+        expect(e.map(([k]) => k).sort()).toEqual(["deposit.1", "deposit.2"]);
+    });
+
+    it("warns with the physical key on a corrupt value", async () => {
+        const warn = vi.fn();
+        const noop = () => {};
+        setLogger({
+            trace: noop,
+            debug: noop,
+            info: noop,
+            warn,
+            error: noop,
+            log: noop,
+        });
+        try {
+            const storage = createMapStorage();
+            const kv = new LocalStorageKeyValueStore({
+                storage,
+                prefix: "boltz.",
+            });
+            const badKey = physicalKey("boltz.", "bad");
+            storage.setItem(badKey, "{nope");
+            expect(await kv.get("bad")).toBeUndefined();
+            expect(warn).toHaveBeenCalledWith(
+                expect.stringContaining("corrupt"),
+                expect.objectContaining({ key: badKey }),
+            );
+        } finally {
+            setLogger({
+                trace: noop,
+                debug: noop,
+                info: noop,
+                warn: noop,
+                error: noop,
+                log: noop,
+            });
+        }
+    });
+
+    // Exercises the null-key and null-raw defensive skips that
+    // createMapStorage cannot produce at an in-range index.
+    it("skips null keys and null raw values in entries() without throwing", async () => {
+        const goodKey = physicalKey("boltz.", "good");
+        const goneKey = physicalKey("boltz.", "gone");
+        const keys: Array<string | null> = [null, goodKey, goneKey];
+        const double = {
+            length: keys.length,
+            key: (i: number) => keys[i] ?? null,
+            getItem: (k: string) =>
+                k === goodKey ? JSON.stringify({ ok: true }) : null,
+            setItem: () => {},
+            removeItem: () => {},
+            clear: () => {},
+        } as unknown as Storage;
+        const kv = new LocalStorageKeyValueStore({
+            storage: double,
+            prefix: "boltz.",
+        });
+        expect(await kv.entries<{ ok: boolean }>()).toEqual([
+            ["good", { ok: true }],
+        ]);
+    });
+
+    it("isolates two stores sharing one Storage via prefix", async () => {
+        const shared = createMapStorage();
+        const a = new LocalStorageKeyValueStore({
+            storage: shared,
+            prefix: "a.",
+        });
+        const b = new LocalStorageKeyValueStore({
+            storage: shared,
+            prefix: "b.",
+        });
+        await a.set("k", "from-a");
+        await b.set("k", "from-b");
+        expect(await a.get("k")).toBe("from-a");
+        expect(await b.get("k")).toBe("from-b");
+        expect((await a.entries()).length).toBe(1);
+    });
+
+    it("isolates stores when one namespace prefix extends the other", async () => {
+        const shared = createMapStorage();
+        const a = new LocalStorageKeyValueStore({
+            storage: shared,
+            prefix: "a",
+        });
+        const ab = new LocalStorageKeyValueStore({
+            storage: shared,
+            prefix: "ab",
+        });
+
+        await a.set("bc", "from-a");
+        await ab.set("c", "from-ab");
+
+        expect(shared.length).toBe(2);
+        expect(await a.get("bc")).toBe("from-a");
+        expect(await ab.get("c")).toBe("from-ab");
+        expect(await a.entries()).toEqual([["bc", "from-a"]]);
+        expect(await ab.entries()).toEqual([["c", "from-ab"]]);
+
+        await a.remove("bc");
+        expect(await ab.get("c")).toBe("from-ab");
+    });
+
+    it("resolves globalThis.localStorage when no Storage is injected", async () => {
+        Reflect.set(globalThis, "localStorage", createMapStorage());
+        try {
+            const kv = new LocalStorageKeyValueStore();
+            await kv.set("a", { n: 1 });
+            expect(await kv.get("a")).toEqual({ n: 1 });
+        } finally {
+            Reflect.deleteProperty(globalThis, "localStorage");
+        }
+    });
+
+    it("throws in the constructor when no Storage is available", () => {
+        if (typeof globalThis.localStorage !== "undefined") {
+            return; // environment provides localStorage; not applicable
+        }
+        expect(() => new LocalStorageKeyValueStore()).toThrow(
+            /no Storage available/,
+        );
+    });
+});

--- a/packages/boltz-swaps/tests/storage/memory.spec.ts
+++ b/packages/boltz-swaps/tests/storage/memory.spec.ts
@@ -1,0 +1,17 @@
+import { MemoryKeyValueStore } from "boltz-swaps/storage";
+import { describe, expect, it } from "vitest";
+
+// The behavioral contract lives in parity.spec.ts; only the construction
+// guard is unique to this store.
+describe("MemoryKeyValueStore", () => {
+    it("refuses construction without the production acknowledgment", () => {
+        // @ts-expect-error — the acknowledgment argument is required
+        expect(() => new MemoryKeyValueStore()).toThrow(/in-memory/i);
+        expect(
+            () =>
+                new MemoryKeyValueStore({
+                    inMemoryStorageShouldNeverBeUsedInProduction: false,
+                }),
+        ).toThrow(/inMemoryStorageShouldNeverBeUsedInProduction/);
+    });
+});

--- a/packages/boltz-swaps/tests/storage/parity.spec.ts
+++ b/packages/boltz-swaps/tests/storage/parity.spec.ts
@@ -1,0 +1,106 @@
+import {
+    type KeyValueStore,
+    LocalStorageKeyValueStore,
+    MemoryKeyValueStore,
+} from "boltz-swaps/storage";
+import { describe, expect, it } from "vitest";
+
+import { createMapStorage } from "../../src/storage/memory.ts";
+
+// One behavioral contract run over both stores — any drift between the
+// in-memory and durable store fails here.
+const stores: Array<[string, () => KeyValueStore]> = [
+    [
+        "MemoryKeyValueStore",
+        () =>
+            new MemoryKeyValueStore({
+                inMemoryStorageShouldNeverBeUsedInProduction: true,
+            }),
+    ],
+    [
+        "LocalStorageKeyValueStore",
+        () => new LocalStorageKeyValueStore({ storage: createMapStorage() }),
+    ],
+];
+
+describe.each(stores)("KeyValueStore parity: %s", (_, make) => {
+    it("round-trips a JSON value", async () => {
+        const kv = make();
+        await kv.set("a", { n: 1, s: "x", nested: { ok: true } });
+        expect(await kv.get("a")).toEqual({
+            n: 1,
+            s: "x",
+            nested: { ok: true },
+        });
+    });
+
+    it("distinguishes stored falsy values from a missing key", async () => {
+        const kv = make();
+        await kv.set("zero", 0);
+        await kv.set("null", null);
+        await kv.set("empty", "");
+        expect(await kv.get<number>("zero")).toBe(0);
+        expect(await kv.get<null>("null")).toBeNull();
+        expect(await kv.get<string>("empty")).toBe("");
+        expect(await kv.get("absent")).toBeUndefined();
+    });
+
+    it("removes a key", async () => {
+        const kv = make();
+        await kv.set("a", 1);
+        await kv.remove("a");
+        expect(await kv.get("a")).toBeUndefined();
+    });
+
+    it("treats set(undefined) as a removal", async () => {
+        const kv = make();
+        await kv.set("a", 1);
+        await kv.set("a", undefined);
+        expect(await kv.get("a")).toBeUndefined();
+        expect((await kv.entries()).length).toBe(0);
+    });
+
+    it("enumerates entries filtered by prefix", async () => {
+        const kv = make();
+        await kv.set("deposit.1", { id: 1 });
+        await kv.set("deposit.2", { id: 2 });
+        await kv.set("watermark.POL", 10);
+        const deposits = await kv.entries<{ id: number }>("deposit.");
+        expect(deposits.map(([k]) => k).sort()).toEqual([
+            "deposit.1",
+            "deposit.2",
+        ]);
+        expect((await kv.entries()).length).toBe(3);
+    });
+
+    it("returns defensive copies (mutations do not leak into the store)", async () => {
+        const kv = make();
+        const input = { n: 1 };
+        await kv.set("a", input);
+        input.n = 99;
+        const first = await kv.get<{ n: number }>("a");
+        expect(first?.n).toBe(1);
+        first!.n = 42;
+        expect((await kv.get<{ n: number }>("a"))?.n).toBe(1);
+        const e = await kv.entries<{ n: number }>();
+        e[0][1].n = 7;
+        expect((await kv.get<{ n: number }>("a"))?.n).toBe(1);
+    });
+
+    it("rejects a bigint", async () => {
+        await expect(make().set("b", 5n)).rejects.toThrow(TypeError);
+    });
+
+    it("normalizes a Date to its ISO string", async () => {
+        const kv = make();
+        const date = new Date("2026-01-02T03:04:05.000Z");
+        await kv.set("d", date);
+        expect(await kv.get<string>("d")).toBe("2026-01-02T03:04:05.000Z");
+    });
+
+    it("drops undefined object properties", async () => {
+        const kv = make();
+        await kv.set("a", { keep: 1, drop: undefined });
+        expect(await kv.get("a")).toEqual({ keep: 1 });
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a pluggable asynchronous `KeyValueStore` API.
  - Added `LocalStorageKeyValueStore` with namespaced storage, prefix-based `entries`, safe handling of corrupt data, and configurable backing `Storage`.
  - Added `MemoryKeyValueStore` for temporary/test use with explicit “never in production” opt-in.
  - Exposed storage via the package root (`storage` namespace) and a dedicated `./storage` entry point.
- **Tests**
  - Added unit and parity test coverage for serialization, filtering, isolation, removals, corrupt-value tolerance, and in-memory safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->