### PR TITLE
fix: allow direct EVM rescue claims without a wallet

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -185,7 +185,7 @@ const dict = {
         transaction_prompt:
             'Press "{{ button }}" in order to open your connected wallet and confirm the displayed transaction.',
         transaction_prompt_receive:
-            'Press "{{ button }}" in order to open your connected wallet and confirm the displayed transaction to receive {{ asset }}.',
+            'Press "{{ button }}" to start claiming {{ asset }}.',
         transaction_failed: "Transaction failed: {{ error }}",
         wallet_request_rejected: "Request was rejected in your wallet.",
         invalid_address: "Invalid {{ asset }} address",
@@ -743,7 +743,7 @@ const dict = {
         transaction_prompt:
             '"{{ button }}" klicken um das verbundene Wallet zu öffnen und bestätige die angezeigte Transaktion.',
         transaction_prompt_receive:
-            '"{{ button }}" klicken um das verbundene Wallet zu öffnen und bestätige die angezeigte Transaktion um {{ asset }} zu empfangen.',
+            '"{{ button }}" klicken, um {{ asset }} zu claimen.',
         transaction_failed: "Transaktion fehlgeschlagen: {{ error }}",
         wallet_request_rejected:
             "Die Anfrage wurde in deinem Wallet abgelehnt.",
@@ -1317,7 +1317,7 @@ const dict = {
         transaction_prompt:
             'Pulse "{{ button }}" para abrir tu monedero conectado y confirmar la transacción mostrada.',
         transaction_prompt_receive:
-            'Pulse "{{ button }}" para abrir tu monedero conectado y confirmar la transacción mostrada para recibir {{ asset }}.',
+            'Pulse "{{ button }}" para comenzar a reclamar {{ asset }}.',
         transaction_failed: "Transacción fallida: {{ error }}",
         wallet_request_rejected: "La solicitud fue rechazada en tu monedero.",
         invalid_address: "Dirección {{ asset }} inválida",
@@ -1885,7 +1885,7 @@ const dict = {
         transaction_prompt:
             'Pressione "{{ button }}" para abrir sua carteira conectada e confirmar a transação exibida.',
         transaction_prompt_receive:
-            'Pressione "{{ button }}" para abrir sua carteira conectada e confirmar a transação para receber {{ asset }}.',
+            'Pressione "{{ button }}" para começar a reivindicar {{ asset }}.',
         transaction_failed: "Falha na transação: {{ error }}",
         wallet_request_rejected: "A solicitação foi rejeitada na sua carteira.",
         invalid_address: "Endereço {{ asset }} inválido",
@@ -2427,8 +2427,7 @@ const dict = {
         back_to_home: "返回首页",
         transaction_prompt:
             "按“{{ button }}”以打开已连接的钱包并确认显示的交易。",
-        transaction_prompt_receive:
-            "按“{{ button }}”以打开已连接的钱包并确认显示的交易以便收{{ asset }}。",
+        transaction_prompt_receive: "按“{{ button }}”以开始领取 {{ asset }}。",
         transaction_failed: "交易失败：{{ error }}",
         wallet_request_rejected: "该请求已在您的钱包中被拒绝。",
         invalid_address: "无效的{{ asset }}地址",
@@ -2956,7 +2955,7 @@ const dict = {
         transaction_prompt:
             " 接続したウォレットを開いて、表示されたトランザクションを確認するために　{{ button }} を押してください",
         transaction_prompt_receive:
-            " 接続したウォレットを開いて、{{ asset }} を受け取るために表示されたトランザクションを確認するために {{ button }} を押してください",
+            "{{ asset }} の請求を開始するには {{ button }} を押してください",
         transaction_failed: "トランザクションに失敗しました: {{ error }}",
         wallet_request_rejected: "ウォレットでリクエストが拒否されました。",
         invalid_address: "無効な {{ asset }} アドレス",

--- a/src/pages/RescueEvm.tsx
+++ b/src/pages/RescueEvm.tsx
@@ -374,23 +374,42 @@ const ClaimState = (props: {
 
         return restoredReceiveAsset();
     };
-    const claimDestination = (useOriginalDestination: boolean) =>
-        useOriginalDestination
-            ? (props.claimData.restoredSwap?.originalDestination ??
-              signer()?.address)
+    const rescueGasSigner = () => {
+        const file = rescueFile();
+        return file === undefined
+            ? undefined
+            : getGasAbstractionSigner(routeClaimAsset(), file);
+    };
+    const hasDirectDestination = () => {
+        const gasSigner = rescueGasSigner();
+        return (
+            gasSigner !== undefined &&
+            normalizeEvmId(props.claimData.claimAddress) !==
+                normalizeEvmId(gasSigner.address)
+        );
+    };
+    const claimDestination = () => {
+        if (routedDex() !== undefined) {
+            return (
+                props.claimData.restoredSwap?.originalDestination ??
+                signer()?.address
+            );
+        }
+
+        return hasDirectDestination()
+            ? props.claimData.claimAddress
             : signer()?.address;
+    };
 
     const canClaimWithoutWallet = () =>
-        routedDex() !== undefined &&
-        props.claimData.restoredSwap?.originalDestination !== undefined &&
         getKindForAsset(routeClaimAsset()) === AssetKind.ERC20 &&
-        rescueFile() !== undefined;
+        rescueFile() !== undefined &&
+        (routedDex() !== undefined
+            ? props.claimData.restoredSwap?.originalDestination !== undefined
+            : hasDirectDestination());
 
     const signerOverride = () =>
-        signer() ??
-        (canClaimWithoutWallet()
-            ? getGasAbstractionSigner(routeClaimAsset(), rescueFile())
-            : undefined);
+        signer() ?? (canClaimWithoutWallet() ? rescueGasSigner() : undefined);
 
     const getGasAbstraction = async (
         asset: string,
@@ -429,9 +448,9 @@ const ClaimState = (props: {
 
         try {
             const gasAbstraction = await getGasAbstraction(asset);
-            const sig = signer();
+            const sig = signerOverride();
             const dex = routedDex();
-            const destination = claimDestination(dex !== undefined);
+            const destination = claimDestination();
             if (destination === undefined) {
                 throw new Error("missing claim destination");
             }

--- a/tests/pages/RescueEvm.spec.tsx
+++ b/tests/pages/RescueEvm.spec.tsx
@@ -30,6 +30,7 @@ const preimage =
 const {
     mockGetLogsFromReceipt,
     mockNavigate,
+    mockClaimAsset,
     mockQuoteDexAmountIn,
     mockResolveLockupTokenFunder,
     paramsMock,
@@ -37,6 +38,7 @@ const {
 } = vi.hoisted(() => ({
     mockGetLogsFromReceipt: vi.fn(),
     mockNavigate: vi.fn(),
+    mockClaimAsset: vi.fn(),
     mockQuoteDexAmountIn: vi.fn(),
     mockResolveLockupTokenFunder: vi.fn(),
     paramsMock: {
@@ -91,8 +93,12 @@ vi.mock("../../src/utils/evmLockup", async () => {
     };
 });
 
+vi.mock("../../src/utils/evmTransaction", () => ({
+    claimAsset: mockClaimAsset,
+}));
+
 const gasSigner = {
-    address: "0x0000000000000000000000000000000000000004",
+    address: "0x0000000000000000000000000000000000000004" as const,
     provider: {
         getChainId: () =>
             Promise.resolve(config.assets?.TBTC?.network?.chainId ?? 1),
@@ -234,6 +240,10 @@ describe("RescueEvm", () => {
             action: RskRescueMode.Claim,
         };
         mockGetLogsFromReceipt.mockResolvedValue(logData);
+        mockClaimAsset.mockResolvedValue({
+            transactionHash,
+            receiveAmount: logData.amount,
+        });
         mockQuoteDexAmountIn.mockResolvedValue([]);
         mockResolveLockupTokenFunder.mockResolvedValue(originalFunder);
         rescueSwaps.current = [
@@ -246,15 +256,45 @@ describe("RescueEvm", () => {
         ];
     });
 
-    test("loads a restored DEX claim before the wallet is connected", async () => {
+    test("claims a plain restored ERC20 swap without a connected wallet", async () => {
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        const continueButton = await screen.findByRole("button", {
+            name: i18n.en.continue,
+        });
+        expect(
+            screen.queryByRole("button", { name: "Connect wallet" }),
+        ).toBeNull();
+
+        fireEvent.click(continueButton);
+        await waitFor(() => expect(mockClaimAsset).toHaveBeenCalledOnce());
+        const claimParams = mockClaimAsset.mock.calls[0][0];
+        expect(claimParams.destination).toEqual(logData.claimAddress);
+        expect(claimParams.signer()).toEqual(gasSigner);
+        expect(mockGetLogsFromReceipt).toHaveBeenCalled();
+    });
+
+    test("keeps a plain claim gated when its destination is not recoverable", async () => {
+        const unresolvedClaim = {
+            ...logData,
+            claimAddress: gasSigner.address,
+        };
+        mockGetLogsFromReceipt.mockResolvedValue(unresolvedClaim);
+        rescueSwaps.current = [
+            {
+                ...unresolvedClaim,
+                action: RskRescueMode.Claim,
+                preimage,
+                restoredSwap,
+            },
+        ];
+
         render(() => <RescueEvm />, { wrapper: contextWrapper });
 
         expect(
             await screen.findByRole("button", { name: "Connect wallet" }),
         ).toBeInTheDocument();
         expect(screen.getByRole("button", { name: "Claim" })).toBeDisabled();
-        expect(screen.queryByText("No wallet connected")).toBeNull();
-        expect(mockGetLogsFromReceipt).toHaveBeenCalled();
     });
 
     test("enables a plain restored refund without a connected wallet", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ERC20 claims can now continue without a connected wallet when the claim destination can be safely determined.
  * Improved handling of claim destinations for direct claims and routed swaps.

* **Bug Fixes**
  * Prevented claims from proceeding when the destination cannot be recovered.
  * Updated claim instructions across English, German, Spanish, Portuguese, Chinese, and Japanese translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->