### PR TITLE
fix: invoice error message on commitment swaps

### DIFF
--- a/src/consts/Enums.ts
+++ b/src/consts/Enums.ts
@@ -32,6 +32,7 @@ export enum AssetSelection {
 export enum InvoiceValidation {
     MinAmount = "minAmount",
     MaxAmount = "maxAmount",
+    ExactAmount = "exactAmount",
 }
 
 export enum Currency {

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -947,7 +947,7 @@ const dict = {
         max_amount_destination:
             "Höchstbetrag für die Zieladresse ist {{ amount }} {{ denomination }}",
         exact_amount_destination:
-            "Rechnungsbetrag muss genau {{ amount }} {{ denomination }} betragen",
+            "Betrag muss genau {{ amount }} {{ denomination }} sein",
         destination: "Zieladresse",
         destination_address: "{{ address }}",
 

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -380,6 +380,8 @@ const dict = {
             "Minimum amount for the destination address is {{ amount }} {{ denomination }}",
         max_amount_destination:
             "Maximum amount for the destination address is {{ amount }} {{ denomination }}",
+        exact_amount_destination:
+            "Invoice amount must be exactly {{ amount }} {{ denomination }}",
         destination: "Destination",
         destination_address: "{{ address }}",
 
@@ -944,6 +946,8 @@ const dict = {
             "Mindestbetrag für die Zieladresse ist {{ amount }} {{ denomination }}",
         max_amount_destination:
             "Höchstbetrag für die Zieladresse ist {{ amount }} {{ denomination }}",
+        exact_amount_destination:
+            "Rechnungsbetrag muss genau {{ amount }} {{ denomination }} betragen",
         destination: "Zieladresse",
         destination_address: "{{ address }}",
 
@@ -1506,6 +1510,8 @@ const dict = {
             "La cantidad mínima para la dirección de destino es {{ amount }} {{ denomination }}",
         max_amount_destination:
             "La cantidad máxima para la dirección de destino es {{ amount }} {{ denomination }}",
+        exact_amount_destination:
+            "El importe de la factura debe ser exactamente {{ amount }} {{ denomination }}",
         destination: "Destino",
         destination_address: "{{ address }}",
 
@@ -2064,6 +2070,8 @@ const dict = {
             "O valor mínimo para o endereço de destino é {{ amount }} {{ denomination }}",
         max_amount_destination:
             "O valor máximo para o endereço de destino é {{ amount }} {{ denomination }}",
+        exact_amount_destination:
+            "O valor do invoice deve ser exatamente {{ amount }} {{ denomination }}",
         destination: "Destino",
         destination_address: "{{ address }}",
 
@@ -2581,6 +2589,8 @@ const dict = {
             "目标地址的最小金额为{{ amount }}{{ denomination }}",
         max_amount_destination:
             "目标地址的最大金额为{{ amount }}{{ denomination }}",
+        exact_amount_destination:
+            "发票金额必须正好为{{ amount }}{{ denomination }}",
         destination: "目标地址",
         destination_address: "{{ address }}",
 
@@ -3121,6 +3131,8 @@ const dict = {
             "宛先アドレスの最小金額は{{ amount }} {{ denomination }}です",
         max_amount_destination:
             "宛先アドレスの最大金額は{{ amount }} {{ denomination }}です",
+        exact_amount_destination:
+            "インボイスの金額は正確に{{ amount }} {{ denomination }}である必要があります",
         destination: "宛先アドレス",
         destination_address: "{{ address }}",
 

--- a/src/status/CommitmentCreated.tsx
+++ b/src/status/CommitmentCreated.tsx
@@ -48,6 +48,7 @@ import {
     isDeferredInvoiceDestination,
 } from "../utils/invoice";
 import {
+    type BridgeDetail,
     type CommitmentSwap,
     createSubmarine,
     getPreBridgeDetail,
@@ -174,6 +175,7 @@ const CommitmentInvoiceHeader = (props: {
     invoiceAsset: string;
     lockupAsset: string;
     lockupTxHash: string;
+    bridge?: BridgeDetail;
 }) => {
     const { separator, t } = useGlobalContext();
 
@@ -204,19 +206,29 @@ const CommitmentInvoiceHeader = (props: {
                 <CommitmentLockupTransaction
                     asset={props.lockupAsset}
                     txHash={props.lockupTxHash}
+                    bridge={props.bridge}
                 />
             </div>
         </div>
     );
 };
 
-const CommitmentLockupTransaction = (props: {
+export const CommitmentLockupTransaction = (props: {
     asset: string;
     txHash: string;
+    bridge?: BridgeDetail;
 }) => {
     const { t } = useGlobalContext();
     const explorerHref = () =>
         blockExplorerLink(props.asset, true, props.txHash);
+    // On bridged commitments this tx is the bridge send, not the final
+    // lockup; that one is linked on the next step
+    const label = () =>
+        props.bridge !== undefined
+            ? t("check_bridge_status")
+            : t("blockexplorer", {
+                  typeLabel: t("blockexplorer_lockup_tx"),
+              });
 
     return (
         <Show when={explorerHref()}>
@@ -224,11 +236,9 @@ const CommitmentLockupTransaction = (props: {
                 <ExternalLink
                     class="commitment-lockup-transaction"
                     href={href()}
-                    aria-label={t("blockexplorer", {
-                        typeLabel: t("blockexplorer_lockup_tx"),
-                    })}>
+                    aria-label={label()}>
                     <BsGlobe size={14} />
-                    <span>{t("blockexplorer_lockup_tx")}</span>
+                    <span>{label()}</span>
                 </ExternalLink>
             )}
         </Show>
@@ -623,6 +633,9 @@ const CommitmentCreated = () => {
                                         lockupTxHash={
                                             commitment().commitmentLockupTxHash!
                                         }
+                                        bridge={getPreBridgeDetail(
+                                            commitment().bridge,
+                                        )}
                                     />
                                     <input
                                         required

--- a/src/status/CommitmentCreated.tsx
+++ b/src/status/CommitmentCreated.tsx
@@ -28,7 +28,7 @@ import ExternalLink from "../components/ExternalLink";
 import LoadingSpinner from "../components/LoadingSpinner";
 import LockupEvm from "../components/LockupEvm";
 import RefundButton from "../components/RefundButton";
-import { Denomination } from "../consts/Enums";
+import { Denomination, InvoiceValidation } from "../consts/Enums";
 import type { ButtonLabelParams } from "../consts/Types";
 import { useGlobalContext } from "../context/Global";
 import { usePayContext } from "../context/Pay";
@@ -131,8 +131,9 @@ export const validateCommitmentInvoice = (
 ): InvoiceData => {
     const invoice = extractInvoice(value) ?? "";
     const sats = validateInvoice(invoice);
-    if (sats !== getInvoiceSats(amounts)) {
-        throw new Error("invalid_invoice");
+    const expectedSats = getInvoiceSats(amounts);
+    if (sats !== expectedSats) {
+        throw new Error(InvoiceValidation.ExactAmount, { cause: expectedSats });
     }
 
     return { invoice, sats };

--- a/src/utils/invoice.ts
+++ b/src/utils/invoice.ts
@@ -62,6 +62,9 @@ export const invoiceAmountLabel = (
         case InvoiceValidation.MaxAmount:
             key = "max_amount_destination";
             break;
+        case InvoiceValidation.ExactAmount:
+            key = "exact_amount_destination";
+            break;
         default: {
             const unhandled: never = error.message as never;
             return unhandled;

--- a/tests/status/CommitmentCreated.spec.ts
+++ b/tests/status/CommitmentCreated.spec.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from "bignumber.js";
 import type { Hash, PublicClient, TransactionReceipt } from "viem";
 
+import { InvoiceValidation } from "../../src/consts/Enums";
 import {
     type CommitmentAmounts,
     calculateCommittedSubmarineAmounts,
@@ -107,13 +108,25 @@ describe("CommitmentCreated", () => {
         expect(validateInvoice).not.toHaveBeenCalled();
     });
 
-    test("rejects invoices with the wrong amount", () => {
-        expect(() =>
+    test("rejects invoices with the wrong amount and reports the expected amount", () => {
+        const expectedSats = validateInvoice(invoice) + 1;
+
+        let thrown: unknown;
+        try {
             validateCommitmentInvoice(`lightning:${invoice}`, {
                 ...commitmentAmountsForInvoice(invoice),
-                receiveAmount: BigNumber(validateInvoice(invoice) + 1),
-            }),
-        ).toThrow("invalid_invoice");
+                receiveAmount: BigNumber(expectedSats),
+            });
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(thrown).toBeInstanceOf(Error);
+        expect((thrown as Error).message).toEqual(
+            InvoiceValidation.ExactAmount,
+        );
+        // The expected amount is carried on the cause so the UI can render it
+        expect((thrown as Error).cause).toEqual(expectedSats);
     });
 
     test("retries commitment lockup receipt lookup after transient failures", async () => {

--- a/tests/status/CommitmentCreated.spec.tsx
+++ b/tests/status/CommitmentCreated.spec.tsx
@@ -1,16 +1,24 @@
+import { render, screen } from "@solidjs/testing-library";
 import { BigNumber } from "bignumber.js";
+import { SwapPosition } from "boltz-swaps/types";
 import type { Hash, PublicClient, TransactionReceipt } from "viem";
 
+import { config } from "../../src/config";
+import { USDT0 } from "../../src/consts/Assets";
 import { InvoiceValidation } from "../../src/consts/Enums";
+import dict from "../../src/i18n/i18n";
 import {
     type CommitmentAmounts,
+    CommitmentLockupTransaction,
     calculateCommittedSubmarineAmounts,
     validateCommitmentInvoice,
     validateCommitmentInvoiceInput,
     waitForCommitmentLockupReceipt,
 } from "../../src/status/CommitmentCreated";
 import type Pair from "../../src/utils/Pair";
+import type { BridgeDetail } from "../../src/utils/swapCreator";
 import { validateInvoice } from "../../src/utils/validation";
+import { contextWrapper } from "../helper";
 
 const invoice = "lnbcrt1mock";
 const invoiceSats = 40_720;
@@ -162,5 +170,67 @@ describe("CommitmentCreated", () => {
             waitForCommitmentLockupReceipt(provider, hash, 1, 0, 2),
         ).rejects.toThrow("rpc timeout");
         expect(provider.waitForTransactionReceipt).toHaveBeenCalledTimes(2);
+    });
+
+    describe("CommitmentLockupTransaction", () => {
+        const txHash = "0xdeadbeef";
+        const lockupTransactionLabel = dict.en.blockexplorer.replace(
+            "{{ typeLabel }}",
+            dict.en.blockexplorer_lockup_tx,
+        );
+        const preBridge = {
+            kind: "oft",
+            sourceAsset: "USDT0-ETH",
+            destinationAsset: USDT0,
+            position: SwapPosition.Pre,
+        } as unknown as BridgeDetail;
+
+        const explorerTxHref = () =>
+            `${config.assets![USDT0].blockExplorerUrl!.normal}/tx/${txHash}`;
+
+        test("labels the link as bridge status for bridged commitments", async () => {
+            render(
+                () => (
+                    <CommitmentLockupTransaction
+                        asset={USDT0}
+                        txHash={txHash}
+                        bridge={preBridge}
+                    />
+                ),
+                { wrapper: contextWrapper },
+            );
+
+            const link = (
+                await screen.findByText(dict.en.check_bridge_status)
+            ).closest("a")!;
+
+            expect(screen.queryByText(lockupTransactionLabel)).toBeNull();
+            expect(link.getAttribute("aria-label")).toEqual(
+                dict.en.check_bridge_status,
+            );
+            expect(link.href).toEqual(explorerTxHref());
+        });
+
+        test("keeps the lockup transaction label for non-bridged commitments", async () => {
+            render(
+                () => (
+                    <CommitmentLockupTransaction
+                        asset={USDT0}
+                        txHash={txHash}
+                    />
+                ),
+                { wrapper: contextWrapper },
+            );
+
+            const link = (
+                await screen.findByText(lockupTransactionLabel)
+            ).closest("a")!;
+
+            expect(screen.queryByText(dict.en.check_bridge_status)).toBeNull();
+            expect(link.getAttribute("aria-label")).toEqual(
+                lockupTransactionLabel,
+            );
+            expect(link.href).toEqual(explorerTxHref());
+        });
     });
 });

--- a/tests/utils/invoice.spec.ts
+++ b/tests/utils/invoice.spec.ts
@@ -2,11 +2,14 @@ import BigNumber from "bignumber.js";
 import { getConfiguredNetwork } from "boltz-swaps/config";
 
 import { BTC, LBTC, LN } from "../../src/consts/Assets";
+import { Denomination, InvoiceValidation } from "../../src/consts/Enums";
+import { formatAmount, formatDenomination } from "../../src/utils/denomination";
 import {
     extractAddress,
     extractBip21Amount,
     extractInvoice,
     getAssetByBip21Prefix,
+    invoiceAmountLabel,
     isBip21,
     isInvoice,
     isLnurl,
@@ -136,6 +139,43 @@ describe("invoice", () => {
             expect(isInvoice(undefined as never)).toBe(false);
             expect(isInvoice(null as never)).toBe(false);
             expect(isInvoice(123 as never)).toBe(false);
+        });
+    });
+
+    describe("invoiceAmountLabel", () => {
+        const options = {
+            denomination: Denomination.Sat,
+            separator: " ",
+            asset: BTC,
+        };
+
+        test("maps an exact-amount mismatch to the required-amount label", () => {
+            const requiredSats = 1529;
+            const error = new Error(InvoiceValidation.ExactAmount, {
+                cause: requiredSats,
+            });
+
+            expect(invoiceAmountLabel(error, options)).toEqual({
+                key: "exact_amount_destination",
+                params: {
+                    amount: formatAmount(
+                        BigNumber(requiredSats),
+                        options.denomination,
+                        options.separator,
+                        options.asset,
+                    ),
+                    denomination: formatDenomination(
+                        options.denomination,
+                        options.asset,
+                    ),
+                },
+            });
+        });
+
+        test("ignores errors that are not invoice validation errors", () => {
+            expect(
+                invoiceAmountLabel(new Error("invalid_invoice"), options),
+            ).toBeUndefined();
         });
     });
 });


### PR DESCRIPTION
closes: #1567 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added exact-amount invoice validation to ensure destination invoices match the required amount precisely.
  * Added localized messages explaining the exact amount required across supported languages.
  * Improved bridged commitment details with a clear link to check bridge status.

* **Bug Fixes**
  * Replaced generic invoice validation failures with specific, actionable amount-mismatch feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->