### PR TITLE
fix: require rescue key backup on commitment swap creation

### DIFF
--- a/e2e/arbitrum/commitment.spec.ts
+++ b/e2e/arbitrum/commitment.spec.ts
@@ -59,6 +59,8 @@ const createCommitmentSwap = async (
     await expect(createButton).toBeEnabled({ timeout: actionTimeout });
     await createButton.click();
 
+    await verifyRescueFile(page);
+
     await expect(
         page
             .getByRole("button", { name: /^approve$/i })

--- a/src/pages/Pay.tsx
+++ b/src/pages/Pay.tsx
@@ -170,7 +170,6 @@ const Pay = () => {
         return (
             currentSwap !== null &&
             currentSwap.type !== SwapType.Reverse &&
-            !isCommitmentSwap(currentSwap) &&
             !rescueFileBackupDone()
         );
     });
@@ -211,11 +210,7 @@ const Pay = () => {
             };
         },
         async ({ backupDone, swap: currentSwap, timedOutRefundable }) => {
-            if (
-                currentSwap.type !== SwapType.Reverse &&
-                !isCommitmentSwap(currentSwap) &&
-                !backupDone
-            ) {
+            if (currentSwap.type !== SwapType.Reverse && !backupDone) {
                 return;
             }
 

--- a/tests/pages/Pay.spec.tsx
+++ b/tests/pages/Pay.spec.tsx
@@ -292,6 +292,24 @@ describe("Pay", () => {
         expect(mockGetSwapStatus).not.toHaveBeenCalled();
     });
 
+    test("should require backup before funding a commitment swap", async () => {
+        swapsGetItemMock.mockResolvedValue({
+            id: "commitment-123",
+            type: SwapType.Commitment,
+            assetReceive: LN,
+            assetSend: USDT0,
+        } as SomeSwap);
+
+        renderPay(false);
+
+        await screen.findByText(dict.en.download_boltz_rescue_key);
+        expect(screen.queryByTestId("commitment-created")).toBeNull();
+
+        globalSignals.setRescueFileBackupDone(true);
+
+        expect(await screen.findByTestId("commitment-created")).toBeVisible();
+    });
+
     test("should start backup flow on mnemonic step when ?backup=mnemonic is set", async () => {
         window.history.replaceState({}, "", "/?backup=mnemonic");
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added backup verification flow for Commitment swaps before allowing users to proceed.
  * Shows the rescue-key download prompt until backup completion is confirmed.

* **Bug Fixes**
  * Prevented swap status updates from running when rescue-file backup isn’t completed for applicable swaps.
  * Improved Commitment-swap creation verification in end-to-end coverage.

* **Tests**
  * Added a `Pay` test to confirm the Commitment swap UI waits for rescue backup before rendering the next step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->