### PR TITLE
fix: commitment swap strings

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -65,7 +65,8 @@ const dict = {
             "Swap limits changed. Please confirm new amounts and continue with swap.",
         commitment_invoice_heading:
             "Enter a Lightning Invoice for {{ amount }} {{ denomination }}",
-        commitment_invoice_deferred: "Invoice to be entered after funding",
+        commitment_invoice_deferred:
+            "Enter Lightning destination after payment",
         clear_amount: "Clear",
         create_and_paste:
             "Paste a Lightning invoice, BOLT12 or LNURL to receive funds",
@@ -613,8 +614,7 @@ const dict = {
             "Swap-Limits haben sich geändert. Bitte bestätige die neuen Beträge und fahre mit dem Swap fort.",
         commitment_invoice_heading:
             "Lightning-Rechnung über {{ amount }} {{ denomination }} eingeben",
-        commitment_invoice_deferred:
-            "Rechnung wird nach der Zahlung eingegeben",
+        commitment_invoice_deferred: "Lightning-Ziel nach Zahlung eingeben",
         clear_amount: "Löschen",
         create_and_paste:
             "Füge eine Lightning-Rechnung, BOLT12 oder LNURL des Empfängers ein",
@@ -1180,7 +1180,7 @@ const dict = {
         commitment_invoice_heading:
             "Introduce una factura Lightning por {{ amount }} {{ denomination }}",
         commitment_invoice_deferred:
-            "La factura se introducirá después de financiar",
+            "Ingresa el destino Lightning después del pago",
         clear_amount: "Borrar",
         create_and_paste:
             "Pega una factura Lightning, una dirección BOLT12 o una LNURL para recibir los fondos",
@@ -1743,7 +1743,7 @@ const dict = {
         commitment_invoice_heading:
             "Insira um invoice Lightning de {{ amount }} {{ denomination }}",
         commitment_invoice_deferred:
-            "Invoice será inserido após o envio dos fundos",
+            "Insira o destino Lightning após o pagamento",
         clear_amount: "Limpar",
         create_and_paste:
             "Cole um invoice Lightning, um endereço BOLT12 ou um LNURL para receber os fundos",
@@ -2296,7 +2296,7 @@ const dict = {
         amount_limits_changed: "兑换限额已变更，请确认新的金额并继续进行兑换。",
         commitment_invoice_heading:
             "输入 {{ amount }} {{ denomination }} 的闪电发票",
-        commitment_invoice_deferred: "资金发送后输入发票",
+        commitment_invoice_deferred: "支付后输入闪电网络目标",
         clear_amount: "清除",
         create_and_paste: "粘贴闪电发票、BOLT12 地址或 LNURL 以接收资金",
         invoice_cleared_amount_changed: "金额已更改，发票已清除。",
@@ -2801,7 +2801,7 @@ const dict = {
             "スワップの上限／下限が変更されました。新しい金額を確認し、スワップを続行してください。",
         commitment_invoice_heading:
             "{{ amount }} {{ denomination }} のライトニングインボイスを入力してください",
-        commitment_invoice_deferred: "送金後にインボイスを入力",
+        commitment_invoice_deferred: "支払い後にライトニングの送金先を入力",
         clear_amount: "クリア",
         create_and_paste:
             "資金を受け取るために、ライトニングインボイス、BOLT12、またはLNURLを貼り付けてください",

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -3,6 +3,7 @@ import { BigNumber } from "bignumber.js";
 import { getRpcUrls } from "boltz-swaps/config";
 import { AssetKind, NetworkTransport } from "boltz-swaps/types";
 import log from "loglevel";
+import { IoClose } from "solid-icons/io";
 import {
     Show,
     createEffect,
@@ -989,8 +990,9 @@ const Create = () => {
                                 type="button"
                                 class="btn-small invoice-slot-action"
                                 data-testid="committed-invoice-clear"
+                                aria-label={t("clear_amount")}
                                 onClick={clearCommittedAmounts}>
-                                {t("clear_amount")}
+                                <IoClose size={16} />
                             </button>
                         </div>
                     </Show>

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -690,47 +690,35 @@ textarea.invalid {
 .committed-invoice-input:disabled::placeholder {
     color: var(--color-white-30);
 }
-.committed-invoice-row .invoice-slot-action {
+.committed-invoice-input {
+    padding-right: 40px;
+}
+.invoice-slot-action {
     position: absolute;
     top: 50%;
     right: 10px;
     transform: translateY(-50%);
-    padding: 0 7px;
-    border-color: var(--color-white-05);
+    padding: 0 4px;
+    border: 1px solid var(--color-white-05);
     background: var(--color-white-05);
     color: var(--color-white-50);
-    font-size: 0.75rem;
-    font-weight: 600;
-}
-.invoice-slot-action {
-    flex: 0 0 auto;
-    border: 1px solid var(--color-white-15);
-    background: var(--color-secondary-700);
-    color: var(--color-text);
-    font-weight: 600;
-}
-@media (hover: hover) {
-    .invoice-slot-action:hover {
-        background: var(--color-secondary-100);
-        color: var(--color-secondary-700);
-    }
 }
 .invoice-slot-action:focus-visible,
 .invoice-slot-action:active {
-    background: var(--color-secondary-100);
-    color: var(--color-secondary-700);
-}
-.committed-invoice-row .invoice-slot-action:focus-visible,
-.committed-invoice-row .invoice-slot-action:active {
     border-color: var(--color-white-10);
     background: var(--color-white-10);
     color: var(--color-white-80);
 }
 @media (hover: hover) {
-    .committed-invoice-row .invoice-slot-action:hover {
+    .invoice-slot-action:hover {
         border-color: var(--color-white-10);
         background: var(--color-white-10);
         color: var(--color-white-80);
+    }
+}
+@media (max-width: 488px) {
+    .committed-invoice-input::placeholder {
+        font-size: 0.8rem;
     }
 }
 .fees-dyn label {

--- a/tests/pages/Create.spec.tsx
+++ b/tests/pages/Create.spec.tsx
@@ -1489,7 +1489,7 @@ describe("Create", () => {
             ).toBeInTheDocument();
             expect(
                 screen.getByTestId("committed-invoice-clear"),
-            ).toHaveTextContent(i18n.en.clear_amount);
+            ).toHaveAccessibleName(i18n.en.clear_amount);
 
             fireEvent.click(screen.getByTestId("committed-invoice-clear"));
 


### PR DESCRIPTION
- shortened strings and moved all to imperative
- added padding for clear button
- replaced "Clear" button with an "x" on mobile and desktop

Before (iPhone SE):
<img width="468" height="76" alt="image" src="https://github.com/user-attachments/assets/e3d02918-fc38-4c83-9dae-af6cadcd7247" />

After (iPhone SE):
<img width="468" height="76" alt="image" src="https://github.com/user-attachments/assets/7ea34a8d-01ae-4261-a970-998282880cf1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features / UX**
  * Updated the committed-invoice prompt copy across supported languages to guide users to enter a Lightning destination after payment.
  * Replaced the “clear” control text with a close icon and added an accessibility label.

* **Style**
  * Refined invoice input and slot action button styling, including unified interaction states and improved spacing.
  * Added a small-screen adjustment for placeholder sizing.

* **Tests**
  * Updated the Create page assertion to verify the control’s accessibility name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->