### PR TITLE
fix: handle insufficient USDT0 bridge credits

### DIFF
--- a/packages/boltz-swaps/src/errors.ts
+++ b/packages/boltz-swaps/src/errors.ts
@@ -103,6 +103,25 @@ export class LnurlAmountError extends Error {
 export const isLnurlAmountError = (value: unknown): value is LnurlAmountError =>
     value instanceof LnurlAmountError;
 
+export class BridgeCapacityError extends Error {
+    // available/requested are in the bridge token's native decimals
+    constructor(
+        public readonly available: bigint,
+        public readonly requested: bigint,
+        options?: ErrorOptions,
+    ) {
+        super(
+            `bridge capacity exceeded: requested ${requested}, available ${available}`,
+            options,
+        );
+        this.name = "BridgeCapacityError";
+    }
+}
+
+export const isBridgeCapacityError = (
+    value: unknown,
+): value is BridgeCapacityError => value instanceof BridgeCapacityError;
+
 export const formatError = (message: unknown): string => {
     if (isWalletRejectionError(message)) {
         return walletRejectionMessage;

--- a/packages/boltz-swaps/src/oft/evm.ts
+++ b/packages/boltz-swaps/src/oft/evm.ts
@@ -46,6 +46,8 @@ export const oftAbi = parseAbi([
     "function send((uint32 dstEid,bytes32 to,uint256 amountLD,uint256 minAmountLD,bytes extraOptions,bytes composeMsg,bytes oftCmd) sendParam, (uint256 nativeFee,uint256 lzTokenFee) msgFee, address refundAddress) payable returns ((bytes32 guid,uint64 nonce,(uint256 amountSentLD,uint256 amountReceivedLD) receipt), (uint256 nativeFee,uint256 lzTokenFee))",
     "event OFTSent(bytes32 indexed guid, uint32 dstEid, address indexed fromAddress, uint256 amountSentLD, uint256 amountReceivedLD)",
     "event OFTReceived(bytes32 indexed guid, uint32 srcEid, address indexed toAddress, uint256 amountReceivedLD)",
+    // Thrown by the USDT0 legacy mesh when the destination pathway lacks capacity
+    "error InsufficientCredits(uint32 eid, uint256 credits, uint256 amountToSend)",
 ]);
 
 export const tempoOftWrapperAbi = parseAbi([

--- a/packages/boltz-swaps/src/oft/oft.ts
+++ b/packages/boltz-swaps/src/oft/oft.ts
@@ -6,6 +6,7 @@ import {
     type Hex,
     type PublicClient,
     concat,
+    decodeErrorResult,
     encodeFunctionData,
     encodePacked,
     getAddress,
@@ -23,6 +24,7 @@ import {
     requireRpcUrls,
     requireTokenConfig,
 } from "../config.ts";
+import { BridgeCapacityError } from "../errors.ts";
 import { prefix0x } from "../evm/prefix0x.ts";
 import { createAssetProvider } from "../evm/provider.ts";
 import { erc20Abi } from "../generated/evm-abis.ts";
@@ -50,6 +52,7 @@ import {
     getEvmOftReceivedEvent,
     getEvmOftReceivedEventByGuid,
     getEvmOftSentEvent,
+    oftAbi,
 } from "./evm.ts";
 import {
     type OftContract,
@@ -78,6 +81,7 @@ import type {
 
 const providerCachePrefix = "oft:provider:";
 const executorNativeAmountExceedsCapSelector = "0x0084ce02";
+const insufficientCreditsSelector = "0x735f7cd7";
 const type3Option = 3;
 const executorWorkerId = 1;
 const optionTypeLzReceive = 1;
@@ -92,7 +96,11 @@ const getErrorData = (error: unknown): string | undefined => {
 
     const candidate = error as {
         data?: unknown;
+        // Raw revert data of viem's ContractFunctionRevertedError; its "data"
+        // holds the decoded error instead
+        raw?: unknown;
         error?: unknown;
+        cause?: unknown;
         info?: {
             error?: unknown;
         };
@@ -101,8 +109,15 @@ const getErrorData = (error: unknown): string | undefined => {
     if (typeof candidate.data === "string") {
         return candidate.data;
     }
+    if (typeof candidate.raw === "string") {
+        return candidate.raw;
+    }
 
-    return getErrorData(candidate.error) ?? getErrorData(candidate.info?.error);
+    return (
+        getErrorData(candidate.error) ??
+        getErrorData(candidate.cause) ??
+        getErrorData(candidate.info?.error)
+    );
 };
 
 export const isExecutorNativeAmountExceedsCapError = (
@@ -132,6 +147,39 @@ export const decodeExecutorNativeAmountExceedsCapError = (
         amount: BigInt(prefix0x(data.slice(10, 74))),
         cap: BigInt(prefix0x(data.slice(74, 138))),
     };
+};
+
+export const isInsufficientCreditsError = (error: unknown): boolean =>
+    getErrorData(error)?.startsWith(insufficientCreditsSelector) ?? false;
+
+export const decodeInsufficientCreditsError = (
+    error: unknown,
+):
+    | {
+          eid: number;
+          credits: bigint;
+          amountToSend: bigint;
+      }
+    | undefined => {
+    const data = getErrorData(error);
+    if (data === undefined || !data.startsWith(insufficientCreditsSelector)) {
+        return undefined;
+    }
+
+    try {
+        const decoded = decodeErrorResult({
+            abi: oftAbi,
+            data: data as Hex,
+        });
+        const [eid, credits, amountToSend] = decoded.args as [
+            number,
+            bigint,
+            bigint,
+        ];
+        return { eid, credits, amountToSend };
+    } catch {
+        return undefined;
+    }
 };
 
 export const clearOftDeployments = () => {
@@ -532,10 +580,29 @@ export const quoteOftSend = async (
         ),
     );
     const [oftLimit, oftFeeDetails, oftReceipt] = await oft.quoteOFT(sendParam);
+    if (oftLimit[1] > 0n && amount > oftLimit[1]) {
+        throw new BridgeCapacityError(oftLimit[1], amount);
+    }
+
     const quotedSendParam: SendParam = [...sendParam];
     quotedSendParam[3] = oftReceipt[1];
 
-    const quotedMsgFee = await oft.quoteSend(quotedSendParam, false);
+    let quotedMsgFee: MsgFee;
+    try {
+        quotedMsgFee = await oft.quoteSend(quotedSendParam, false);
+    } catch (error) {
+        const decoded = decodeInsufficientCreditsError(error);
+        if (decoded !== undefined) {
+            throw new BridgeCapacityError(
+                decoded.credits,
+                decoded.amountToSend,
+                {
+                    cause: error,
+                },
+            );
+        }
+        throw error;
+    }
     const msgFee: MsgFee = [quotedMsgFee[0], quotedMsgFee[1]];
 
     return {

--- a/packages/boltz-swaps/tests/errors.spec.ts
+++ b/packages/boltz-swaps/tests/errors.spec.ts
@@ -1,7 +1,9 @@
 import {
+    BridgeCapacityError,
     LnurlAmountError,
     LnurlAmountErrorKind,
     formatError,
+    isBridgeCapacityError,
     isLnurlAmountError,
     toError,
 } from "../src/errors.ts";
@@ -80,6 +82,40 @@ describe("isLnurlAmountError", () => {
         expect(isLnurlAmountError(null)).toBe(false);
         expect(isLnurlAmountError(undefined)).toBe(false);
         expect(isLnurlAmountError({})).toBe(false);
+    });
+});
+
+describe("BridgeCapacityError", () => {
+    test("exposes name, message, amounts and cause", () => {
+        const cause = new Error("execution reverted");
+        const err = new BridgeCapacityError(50n, 100n, { cause });
+        expect(err).toBeInstanceOf(Error);
+        expect(err).toBeInstanceOf(BridgeCapacityError);
+        expect(err.name).toBe("BridgeCapacityError");
+        expect(err.message).toBe(
+            "bridge capacity exceeded: requested 100, available 50",
+        );
+        expect(err.available).toBe(50n);
+        expect(err.requested).toBe(100n);
+        expect(err.cause).toBe(cause);
+    });
+
+    test("isBridgeCapacityError only matches instances", () => {
+        expect(isBridgeCapacityError(new BridgeCapacityError(1n, 2n))).toBe(
+            true,
+        );
+        expect(
+            isBridgeCapacityError(new Error("bridge capacity exceeded")),
+        ).toBe(false);
+        expect(isBridgeCapacityError(undefined)).toBe(false);
+        expect(isBridgeCapacityError({ available: 1n, requested: 2n })).toBe(
+            false,
+        );
+    });
+
+    test("toError returns the same BridgeCapacityError instance", () => {
+        const err = new BridgeCapacityError(1n, 2n);
+        expect(toError(err)).toBe(err);
     });
 });
 

--- a/packages/boltz-swaps/tests/oft/bridgeDriver.spec.ts
+++ b/packages/boltz-swaps/tests/oft/bridgeDriver.spec.ts
@@ -1,15 +1,18 @@
 import { base58, hex } from "@scure/base";
 import { OftBridgeDriver } from "boltz-swaps/bridge";
 import { setBoltzSwapsConfig } from "boltz-swaps/config";
+import { BridgeCapacityError } from "boltz-swaps/errors";
 import {
     clearOftDeployments,
     createOftContract,
     decodeExecutorNativeAmountExceedsCapError,
+    decodeInsufficientCreditsError,
     getOftContract,
     getOftReceivedEventByGuid,
     getRequiredSolanaOftNativeBalance,
     getSolanaOftGuidFromLogs as getSolanaOftSentEventFromTransaction,
     isExecutorNativeAmountExceedsCapError,
+    isInsufficientCreditsError,
     oftAbi,
     quoteOftAmountInForAmountOut,
     quoteOftSend,
@@ -21,7 +24,12 @@ import {
     CctpTransferMode,
     NetworkTransport,
 } from "boltz-swaps/types";
-import { encodeAbiParameters, encodeEventTopics, getAbiItem } from "viem";
+import {
+    ContractFunctionRevertedError,
+    encodeAbiParameters,
+    encodeEventTopics,
+    getAbiItem,
+} from "viem";
 
 import {
     mainnetAssets,
@@ -863,6 +871,183 @@ describe("oft", () => {
             amount: 885449409847968336n,
             cap: 210000000000000000n,
         });
+
+        const viemStyle = { cause: { raw: error.data } };
+        expect(isExecutorNativeAmountExceedsCapError(viemStyle)).toBe(true);
+        expect(decodeExecutorNativeAmountExceedsCapError(viemStyle)).toEqual(
+            decodeExecutorNativeAmountExceedsCapError(error),
+        );
+    });
+
+    const insufficientCreditsRevertData = ("0x735f7cd7" +
+        encodeAbiParameters(
+            [{ type: "uint32" }, { type: "uint256" }, { type: "uint256" }],
+            [30420, 1301678000n, 3202712942n],
+        ).slice(2)) as `0x${string}`;
+
+    test("should decode InsufficientCredits reverts", () => {
+        const ethersStyle = { data: insufficientCreditsRevertData };
+        const viemStyle = { cause: { raw: insufficientCreditsRevertData } };
+        const deeplyNested = {
+            cause: { cause: { raw: insufficientCreditsRevertData } },
+        };
+        const realViemError = new Error("quoteSend reverted", {
+            cause: new ContractFunctionRevertedError({
+                abi: oftAbi,
+                data: insufficientCreditsRevertData,
+                functionName: "quoteSend",
+            }),
+        });
+
+        for (const error of [
+            ethersStyle,
+            viemStyle,
+            deeplyNested,
+            realViemError,
+        ]) {
+            expect(isInsufficientCreditsError(error)).toBe(true);
+            expect(decodeInsufficientCreditsError(error)).toEqual({
+                eid: 30420,
+                credits: 1301678000n,
+                amountToSend: 3202712942n,
+            });
+        }
+
+        expect(isInsufficientCreditsError({ data: "0x0084ce02" })).toBe(false);
+        expect(isInsufficientCreditsError(undefined)).toBe(false);
+        expect(isInsufficientCreditsError(new Error("reverted"))).toBe(false);
+        expect(
+            decodeInsufficientCreditsError({ data: "0x735f7cd7" }),
+        ).toBeUndefined();
+        expect(
+            decodeInsufficientCreditsError({ data: "0xdeadbeef" }),
+        ).toBeUndefined();
+    });
+
+    const stubUsdt0Deployments = () =>
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValue(
+                createOkFetchResponse({
+                    usdt0: {
+                        native: [
+                            {
+                                name: "Ethereum",
+                                chainId: 1,
+                                lzEid: "30101",
+                                contracts: [
+                                    {
+                                        name: "OFT Adapter",
+                                        address:
+                                            "0x1000000000000000000000000000000000000001",
+                                        explorer: "",
+                                    },
+                                ],
+                            },
+                            {
+                                name: "Polygon PoS",
+                                chainId: 137,
+                                lzEid: "30109",
+                                contracts: [
+                                    {
+                                        name: "OFT",
+                                        address:
+                                            "0x1000000000000000000000000000000000000000",
+                                        explorer: "",
+                                    },
+                                ],
+                            },
+                        ],
+                        legacyMesh: [],
+                    },
+                }),
+            ),
+        );
+
+    test("should throw BridgeCapacityError when the amount exceeds the OFT limit", async () => {
+        stubUsdt0Deployments();
+
+        const oft = {
+            quoteOFT: vi.fn().mockResolvedValue([[0n, 50n], [], [100n, 99n]]),
+            quoteSend: vi.fn(),
+        };
+
+        const promise = quoteOftSend(
+            oft as never,
+            getOftRoute("USDT0-ETH", "USDT0-POL"),
+            "0x2000000000000000000000000000000000000000",
+            100n,
+        );
+
+        await expect(promise).rejects.toBeInstanceOf(BridgeCapacityError);
+        await expect(promise).rejects.toMatchObject({
+            available: 50n,
+            requested: 100n,
+        });
+        expect(oft.quoteSend).not.toHaveBeenCalled();
+    });
+
+    test.each([
+        {
+            style: "ethers",
+            createError: (data: string) =>
+                Object.assign(new Error("execution reverted"), { data }),
+        },
+        {
+            style: "viem",
+            createError: (data: string) =>
+                Object.assign(new Error("execution reverted"), {
+                    cause: { raw: data },
+                }),
+        },
+    ])(
+        "should map $style-style InsufficientCredits quoteSend reverts to BridgeCapacityError",
+        async ({ createError }) => {
+            stubUsdt0Deployments();
+
+            const revertError = createError(insufficientCreditsRevertData);
+            const oft = {
+                quoteOFT: vi
+                    .fn()
+                    .mockResolvedValue([[0n, 0n], [], [100n, 99n]]),
+                quoteSend: vi.fn().mockRejectedValue(revertError),
+            };
+
+            const promise = quoteOftSend(
+                oft as never,
+                getOftRoute("USDT0-ETH", "USDT0-POL"),
+                "0x2000000000000000000000000000000000000000",
+                100n,
+            );
+
+            await expect(promise).rejects.toBeInstanceOf(BridgeCapacityError);
+            await expect(promise).rejects.toMatchObject({
+                available: 1301678000n,
+                requested: 3202712942n,
+                cause: revertError,
+            });
+        },
+    );
+
+    test("should rethrow undecodable quoteSend errors", async () => {
+        stubUsdt0Deployments();
+
+        const revertError = Object.assign(new Error("execution reverted"), {
+            data: "0xdeadbeef",
+        });
+        const oft = {
+            quoteOFT: vi.fn().mockResolvedValue([[0n, 0n], [], [100n, 99n]]),
+            quoteSend: vi.fn().mockRejectedValue(revertError),
+        };
+
+        await expect(
+            quoteOftSend(
+                oft as never,
+                getOftRoute("USDT0-ETH", "USDT0-POL"),
+                "0x2000000000000000000000000000000000000000",
+                100n,
+            ),
+        ).rejects.toBe(revertError);
     });
 });
 

--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -292,6 +292,7 @@ const CreateButton = () => {
         setReceiveAmount,
         bolt12Loading,
         quoteLoading,
+        quoteError,
         setAmountChanged,
     } = useCreateContext();
     const {
@@ -361,6 +362,7 @@ const CreateButton = () => {
                 addressValid,
                 invoiceValid,
                 invoiceError,
+                quoteError,
                 amountChanged,
                 pair,
                 lnurl,
@@ -423,6 +425,16 @@ const CreateButton = () => {
                     !(sendAmount().isZero() && hasInvalidDestinationInput());
 
                 if (shouldShowAmountError()) {
+                    const quoteErrorKey = quoteError();
+                    if (
+                        quoteErrorKey !== undefined &&
+                        (sendAmount().isGreaterThan(0) ||
+                            receiveAmount().isGreaterThan(0))
+                    ) {
+                        setButtonLabel({ key: quoteErrorKey });
+                        return;
+                    }
+
                     if (
                         sendAmount().isGreaterThan(0) &&
                         receiveAmount().isZero()

--- a/src/context/Create.tsx
+++ b/src/context/Create.tsx
@@ -317,6 +317,8 @@ export type CreateContextType = {
     setBolt12Loading: Setter<boolean>;
     quoteLoading: Accessor<boolean>;
     setQuoteLoading: Setter<boolean>;
+    quoteError: Accessor<DictKey | undefined>;
+    setQuoteError: Setter<DictKey | undefined>;
     destinationLocked: Accessor<boolean>;
     setDestinationLocked: Setter<boolean>;
 };
@@ -369,6 +371,9 @@ const CreateProvider = (props: { children: JSX.Element }) => {
     );
     const [bolt12Loading, setBolt12Loading] = createSignal(false);
     const [quoteLoading, setQuoteLoading] = createSignal(false);
+    const [quoteError, setQuoteError] = createSignal<DictKey | undefined>(
+        undefined,
+    );
     const [destinationLocked, setDestinationLocked] = createSignal(false);
 
     const resetDestinationState = () => {
@@ -469,6 +474,7 @@ const CreateProvider = (props: { children: JSX.Element }) => {
         setSendAmountFormatted("");
         setReceiveAmountFormatted("");
         setAmountValid(false);
+        setQuoteError(undefined);
     };
 
     const [amountChanged, setAmountChanged] = createSignal(Side.Send);
@@ -551,6 +557,8 @@ const CreateProvider = (props: { children: JSX.Element }) => {
                 setBolt12Loading,
                 quoteLoading,
                 setQuoteLoading,
+                quoteError,
+                setQuoteError,
                 destinationLocked,
                 setDestinationLocked,
             }}>

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -232,6 +232,7 @@ const dict = {
         bridge_messaging_fee: "Bridge Messaging Fee",
         bridge_transfer_fee: "Bridge Transfer Fee",
         retry: "Retry",
+        error_bridge_capacity: "Amount exceeds bridge capacity",
         error_no_quote:
             "A quote could not be obtained. Please check your connection and try again.",
         error_zero_quote: "Increase send amount",
@@ -792,6 +793,7 @@ const dict = {
         bridge_messaging_fee: "Bridge-Messaging-Gebühr",
         bridge_transfer_fee: "Bridge-Transfer-Gebühr",
         retry: "Erneut versuchen",
+        error_bridge_capacity: "Betrag übersteigt die Bridge-Kapazität",
         error_no_quote:
             "Ein Angebot konnte nicht abgerufen werden. Bitte prüfe deine Verbindung und versuche es erneut.",
         error_zero_quote: "Sendebetrag erhöhen",
@@ -1364,6 +1366,7 @@ const dict = {
         bridge_messaging_fee: "Tarifa de Mensajería del Puente",
         bridge_transfer_fee: "Tarifa de Transferencia del Puente",
         retry: "Reintentar",
+        error_bridge_capacity: "La cantidad excede la capacidad del puente",
         error_no_quote:
             "No se pudo obtener una cotización. Por favor, verifique su conexión e inténtelo de nuevo.",
         error_zero_quote: "Aumenta la cantidad a enviar",
@@ -1929,6 +1932,7 @@ const dict = {
         bridge_messaging_fee: "Taxa de Mensagem da Ponte",
         bridge_transfer_fee: "Taxa de Transferência da Ponte",
         retry: "Tentar novamente",
+        error_bridge_capacity: "O valor excede a capacidade da ponte",
         error_no_quote:
             "Não foi possível obter uma cotação. Por favor, verifique sua conexão e tente novamente.",
         error_zero_quote: "Aumente o valor a enviar",
@@ -2468,6 +2472,7 @@ const dict = {
         bridge_messaging_fee: "桥接消息费用",
         bridge_transfer_fee: "桥接转账费用",
         retry: "重试",
+        error_bridge_capacity: "金额超过桥接容量",
         error_no_quote: "无法获取报价。请检查您的网络连接并重试。",
         error_zero_quote: "提高发送金额",
         oft_eta: "预计约{{ time }}后到达",
@@ -2998,6 +3003,7 @@ const dict = {
         bridge_messaging_fee: "ブリッジメッセージ手数料",
         bridge_transfer_fee: "ブリッジ転送手数料",
         retry: "再試行",
+        error_bridge_capacity: "金額がブリッジ容量を超えています",
         error_no_quote:
             "見積もりを取得できませんでした。接続を確認してもう一度お試しください。",
         error_zero_quote: "送信額を増やす",

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -1,6 +1,7 @@
 import { useSearchParams } from "@solidjs/router";
 import { BigNumber } from "bignumber.js";
 import { getRpcUrls } from "boltz-swaps/config";
+import { isBridgeCapacityError } from "boltz-swaps/errors";
 import { AssetKind, NetworkTransport } from "boltz-swaps/types";
 import log from "loglevel";
 import { IoClose } from "solid-icons/io";
@@ -119,6 +120,8 @@ const Create = () => {
         onchainAddress,
         quoteLoading,
         setQuoteLoading,
+        quoteError,
+        setQuoteError,
         destinationLocked,
     } = useCreateContext();
     const { connectedWallet, signer } = useWeb3Signer();
@@ -299,12 +302,35 @@ const Create = () => {
     };
 
     const loadingGuard = (fn: (isCurrent: () => boolean) => Promise<void>) => {
+        const runQuote = async (isCurrent: () => boolean) => {
+            setQuoteError(undefined);
+            try {
+                await fn(isCurrent);
+            } catch (error) {
+                log.error("Amount quote failed", error);
+                if (!isCurrent()) {
+                    return;
+                }
+                setQuoteError(
+                    isBridgeCapacityError(error)
+                        ? "error_bridge_capacity"
+                        : "error_no_quote",
+                );
+                if (amountChanged() === Side.Receive) {
+                    setSendAmount(BigNumber(0));
+                } else {
+                    setReceiveAmount(BigNumber(0));
+                }
+                validateAmount();
+            }
+        };
+
         if (!pair().needsNetworkForQuote) {
             ++quoteRequestId;
             clearQuoteDebounce();
             setQuoteLoading(false);
             const id = quoteRequestId;
-            void fn(() => id === quoteRequestId);
+            void runQuote(() => id === quoteRequestId);
             return;
         }
 
@@ -316,7 +342,7 @@ const Create = () => {
             quoteDebounceTimeout = undefined;
             void (async () => {
                 try {
-                    await fn(() => requestId === quoteRequestId);
+                    await runQuote(() => requestId === quoteRequestId);
                 } finally {
                     if (requestId === quoteRequestId) {
                         setQuoteLoading(false);
@@ -524,6 +550,16 @@ const Create = () => {
         };
 
         setCustomValidity("", false);
+
+        const quoteErrorKey = quoteError();
+        if (
+            quoteErrorKey !== undefined &&
+            (sendAmount().isGreaterThan(0) || receiveAmount().isGreaterThan(0))
+        ) {
+            setCustomValidity(t(quoteErrorKey), false);
+            setAmountValid(false);
+            return;
+        }
 
         const amount = Number(sendAmount());
         if (pair().canZeroAmount && amount === 0) {

--- a/tests/pages/Create.spec.tsx
+++ b/tests/pages/Create.spec.tsx
@@ -9,6 +9,7 @@ import {
 import { BigNumber } from "bignumber.js";
 import { type BridgeDriver, bridgeRegistry } from "boltz-swaps/bridge";
 import type { Pairs } from "boltz-swaps/client";
+import { BridgeCapacityError } from "boltz-swaps/errors";
 import {
     BridgeKind,
     NetworkTransport,
@@ -837,6 +838,216 @@ describe("Create", () => {
                 expect(button.disabled).toBe(true);
                 expect(button.textContent).toBe(i18n.en.error_zero_quote);
             });
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test.each([
+        {
+            kind: "generic",
+            error: new Error("quote failed"),
+            expectedMessage: i18n.en.error_no_quote,
+        },
+        {
+            kind: "bridge capacity",
+            error: new BridgeCapacityError(50n, 100n),
+            expectedMessage: i18n.en.error_bridge_capacity,
+        },
+    ])(
+        "should block creation with a $kind error when a routed quote rejects",
+        async ({ error, expectedMessage }) => {
+            vi.useFakeTimers();
+
+            try {
+                render(
+                    () => (
+                        <>
+                            <TestComponent />
+                            <Create />
+                        </>
+                    ),
+                    {
+                        wrapper: contextWrapper,
+                    },
+                );
+
+                globalSignals.setOnline(true);
+                globalSignals.setPairs(pairs);
+                setPairAssets("USDT0-SOL", BTC);
+
+                const currentPair = signals.pair();
+                Object.defineProperty(currentPair, "needsNetworkForQuote", {
+                    configurable: true,
+                    get: () => true,
+                });
+                currentPair.calculateReceiveAmount = vi
+                    .fn(() => Promise.reject(error))
+                    .mockName("calculateReceiveAmount");
+
+                signals.setAddressValid(true);
+                signals.setOnchainAddress(
+                    "bcrt1q7vq47xpsg4t080205edaulc3sdsjpdxy9svhr3",
+                );
+
+                fireEvent.input(await screen.findByTestId("sendAmount"), {
+                    target: { value: "100000" },
+                });
+
+                await flushQuoteDebounce();
+
+                await waitFor(() => {
+                    expect(
+                        currentPair.calculateReceiveAmount,
+                    ).toHaveBeenCalled();
+                });
+
+                const button = (await screen.findByTestId(
+                    "create-swap-button",
+                )) as HTMLButtonElement;
+
+                vi.useRealTimers();
+
+                await waitFor(() => {
+                    expect(signals.amountValid()).toBe(false);
+                    expect(button.disabled).toBe(true);
+                    expect(button.textContent).toBe(expectedMessage);
+                });
+
+                fireEvent.input(await screen.findByTestId("sendAmount"), {
+                    target: { value: "" },
+                });
+
+                await waitFor(() => {
+                    expect(button.textContent).not.toBe(expectedMessage);
+                });
+            } finally {
+                vi.useRealTimers();
+            }
+        },
+    );
+
+    test("should reset the send amount when a receive-side quote rejects", async () => {
+        vi.useFakeTimers();
+
+        try {
+            render(
+                () => (
+                    <>
+                        <TestComponent />
+                        <Create />
+                    </>
+                ),
+                {
+                    wrapper: contextWrapper,
+                },
+            );
+
+            globalSignals.setOnline(true);
+            globalSignals.setPairs(pairs);
+            setPairAssets(LN, BTC);
+
+            const currentPair = signals.pair();
+            Object.defineProperty(currentPair, "needsNetworkForQuote", {
+                configurable: true,
+                get: () => true,
+            });
+            currentPair.calculateSendAmount = vi
+                .fn(() => Promise.reject(new Error("bridge capacity exceeded")))
+                .mockName("calculateSendAmount");
+
+            fireEvent.input(await screen.findByTestId("receiveAmount"), {
+                target: { value: "100000" },
+            });
+
+            await flushQuoteDebounce();
+
+            await waitFor(() => {
+                expect(currentPair.calculateSendAmount).toHaveBeenCalled();
+            });
+
+            const button = (await screen.findByTestId(
+                "create-swap-button",
+            )) as HTMLButtonElement;
+
+            vi.useRealTimers();
+
+            await waitFor(() => {
+                expect(signals.sendAmount().toString()).toBe("0");
+                expect(signals.amountValid()).toBe(false);
+                expect(button.textContent).toBe(i18n.en.error_no_quote);
+            });
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("should ignore a stale quote rejection after a newer quote resolves", async () => {
+        vi.useFakeTimers();
+
+        try {
+            render(
+                () => (
+                    <>
+                        <TestComponent />
+                        <Create />
+                    </>
+                ),
+                {
+                    wrapper: contextWrapper,
+                },
+            );
+
+            globalSignals.setOnline(true);
+            globalSignals.setPairs(pairs);
+            setPairAssets(LN, BTC);
+
+            const currentPair = signals.pair();
+            let rejectFirstQuote: ((reason: Error) => void) | undefined;
+            const firstQuote = new Promise<BigNumber>((_, reject) => {
+                rejectFirstQuote = reject;
+            });
+
+            Object.defineProperty(currentPair, "needsNetworkForQuote", {
+                configurable: true,
+                get: () => true,
+            });
+            currentPair.calculateReceiveAmount = vi
+                .fn()
+                .mockImplementationOnce(() => firstQuote)
+                .mockImplementation(() => Promise.resolve(BigNumber(90_000)))
+                .mockName("calculateReceiveAmount");
+
+            fireEvent.input(await screen.findByTestId("sendAmount"), {
+                target: { value: "100000" },
+            });
+
+            await flushQuoteDebounce();
+
+            await waitFor(() => {
+                expect(
+                    currentPair.calculateReceiveAmount,
+                ).toHaveBeenCalledTimes(1);
+            });
+
+            fireEvent.input(await screen.findByTestId("sendAmount"), {
+                target: { value: "200000" },
+            });
+
+            await flushQuoteDebounce();
+
+            await waitFor(() => {
+                expect(
+                    currentPair.calculateReceiveAmount,
+                ).toHaveBeenCalledTimes(2);
+                expect(signals.receiveAmount().toString()).toBe("90000");
+            });
+
+            rejectFirstQuote?.(new Error("bridge capacity exceeded"));
+            await flushQuoteDebounce();
+
+            expect(signals.receiveAmount().toString()).toBe("90000");
+            expect(signals.amountValid()).toBe(true);
         } finally {
             vi.useRealTimers();
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer bridge-capacity errors shown in the Create flow, including available vs. requested amounts.
  * Improved insufficient-credits detection and mapping during quoting.
  * Added a new `error_bridge_capacity` i18n translation key across locales.
* **Bug Fixes**
  * Quote failures now clear/reset invalid amounts, prevent swaps from proceeding, and disable/adjust create actions accordingly.
  * Stale quote rejections no longer overwrite newer, valid quote results.
  * Create button labels and amount validity now reflect quote errors consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->