### PR TITLE
fix: rescue stranded USDT/C-ARB during OFT send

### DIFF
--- a/e2e/arbitrum/gasAbstractionSweepRescue.spec.ts
+++ b/e2e/arbitrum/gasAbstractionSweepRescue.spec.ts
@@ -1,0 +1,175 @@
+import type { Locator, Page } from "@playwright/test";
+import fs from "node:fs";
+import { type Address, createWalletClient, http, parseUnits } from "viem";
+
+import { config } from "../../src/config";
+import dict from "../../src/i18n/i18n";
+import { evmAccountFromPrivateKey } from "../../src/utils/rescueDerivation";
+import {
+    type RescueFile,
+    deriveKeyGasAbstraction,
+    generateRescueFile,
+} from "../../src/utils/rescueFile";
+import { injectWalletProvider } from "../fixtures/ethereum";
+import {
+    actionTimeout,
+    arbitrumE2eChain,
+    arbitrumRpcUrl,
+    arbitrumStablesFundingSource,
+    connectWallet,
+    describeArbitrumE2e,
+    expect,
+    fundErc20FromWhale,
+    getArbitrumWalletAddress,
+    getRegtestTokenAddress,
+    getTokenBalance,
+    startExternalRescue,
+    test,
+    testTimeout,
+} from "./shared";
+
+// Deliberately distinct from the account indices used by the other Arbitrum specs.
+const destinationWalletIndex = 7;
+const strandedAmount = parseUnits("40", 6);
+
+const deriveGasAbstractionAddress = (rescueFile: RescueFile): Address => {
+    const chainId = config.assets?.USDT0?.network?.chainId;
+    if (chainId === undefined) {
+        throw new Error("missing USDT0 chainId");
+    }
+
+    return evmAccountFromPrivateKey(
+        deriveKeyGasAbstraction(rescueFile, chainId).privateKey,
+    ).address;
+};
+
+// Retry the upload + scan until the balance shows up; the scan never refetches on its own.
+const scanForSweepableBalance = async (
+    page: Page,
+    rescueFilePath: string,
+    sweepItem: Locator,
+    // Omitted: the scan runs with only the rescue key
+    walletAddress?: Address,
+) => {
+    await expect(async () => {
+        await startExternalRescue(page);
+        await page.getByTestId("refundUpload").setInputFiles(rescueFilePath);
+        if (walletAddress !== undefined) {
+            await connectWallet(page, walletAddress);
+        }
+        await page
+            .getByRole("button", { name: dict.en.rescue, exact: true })
+            .click();
+        await expect(sweepItem).toBeVisible({ timeout: actionTimeout });
+    }).toPass({
+        timeout: actionTimeout * 2,
+        intervals: [2_000, 5_000, 10_000],
+    });
+};
+
+describeArbitrumE2e("Arbitrum gas abstraction sweep rescue e2e", () => {
+    test("rescues stranded USDT0 found with only the rescue key", async ({
+        arbitrum,
+        page,
+    }, testInfo) => {
+        test.setTimeout(testTimeout);
+
+        const rescueFile = generateRescueFile();
+        const rescueFilePath = testInfo.outputPath("rescue-file.json");
+        fs.writeFileSync(rescueFilePath, JSON.stringify(rescueFile));
+
+        const gasAbstractionAddress = deriveGasAbstractionAddress(rescueFile);
+        const token = getRegtestTokenAddress("USDT0");
+
+        // Strand USDT0 on the gas abstraction address, as if an OFT send had
+        // completed without the subsequent TBTC lockup. No ETH on purpose: the
+        // sweep has to be paid by the gas sponsor.
+        await fundErc20FromWhale({
+            publicClient: arbitrum.publicClient,
+            chain: arbitrumE2eChain,
+            rpcUrl: arbitrum.rpcUrl,
+            token,
+            whale: arbitrumStablesFundingSource,
+            recipient: gasAbstractionAddress,
+            amount: strandedAmount,
+            gasRecipientAmount: 0n,
+        });
+
+        const sweepItem = page.getByTestId(
+            `swaplist-item-sweep:USDT0:${gasAbstractionAddress}`,
+        );
+
+        // The stranded balance must be found without a connected wallet.
+        await scanForSweepableBalance(page, rescueFilePath, sweepItem);
+        await expect(
+            sweepItem.getByRole("link", { name: dict.en.refund, exact: true }),
+        ).toBeVisible();
+        await expect(
+            page.locator(".rescue-external-results .swaplist-item"),
+        ).toHaveCount(1);
+
+        // Executing the sweep needs a destination: connect a wallet and refund.
+        const walletAddress = await getArbitrumWalletAddress(
+            arbitrum.publicClient,
+            destinationWalletIndex,
+        );
+        await injectWalletProvider({
+            page,
+            publicClient: arbitrum.publicClient,
+            walletClient: createWalletClient({
+                account: walletAddress,
+                chain: arbitrumE2eChain,
+                transport: http(arbitrumRpcUrl(), { timeout: actionTimeout }),
+            }),
+            chain: arbitrumE2eChain,
+        });
+
+        const walletBalanceBefore = await getTokenBalance(
+            arbitrum.publicClient,
+            token,
+            walletAddress,
+        );
+
+        await scanForSweepableBalance(
+            page,
+            rescueFilePath,
+            sweepItem,
+            walletAddress,
+        );
+        await sweepItem.click();
+
+        const refundButton = page.getByRole("button", {
+            name: dict.en.refund,
+            exact: true,
+        });
+        await expect(refundButton).toBeVisible({ timeout: actionTimeout });
+        await refundButton.click();
+
+        await expect(page.getByText(dict.en.refunded)).toBeVisible({
+            timeout: actionTimeout,
+        });
+
+        await expect
+            .poll(
+                () =>
+                    getTokenBalance(
+                        arbitrum.publicClient,
+                        token,
+                        walletAddress,
+                    ),
+                {
+                    timeout: actionTimeout,
+                    message:
+                        "sweep sends the stranded USDT0 to the connected wallet",
+                },
+            )
+            .toBe(walletBalanceBefore + strandedAmount);
+        expect(
+            await getTokenBalance(
+                arbitrum.publicClient,
+                token,
+                gasAbstractionAddress,
+            ),
+        ).toBe(0n);
+    });
+});

--- a/e2e/arbitrum/shared.ts
+++ b/e2e/arbitrum/shared.ts
@@ -56,7 +56,7 @@ export const stablesFundingSource = getAddress(
     process.env.STABLES_E2E_USDT0_ETH_FUNDING_SOURCE ??
         "0xF977814e90dA44bFA03b6295A0616a897441aceC",
 );
-const arbitrumStablesFundingSource = getAddress(
+export const arbitrumStablesFundingSource = getAddress(
     process.env.STABLES_E2E_USDT0_FUNDING_SOURCE ??
         "0xF977814e90dA44bFA03b6295A0616a897441aceC",
 );

--- a/e2e/reverseSwap.spec.ts
+++ b/e2e/reverseSwap.spec.ts
@@ -1,14 +1,34 @@
 import { expect, test } from "@playwright/test";
+import BigNumber from "bignumber.js";
+import { SwapType } from "boltz-swaps/types";
 
+import { calculateSendAmount } from "../src/utils/calculate";
+import { btcToSat, satToBtc } from "../src/utils/denomination";
 import {
     expectApproxAmount,
     expectApproxBtcAmount,
     generateBitcoinBlock,
     getBitcoinAddress,
     getBitcoinWalletTx,
+    getReversePairFees,
     payInvoiceLnd,
     payInvoiceLndBackground,
 } from "./utils";
+
+// The miner fee component of the quote depends on the backend's current fee
+// estimate, so the expectation must be derived from the live pair data rather
+// than hardcoded.
+const expectedSendAmount = async (receiveAmount: string): Promise<string> => {
+    const fees = await getReversePairFees("BTC", "BTC");
+    return satToBtc(
+        calculateSendAmount(
+            btcToSat(BigNumber(receiveAmount)),
+            fees.percentage,
+            fees.minerFees,
+            SwapType.Reverse,
+        ),
+    ).toString();
+};
 
 test.describe("reverseSwap", () => {
     test.beforeEach(async () => {
@@ -27,7 +47,7 @@ test.describe("reverseSwap", () => {
         const inputSendAmount = page.locator("input[data-testid='sendAmount']");
         const sendAmount = await expectApproxAmount(
             inputSendAmount,
-            "0.01005080",
+            await expectedSendAmount(receiveAmount),
         );
 
         const inputOnchainAddress = page.locator(
@@ -88,7 +108,7 @@ test.describe("reverseSwap", () => {
         const inputSendAmount = page.locator("input[data-testid='sendAmount']");
         const sendAmount = await expectApproxAmount(
             inputSendAmount,
-            "0.01005080",
+            await expectedSendAmount(receiveAmount),
         );
 
         const inputOnchainAddress = page.locator(

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -447,6 +447,23 @@ export const getSubmarinePairFees = async (
     return fees as { percentage: number; minerFees: number };
 };
 
+export const getReversePairFees = async (
+    from: string,
+    to: string,
+): Promise<{ percentage: number; minerFees: number }> => {
+    const res = await axios.get(`${config.apiUrl!.normal}/v2/swap/reverse`);
+    const fees = res.data?.[from]?.[to]?.fees;
+    if (fees === undefined) {
+        throw new Error(`no reverse pair fees for ${from} -> ${to}`);
+    }
+    return {
+        percentage: fees.percentage as number,
+        minerFees:
+            (fees.minerFees.claim as number) +
+            (fees.minerFees.lockup as number),
+    };
+};
+
 export const fetchBip21Invoice = async (invoice: string) => {
     const requestContext = await request.newContext();
 

--- a/packages/boltz-swaps/src/evm/gasAbstractionSweep.ts
+++ b/packages/boltz-swaps/src/evm/gasAbstractionSweep.ts
@@ -32,11 +32,14 @@ const isRoutedErc20 = (asset: string): boolean => {
     );
 };
 
-export type GasAbstractionSweep = {
+export type GasAbstractionBalance = {
     asset: string;
     amount: bigint;
-    destination: Address;
     signer: Signer;
+};
+
+export type GasAbstractionSweep = GasAbstractionBalance & {
+    destination: Address;
 };
 
 export type GasAbstractionSweepSendTransaction = (
@@ -63,23 +66,21 @@ const defaultCreateToken = (
 export const getGasAbstractionSweepDisplayAmount = ({
     asset,
     amount,
-}: Pick<GasAbstractionSweep, "asset" | "amount">): bigint =>
+}: Pick<GasAbstractionBalance, "asset" | "amount">): bigint =>
     isRoutedErc20(asset) ? amount : assetAmountToSats(amount, asset);
 
 export const getSweepableGasAbstractionBalances = async ({
     assets,
-    destination,
     getSigner,
     createToken = defaultCreateToken,
 }: {
     assets: readonly string[];
-    destination: Address;
     getSigner: (asset: string) => Signer;
     createToken?: (
         asset: string,
         signer: Signer,
     ) => GasAbstractionSweepTokenContract;
-}): Promise<GasAbstractionSweep[]> => {
+}): Promise<GasAbstractionBalance[]> => {
     const balances = await Promise.all(
         assets.map(async (asset) => {
             try {
@@ -94,7 +95,6 @@ export const getSweepableGasAbstractionBalances = async ({
                 return {
                     asset,
                     amount,
-                    destination,
                     signer,
                 };
             } catch (error) {
@@ -108,7 +108,7 @@ export const getSweepableGasAbstractionBalances = async ({
     );
 
     return balances.filter(
-        (balance): balance is GasAbstractionSweep => balance !== undefined,
+        (balance): balance is GasAbstractionBalance => balance !== undefined,
     );
 };
 

--- a/src/pages/external-rescue/Results.tsx
+++ b/src/pages/external-rescue/Results.tsx
@@ -15,7 +15,7 @@ import { hiddenInformation } from "../../components/settings/PrivacyMode";
 import { LN } from "../../consts/Assets";
 import { useGlobalContext } from "../../context/Global";
 import { formatAmount, formatDenomination } from "../../utils/denomination";
-import type { GasAbstractionSweep } from "../../utils/gasAbstractionSweep";
+import type { GasAbstractionBalance } from "../../utils/gasAbstractionSweep";
 import { cropString, isMobile } from "../../utils/helper";
 import { RescueAction } from "../../utils/rescue";
 import {
@@ -104,7 +104,7 @@ const resultActionLabel = (
 };
 
 const getSweepAmount = (
-    sweep: GasAbstractionSweep,
+    sweep: GasAbstractionBalance,
     denomination: ReturnType<typeof useGlobalContext>["denomination"],
     separator: ReturnType<typeof useGlobalContext>["separator"],
 ) =>

--- a/src/pages/external-rescue/types.ts
+++ b/src/pages/external-rescue/types.ts
@@ -3,7 +3,7 @@ import type { SwapContract } from "boltz-swaps/evm";
 import type { LogRefundData, RskRescueMode } from "boltz-swaps/types";
 
 import type { Swap } from "../../components/SwapList";
-import type { GasAbstractionSweep } from "../../utils/gasAbstractionSweep";
+import type { GasAbstractionBalance } from "../../utils/gasAbstractionSweep";
 import type { RescueAction } from "../../utils/rescue";
 import type { BridgeDetail, DexDetail } from "../../utils/swapCreator";
 
@@ -99,5 +99,5 @@ export type UnifiedRescueResult =
           action: RescueAction.Refund;
           actionable: true;
           sortValue: number;
-          swap: GasAbstractionSweep;
+          swap: GasAbstractionBalance;
       };

--- a/src/pages/external-rescue/useExternalRescueSearch.ts
+++ b/src/pages/external-rescue/useExternalRescueSearch.ts
@@ -32,7 +32,7 @@ import { useWeb3Signer } from "../../context/Web3";
 import type { DictKey } from "../../i18n/i18n";
 import { formatError } from "../../utils/errors";
 import {
-    type GasAbstractionSweep,
+    type GasAbstractionBalance,
     getSweepableGasAbstractionBalances,
 } from "../../utils/gasAbstractionSweep";
 import {
@@ -106,7 +106,7 @@ type EvmState = {
     claimProgress?: string;
     unmatchedRefundSwaps: number;
     unmatchedClaimSwaps: number;
-    sweepableBalances: GasAbstractionSweep[];
+    sweepableBalances: GasAbstractionBalance[];
     restoredSwaps: RestoredEvmSwap[];
 };
 
@@ -862,11 +862,8 @@ export const useExternalRescueSearch = () => {
         const scanProgress = createScanProgress(setProgress, setUnmatched);
 
         const sweepBalances =
-            action === RskRescueMode.Refund &&
-            currentRescueFile !== undefined &&
-            signerAddress !== undefined
+            action === RskRescueMode.Refund && currentRescueFile !== undefined
                 ? getSweepableGasAbstractionBalances({
-                      destination: signerAddress,
                       rescueFile: currentRescueFile,
                       getGasAbstractionSigner,
                   }).then((balances) => {

--- a/src/utils/gasAbstractionSweep.ts
+++ b/src/utils/gasAbstractionSweep.ts
@@ -1,16 +1,20 @@
 import {
     type GasAbstractionSweepTokenContract,
+    type GasAbstractionBalance as LibGasAbstractionBalance,
     type GasAbstractionSweep as LibGasAbstractionSweep,
     getSweepableGasAbstractionBalances as libGetSweepableGasAbstractionBalances,
     sweepGasAbstractionToken as libSweepGasAbstractionToken,
 } from "boltz-swaps/evm";
-import type { Address } from "viem";
 
 import { type AssetType, TBTC, USDC, USDT0, WBTC } from "../consts/Assets";
 import type { Signer } from "../context/Web3";
 import { sendPopulatedTransaction } from "./evmTransaction";
 import type { RescueFile } from "./rescueFile";
 import { GasAbstractionType } from "./swapCreator";
+
+export type GasAbstractionBalance = LibGasAbstractionBalance & {
+    asset: AssetType;
+};
 
 export type GasAbstractionSweep = LibGasAbstractionSweep & {
     asset: AssetType;
@@ -20,26 +24,23 @@ export const gasAbstractionSweepAssets = [TBTC, WBTC, USDT0, USDC] as const;
 
 export const getSweepableGasAbstractionBalances = ({
     assets = gasAbstractionSweepAssets,
-    destination,
     rescueFile,
     getGasAbstractionSigner,
     createToken,
 }: {
     assets?: readonly AssetType[];
-    destination: Address;
     rescueFile: RescueFile;
     getGasAbstractionSigner: (asset: string, rescueFile?: RescueFile) => Signer;
     createToken?: (
         asset: string,
         signer: Signer,
     ) => GasAbstractionSweepTokenContract;
-}): Promise<GasAbstractionSweep[]> =>
+}): Promise<GasAbstractionBalance[]> =>
     libGetSweepableGasAbstractionBalances({
         assets,
-        destination,
         getSigner: (asset) => getGasAbstractionSigner(asset, rescueFile),
         createToken,
-    }) as Promise<GasAbstractionSweep[]>;
+    }) as Promise<GasAbstractionBalance[]>;
 
 export const sweepGasAbstractionToken = (
     sweep: GasAbstractionSweep,

--- a/tests/pages/RescueExternalEvmScan.spec.tsx
+++ b/tests/pages/RescueExternalEvmScan.spec.tsx
@@ -12,7 +12,7 @@ import {
 import type { JSX } from "solid-js";
 import { vi } from "vitest";
 
-import { TBTC, WBTC } from "../../src/consts/Assets";
+import { TBTC, USDT0, WBTC } from "../../src/consts/Assets";
 import i18n from "../../src/i18n/i18n";
 import Rescue from "../../src/pages/Rescue";
 import type * as RescueUtils from "../../src/utils/rescue";
@@ -85,6 +85,8 @@ vi.mock("boltz-swaps/evm", () => ({
         asset === "TBTC" ? amount / 10n ** 10n : amount,
     createAssetProvider: vi.fn(() => ({})),
     createProvider: vi.fn(() => ({ getTransaction: mockGetTransaction })),
+    getGasAbstractionSweepDisplayAmount: ({ amount }: { amount: bigint }) =>
+        amount,
     getLogsFromReceipt: mockGetLogsFromReceipt,
     getTimelockBlockNumber: vi.fn(() => Promise.resolve(0)),
     isEmptyPreimageHash: (preimageHash: string | undefined) =>
@@ -367,6 +369,54 @@ describe("Rescue EVM scan", () => {
             mockScanLockupEvents.mock.calls as unknown[][]
         ).map((call) => (call[2] as { asset: string }).asset);
         expect(scannedAssets).not.toContain("RBTC");
+    });
+
+    test("finds stranded USDT balances with only the rescue key", async () => {
+        const user = userEvent.setup();
+        const mnemonic =
+            "awake father sword slab matrix myth cargo lock river thumb inspire speed";
+        const gasAbstractionAddress =
+            "0x0000000000000000000000000000000000000002";
+        vi.stubEnv("VITE_ARBITRUM_LOG_SCAN_ENDPOINT", "http://localhost:8547");
+        mockSigner.current = undefined;
+        mockGetSweepableGasAbstractionBalances.mockResolvedValue([
+            {
+                asset: USDT0,
+                amount: 1_000_000n,
+                signer: { address: gasAbstractionAddress },
+            } as never,
+        ]);
+
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Rescue />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        const uploadInput = await screen.findByTestId("refundUpload");
+        const rescueFile = new File(["{}"], "rescue.json", {
+            type: "application/json",
+        });
+        (rescueFile as File & { text: () => Promise<string> }).text = () =>
+            Promise.resolve(JSON.stringify({ mnemonic }));
+
+        await user.upload(uploadInput, rescueFile);
+        await user.click(screen.getByRole("button", { name: i18n.en.rescue }));
+
+        expect(
+            await screen.findByTestId(
+                `swaplist-item-sweep:${USDT0}:${gasAbstractionAddress}`,
+            ),
+        ).toHaveTextContent(i18n.en.refund);
+        expect(mockGetSweepableGasAbstractionBalances).toHaveBeenCalledWith(
+            expect.objectContaining({
+                rescueFile: expect.objectContaining({ mnemonic }),
+            }),
+        );
     });
 
     test("rejects restored refunds whose refund address is not a rescue key", async () => {

--- a/tests/utils/gasAbstractionSweep.spec.ts
+++ b/tests/utils/gasAbstractionSweep.spec.ts
@@ -79,7 +79,6 @@ describe("gas abstraction sweep", () => {
 
         const balances = await getSweepableGasAbstractionBalances({
             assets: [USDT0, USDC],
-            destination: "0xdestination",
             rescueFile: { mnemonic: "test test test" },
             getGasAbstractionSigner,
             createToken,
@@ -89,7 +88,6 @@ describe("gas abstraction sweep", () => {
             {
                 asset: USDT0,
                 amount: 123n,
-                destination: "0xdestination",
                 signer: signerByAsset.get(USDT0),
             },
         ]);


### PR DESCRIPTION
Fixes a regression introduced on https://github.com/BoltzExchange/boltz-web-app/commit/68b988a0b63052a00e8110cea2d37f3d9f0b8d61: when the OFT send is complete but the TBTC lockup didn't happen yet, executing Rescue via the current `main` domain doesn't find any USDT-ARB, but boltz.exchange (previous release) does find the bridged USDT-ARB via External Rescue.

This PR fixes this so the funds aren't left stranded. Now this USDT-ARB shows up on Rescue again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - External rescue scans can now detect stranded token balances using only the rescue key (no connected wallet required).
  - Users can review and refund detected gas-abstraction balances to a connected destination wallet.
  - Added coverage for stranded USDT0 balances found without native gas funds.

- **Bug Fixes**
  - Improved sweepable balance detection to surface only non-zero balances.
  - Refunding flows now correctly format and handle sweepable balance results.

- **Tests**
  - Expanded unit, integration, and Playwright E2E coverage for external rescue scanning and gas-abstraction sweep rescue (including stranded USDT0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->