### PR TITLE
feat: use swap metadata to refund submarine swaps to original source

### DIFF
--- a/boltz.conf.patch
+++ b/boltz.conf.patch
@@ -70,34 +70,3 @@ index 63c2646..0c2bb9d 100755
  
  [[currencies]]
  symbol = "BTC"
-diff --git a/regtest/images/boltz-backend/arbitrum.conf b/regtest/images/boltz-backend/arbitrum.conf
-index 82a8593..96f705d 100644
---- a/regtest/images/boltz-backend/arbitrum.conf
-+++ b/regtest/images/boltz-backend/arbitrum.conf
-@@ -29,6 +29,26 @@ swapTypes = ["chain"]
-   swapMaximal = 2880
-   swapTaproot = 10080
- 
-+# Reverse swaps (LN -> TBTC) power the reverse DEX swap e2e coverage.
-+[[pairs]]
-+base = "TBTC"
-+quote = "BTC"
-+rate = 1
-+fee = 0
-+swapInFee = 0
-+
-+maxSwapAmount = 1_000_000
-+minSwapAmount = 2_500
-+
-+swapTypes = ["reverse"]
-+
-+  [pairs.timeoutDelta]
-+  chain = 1440
-+  reverse = 1440
-+  swapMinimal = 1440
-+  swapMaximal = 2880
-+  swapTaproot = 10080
-+
- [arbitrum]
- networkName = "Arbitrum"
- providerEndpoint = "ws://anvil-arb:8545"

--- a/e2e/arbitrum/evmSubmarineRescue.spec.ts
+++ b/e2e/arbitrum/evmSubmarineRescue.spec.ts
@@ -1,0 +1,151 @@
+import type { Page } from "@playwright/test";
+import { readFileSync } from "fs";
+import { type Address, createWalletClient, http } from "viem";
+
+import { config } from "../../src/config";
+import dict from "../../src/i18n/i18n";
+import { evmAccountFromPrivateKey } from "../../src/utils/rescueDerivation";
+import {
+    type RescueFile,
+    deriveKeyGasAbstraction,
+} from "../../src/utils/rescueFile";
+import { injectWalletProvider } from "../fixtures/ethereum";
+import {
+    generateBitcoinBlock,
+    generateInvoiceLnd,
+    getCurrentSwapId,
+    waitForNodesToSync,
+} from "../utils";
+import {
+    type PublicClient,
+    actionTimeout,
+    approveAndSend,
+    clearBrowserStorage,
+    connectWallet,
+    createEthereumClient,
+    deliverOft,
+    describeArbitrumE2e,
+    ethereumE2eChain,
+    ethereumRpcUrl,
+    expect,
+    fullFlowTestTimeout,
+    fundEthereumStablesE2eWallet,
+    getStablesE2eWalletAddress,
+    mineArbitrumBlocks,
+    saveRescueFile,
+    scanAndSelectExternalResult,
+    selectAssets,
+    test,
+    waitForBridgeTxHash,
+    waitForEthereumRpc,
+    waitForLockupTxHash,
+} from "./shared";
+
+const createSwap = async (
+    page: Page,
+    rescueFilePath: string,
+    walletAddress: Address,
+) => {
+    await page.goto("/swap");
+    await selectAssets(page, "USDT0-ETH", "LN");
+    await page.getByTestId("receiveAmount").fill("0.0002");
+    await page.getByTestId("invoice").fill(await generateInvoiceLnd(20_000));
+    await connectWallet(page, walletAddress);
+
+    const button = page.getByTestId("create-swap-button");
+    await expect(button).toBeEnabled({ timeout: actionTimeout });
+    await button.click();
+    await saveRescueFile(page, rescueFilePath);
+    await expect(page.locator("div[data-status='invoice.set']")).toBeVisible({
+        timeout: actionTimeout,
+    });
+    return getCurrentSwapId(page);
+};
+
+const getRescueAddress = (rescueFilePath: string): Address => {
+    const rescueFile = JSON.parse(
+        readFileSync(rescueFilePath, "utf8"),
+    ) as RescueFile;
+    const chainId = config.assets?.USDT0?.network?.chainId;
+    if (chainId === undefined) {
+        throw new Error("missing USDT0 chain id");
+    }
+    return evmAccountFromPrivateKey(
+        deriveKeyGasAbstraction(rescueFile, chainId).privateKey,
+    ).address;
+};
+
+const waitForBackendLockup = async (
+    publicClient: PublicClient,
+    swapId: string,
+) => {
+    await expect
+        .poll(
+            async () => {
+                await mineArbitrumBlocks(publicClient, 1);
+                const response = await fetch(
+                    `${config.apiUrl.normal}/v2/swap/${swapId}`,
+                    { signal: AbortSignal.timeout(10_000) },
+                );
+                if (!response.ok) {
+                    return "";
+                }
+
+                const swap = (await response.json()) as { status?: unknown };
+                return typeof swap.status === "string" ? swap.status : "";
+            },
+            {
+                timeout: actionTimeout * 2,
+                intervals: [2_000, 3_000, 5_000],
+                message: "Boltz confirms the submarine swap lockup",
+            },
+        )
+        .toBe("transaction.claimed");
+};
+
+describeArbitrumE2e("Submarine pair external rescue e2e", () => {
+    test("shows the original submarine pair", async ({
+        arbitrum,
+        page,
+    }, testInfo) => {
+        test.setTimeout(fullFlowTestTimeout + actionTimeout * 2);
+        await generateBitcoinBlock();
+        await waitForNodesToSync();
+
+        const ethereum = createEthereumClient();
+        await waitForEthereumRpc(ethereum);
+        const walletAddress = await getStablesE2eWalletAddress(ethereum);
+        await fundEthereumStablesE2eWallet(ethereum, walletAddress);
+        await injectWalletProvider({
+            page,
+            publicClient: ethereum,
+            walletClient: createWalletClient({
+                account: walletAddress,
+                chain: ethereumE2eChain,
+                transport: http(ethereumRpcUrl(), { timeout: actionTimeout }),
+            }),
+            chain: ethereumE2eChain,
+        });
+        const rescueFilePath = testInfo.outputPath("rescue-file.json");
+        const swapId = await createSwap(page, rescueFilePath, walletAddress);
+        await approveAndSend(page, walletAddress);
+        const bridgeTxHash = await waitForBridgeTxHash(page, swapId);
+        await deliverOft(
+            ethereum,
+            arbitrum.publicClient,
+            bridgeTxHash,
+            getRescueAddress(rescueFilePath),
+            arbitrum.rpcUrl,
+        );
+        await waitForLockupTxHash(page, swapId);
+        await waitForBackendLockup(arbitrum.publicClient, swapId);
+        await clearBrowserStorage(page);
+        await scanAndSelectExternalResult({
+            page,
+            swapId,
+            rescueFilePath,
+            action: dict.en.refund,
+            assets: ["USDT", "LN"],
+        });
+    });
+});

--- a/e2e/arbitrum/shared.ts
+++ b/e2e/arbitrum/shared.ts
@@ -8,13 +8,17 @@ import {
     createPublicClient,
     createWalletClient,
     defineChain,
+    encodePacked,
     getAddress,
     http,
     isAddressEqual,
+    padHex,
     parseAbi,
     parseEther,
     parseEventLogs,
     parseUnits,
+    slice,
+    zeroAddress,
 } from "viem";
 
 import { config } from "../../src/config";
@@ -691,6 +695,119 @@ export const expectOftSendTx = async (
     expect(isAddressEqual(sent.args.fromAddress, walletAddress)).toBe(true);
     expect(sent.args.amountSentLD).toBeGreaterThan(0n);
     expect(sent.args.amountReceivedLD).toBeGreaterThan(0n);
+};
+
+const oAppAbi = parseAbi([
+    "function endpoint() view returns (address)",
+    "function peers(uint32 eid) view returns (bytes32)",
+    "function lzReceive((uint32 srcEid,bytes32 sender,uint64 nonce) origin,bytes32 guid,bytes message,address executor,bytes extraData) payable",
+]);
+const endpointAbi = parseAbi(["function eid() view returns (uint32)"]);
+
+export const deliverOft = async (
+    sourceClient: PublicClient,
+    destinationClient: PublicClient,
+    sourceTxHash: Hex,
+    recipient: Address,
+    destinationRpcUrl: string,
+) => {
+    const receipt = await sourceClient.waitForTransactionReceipt({
+        hash: sourceTxHash,
+        timeout: actionTimeout,
+    });
+    const [sent] = parseEventLogs({
+        abi: oftAbi,
+        eventName: "OFTSent",
+        logs: receipt.logs,
+    });
+    if (sent === undefined) {
+        throw new Error("missing OFTSent event");
+    }
+
+    const sourceContract = getAddress(sent.address);
+    const sourceEndpoint = await sourceClient.readContract({
+        address: sourceContract,
+        abi: oAppAbi,
+        functionName: "endpoint",
+    });
+    const [sourceEid, destinationPeer] = await Promise.all([
+        sourceClient.readContract({
+            address: sourceEndpoint,
+            abi: endpointAbi,
+            functionName: "eid",
+        }),
+        sourceClient.readContract({
+            address: sourceContract,
+            abi: oAppAbi,
+            functionName: "peers",
+            args: [sent.args.dstEid],
+        }),
+    ]);
+    const destinationContract = getAddress(slice(destinationPeer, 12));
+    const destinationEndpoint = await destinationClient.readContract({
+        address: destinationContract,
+        abi: oAppAbi,
+        functionName: "endpoint",
+    });
+
+    await destinationClient.request({
+        method: "anvil_setBalance" as never,
+        params: [
+            destinationEndpoint,
+            `0x${parseEther("10").toString(16)}`,
+        ] as never,
+    });
+    await destinationClient.request({
+        method: "anvil_impersonateAccount" as never,
+        params: [destinationEndpoint] as never,
+    });
+
+    try {
+        const endpointWallet = createWalletClient({
+            account: destinationEndpoint,
+            chain: arbitrumE2eChain,
+            transport: http(destinationRpcUrl, { timeout: actionTimeout }),
+        });
+        const hash = await endpointWallet.writeContract({
+            address: destinationContract,
+            abi: oAppAbi,
+            functionName: "lzReceive",
+            args: [
+                {
+                    srcEid: sourceEid,
+                    sender: padHex(sourceContract, { size: 32 }),
+                    nonce: 1n,
+                },
+                sent.args.guid,
+                encodePacked(
+                    ["bytes32", "uint64"],
+                    [
+                        padHex(recipient, { size: 32 }),
+                        sent.args.amountReceivedLD,
+                    ],
+                ),
+                zeroAddress,
+                "0x",
+            ],
+        });
+        const destinationReceipt =
+            await destinationClient.waitForTransactionReceipt({
+                hash,
+                timeout: actionTimeout,
+            });
+        const [received] = parseEventLogs({
+            abi: oftAbi,
+            eventName: "OFTReceived",
+            logs: destinationReceipt.logs,
+        });
+        expect(received).toBeDefined();
+        expect(isAddressEqual(received.args.toAddress, recipient)).toBe(true);
+    } finally {
+        await destinationClient.request({
+            method: "anvil_stopImpersonatingAccount" as never,
+            params: [destinationEndpoint] as never,
+        });
+    }
 };
 
 export const getArbitrumWalletAddress = async (

--- a/packages/boltz-swaps/src/client.ts
+++ b/packages/boltz-swaps/src/client.ts
@@ -316,6 +316,7 @@ export const createSubmarineSwap = (
     pairHash: string,
     refundPublicKey?: string,
     metadata?: string,
+    refundAddress?: string,
 ): Promise<SubmarineCreatedResponse> =>
     fetcher("/v2/swap/submarine", {
         from,
@@ -325,6 +326,7 @@ export const createSubmarineSwap = (
         pairHash,
         referralId: getReferralId(),
         metadata,
+        refundAddress,
     });
 
 export const createReverseSwap = (

--- a/packages/boltz-swaps/tests/client.spec.ts
+++ b/packages/boltz-swaps/tests/client.spec.ts
@@ -244,4 +244,23 @@ describe("boltzClient swap metadata", () => {
             { method: "PATCH" },
         );
     });
+
+    test("includes the submarine refund address when provided", async () => {
+        await createSubmarineSwap(
+            "TBTC",
+            "BTC",
+            "lninvoice",
+            "pair-hash",
+            undefined,
+            undefined,
+            "0x8382Ab573C5E48270Abb1b0A76564F76eEbc24c5",
+        );
+
+        expect(fetcherMock).toHaveBeenCalledWith(
+            "/v2/swap/submarine",
+            expect.objectContaining({
+                refundAddress: "0x8382Ab573C5E48270Abb1b0A76564F76eEbc24c5",
+            }),
+        );
+    });
 });

--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -642,6 +642,12 @@ const CreateButton = () => {
                         }
                         const metadata =
                             await buildCreationMetadata(creationData);
+                        const refundAddress =
+                            bridge?.position === SwapPosition.Pre
+                                ? getGasAbstractionSigner(
+                                      bridge.destinationAsset,
+                                  ).address
+                                : undefined;
                         data = await createSubmarine(
                             creationData.from,
                             creationData.to,
@@ -653,6 +659,7 @@ const CreateButton = () => {
                             newKey,
                             originalDestination(),
                             metadata,
+                            refundAddress,
                         );
                     };
 

--- a/src/components/RefundButton.tsx
+++ b/src/components/RefundButton.tsx
@@ -332,6 +332,10 @@ const buildRefundFollowUpCalls = async (
 ) => {
     let resolvedDestination = destination;
     const isPreBridge = bridge?.position === SwapPosition.Pre;
+    // Without the bridge transaction (legacy restores), the original sender
+    // cannot be resolved; deliver to the destination locally instead of
+    // bridging back
+    const bridgeBack = isPreBridge && bridge?.txHash !== undefined;
 
     if (isPreBridge) {
         if (
@@ -343,8 +347,9 @@ const buildRefundFollowUpCalls = async (
             );
         }
 
-        resolvedDestination =
-            bridge.refundAddress ?? (await resolveBridgeSender(bridge));
+        if (bridgeBack) {
+            resolvedDestination = await resolveBridgeSender(bridge);
+        }
     }
 
     if (dexDetails === undefined || dexDetails.position !== SwapPosition.Pre) {
@@ -365,7 +370,7 @@ const buildRefundFollowUpCalls = async (
         throw new Error("missing token address for refund");
     }
 
-    if (!isPreBridge) {
+    if (!bridgeBack) {
         const [quote] = await quoteDexAmountIn(
             quoteChain,
             refundData.tokenAddress,
@@ -409,7 +414,7 @@ const buildRefundFollowUpCalls = async (
     });
 };
 
-const buildErc20RefundTransaction = async ({
+export const buildErc20RefundTransaction = async ({
     gasAbstraction,
     transactionSigner,
     contract,

--- a/src/configs/regtest.ts
+++ b/src/configs/regtest.ts
@@ -5,6 +5,9 @@ import { type Config, baseConfig, chooseUrl } from "src/configs/base";
 const mainnetPreset = buildMainnetConfig({
     filterAssets: (asset) =>
         asset === "TBTC" || asset === "USDT0" || asset === "USDT0-ETH",
+    canSend: {
+        "USDT0-ETH": true,
+    },
     rpcUrls: {
         ARB: [`http://127.0.0.1:${process.env.ARBITRUM_E2E_PORT ?? "18545"}`],
         ETH: [`http://127.0.0.1:${process.env.ETHEREUM_E2E_PORT ?? "18546"}`],

--- a/src/pages/RescueEvm.tsx
+++ b/src/pages/RescueEvm.tsx
@@ -197,10 +197,15 @@ const RefundState = (props: {
         return undefined;
     };
 
-    // Pre-bridge refunds resolve their destination from the bridge instead
+    // Pre-bridge refunds resolve their destination from the bridge instead;
+    // legacy restores may lack the bridge transaction needed to do so
     const needsResolvedDestination = () =>
         dexDetails()?.position === SwapPosition.Pre &&
         bridgeDetails()?.position !== SwapPosition.Pre;
+    const routeResolvesDestination = () =>
+        dexDetails()?.position === SwapPosition.Pre &&
+        bridgeDetails()?.position === SwapPosition.Pre &&
+        bridgeDetails()?.txHash !== undefined;
 
     const [resolvedFunder] = createResource(
         () => {
@@ -244,8 +249,23 @@ const RefundState = (props: {
         }
     };
 
+    // Only routed and commitment lockups pay out to the gas key; plain
+    // lockups refund straight to the user's wallet
+    const refundsToGasKey = () => {
+        const gasSigner = gasAbstraction()?.signer;
+        return (
+            gasSigner !== undefined &&
+            normalizeEvmId(props.refundData.refundAddress) ===
+                normalizeEvmId(gasSigner.address)
+        );
+    };
+
+    // Without a destination, a gas-abstracted refund would strand the funds
+    // on the gas-abstraction address instead of the user's wallet
     const destinationMissing = () =>
-        needsResolvedDestination() && destination() === undefined;
+        refundsToGasKey() &&
+        !routeResolvesDestination() &&
+        destination() === undefined;
 
     return (
         <>

--- a/src/pages/RescueEvm.tsx
+++ b/src/pages/RescueEvm.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useParams } from "@solidjs/router";
 import BigNumber from "bignumber.js";
+import { bridgeRegistry } from "boltz-swaps/bridge";
 import { quoteDexAmountIn } from "boltz-swaps/client";
 import {
     assetAmountToSats,
@@ -59,7 +60,10 @@ import { cropString } from "../utils/helper";
 import { estimateFeesPerGas } from "../utils/provider";
 import { fetchDexQuote } from "../utils/quoter";
 import { getTimeoutEta } from "../utils/rescue";
-import { GasAbstractionType } from "../utils/swapCreator";
+import {
+    GasAbstractionType,
+    getRefundBridgeDetail,
+} from "../utils/swapCreator";
 import { getEvmDisplayAssets } from "./external-rescue/Results";
 import { normalizeEvmId } from "./external-rescue/scan";
 import type { EvmRescueResult } from "./external-rescue/types";
@@ -83,6 +87,12 @@ const getEvmRefundDexDetails = (refundData: EvmRescueResult) =>
 
 const getEvmRefundBridgeDetails = (refundData: EvmRescueResult) =>
     refundData.bridge ?? refundData.restoredSwap?.bridge;
+
+const getEvmRefundBridge = (refundData: EvmRescueResult) =>
+    getRefundBridgeDetail({
+        dex: getEvmRefundDexDetails(refundData),
+        bridge: getEvmRefundBridgeDetails(refundData),
+    });
 
 export const getEvmRefundDisplayAmount = (
     refundData: EvmRescueResult,
@@ -203,9 +213,7 @@ const RefundState = (props: {
         dexDetails()?.position === SwapPosition.Pre &&
         bridgeDetails()?.position !== SwapPosition.Pre;
     const routeResolvesDestination = () =>
-        dexDetails()?.position === SwapPosition.Pre &&
-        bridgeDetails()?.position === SwapPosition.Pre &&
-        bridgeDetails()?.txHash !== undefined;
+        getEvmRefundBridge(props.refundData) !== undefined;
 
     const [resolvedFunder] = createResource(
         () => {
@@ -695,6 +703,11 @@ const RescueEvm = () => {
                                             asset={params.asset}
                                             kind={BlockExplorerTargetKind.Tx}
                                             id={refundTxId()!}
+                                            explorer={bridgeRegistry.getExplorerKind(
+                                                getEvmRefundBridge(
+                                                    rescueData()!,
+                                                ),
+                                            )}
                                         />
                                     </>
                                 }>

--- a/src/pages/external-rescue/Results.tsx
+++ b/src/pages/external-rescue/Results.tsx
@@ -45,6 +45,7 @@ export const getEvmDisplayAssets = (swap: EvmRescueResult) => {
         swap.action !== RskRescueMode.Refund ||
         bridge !== undefined;
     const base = {
+        type: swap.restoredSwap?.type ?? SwapType.Chain,
         bridge,
         dex: shouldUseDex ? dex : undefined,
         assetSend:

--- a/src/status/SwapRefunded.tsx
+++ b/src/status/SwapRefunded.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from "@solidjs/router";
 import { bridgeRegistry } from "boltz-swaps/bridge";
-import { SwapPosition } from "boltz-swaps/types";
 import { Show } from "solid-js";
 
 import BlockExplorer, {
@@ -10,19 +9,17 @@ import { getAssetNetwork } from "../consts/Assets";
 import { useGlobalContext } from "../context/Global";
 import { usePayContext } from "../context/Pay";
 import { formatDenomination } from "../utils/denomination";
+import { getRefundBridgeDetail } from "../utils/swapCreator";
 
 const SwapRefunded = (props: { refundTxId: string }) => {
     const navigate = useNavigate();
     const { swap } = usePayContext();
     const { t, denomination } = useGlobalContext();
-    const preBridge = () =>
-        swap()?.bridge?.position === SwapPosition.Pre
-            ? swap()!.bridge
-            : undefined;
+    const refundBridge = () => getRefundBridgeDetail(swap() ?? {});
 
     return (
         <div>
-            <Show when={preBridge()} fallback={<p>{t("refunded")}</p>}>
+            <Show when={refundBridge()} fallback={<p>{t("refunded")}</p>}>
                 {(bridge) => (
                     <p>
                         {t("refunded_bridge_pending", {
@@ -38,13 +35,19 @@ const SwapRefunded = (props: { refundTxId: string }) => {
                 )}
             </Show>
             <hr />
-            <BlockExplorer
-                asset={preBridge()?.sourceAsset ?? swap()!.assetSend}
-                kind={BlockExplorerTargetKind.Tx}
-                id={props.refundTxId}
-                explorer={bridgeRegistry.getExplorerKind(preBridge())}
-                typeLabel="refund_tx"
-            />
+            <Show when={swap()}>
+                {(currentSwap) => (
+                    <BlockExplorer
+                        asset={currentSwap().assetSend}
+                        kind={BlockExplorerTargetKind.Tx}
+                        id={props.refundTxId}
+                        explorer={bridgeRegistry.getExplorerKind(
+                            refundBridge(),
+                        )}
+                        typeLabel="refund_tx"
+                    />
+                )}
+            </Show>
             <hr />
             <span class="btn" onClick={() => navigate("/swap")}>
                 {t("new_swap")}

--- a/src/utils/swapCreator.ts
+++ b/src/utils/swapCreator.ts
@@ -286,6 +286,15 @@ export const getPostBridgeDetail = (
 ): BridgeDetail | undefined =>
     bridge?.position === SwapPosition.Post ? bridge : undefined;
 
+export const getRefundBridgeDetail = (route: {
+    dex?: DexDetail;
+    bridge?: BridgeDetail;
+}): BridgeDetail | undefined =>
+    route.dex?.position === SwapPosition.Pre &&
+    route.bridge?.txHash !== undefined
+        ? getPreBridgeDetail(route.bridge)
+        : undefined;
+
 const generatePreimage = ({
     asset,
     keyIndex,

--- a/src/utils/swapCreator.ts
+++ b/src/utils/swapCreator.ts
@@ -70,7 +70,6 @@ export type BridgeDetail = BridgeRoute & {
     details?: BridgeDetails;
     pendingSend?: PendingBridgeSend;
     evmSendCandidate?: PendingEvmBridgeSend;
-    refundAddress?: string;
 
     // Recovery state when a pre-bridge DEX quote falls short and the bridged
     // funds must be retried or refunded back to the original sender.
@@ -343,6 +342,7 @@ export const createSubmarine = async (
     newKey: newKeyFn,
     originalDestination?: string,
     metadata?: string,
+    refundAddress?: string,
 ): Promise<SubmarineSwap> => {
     const key = await newKey(assetSend as AssetType);
     const res = await createSubmarineSwap(
@@ -354,6 +354,7 @@ export const createSubmarine = async (
             ? Buffer.from(key.key.publicKey).toString("hex")
             : undefined,
         metadata,
+        refundAddress,
     );
 
     return {

--- a/src/utils/swapMetadata.ts
+++ b/src/utils/swapMetadata.ts
@@ -16,7 +16,12 @@ import {
 
 type SwapMetadataBridge = Pick<
     BridgeDetail,
-    "sourceAsset" | "destinationAsset" | "kind" | "position" | "refundAddress"
+    | "sourceAsset"
+    | "destinationAsset"
+    | "kind"
+    | "position"
+    // Lets restored pre-bridge refunds resolve the original sender
+    | "txHash"
 >;
 type SwapMetadataDex = Pick<DexDetail, "hops" | "position" | "quoteAmount">;
 type SwapMetadataTxIdentity = Pick<
@@ -179,7 +184,7 @@ const parseSwapMetadataPlaintext = parseObject<SwapMetadataPlaintext>({
             destinationAsset: parseString,
             kind: parseEnum(BridgeKind),
             position: parseEnum(SwapPosition),
-            refundAddress: parseOptional(parseString),
+            txHash: parseOptional(parseString),
         }),
     ),
     lockupTx: parseOptional(parseString),
@@ -327,7 +332,7 @@ export const buildSwapMetadataPayload = (
             destinationAsset: fields.bridge.destinationAsset,
             kind: fields.bridge.kind,
             position: fields.bridge.position,
-            refundAddress: fields.bridge.refundAddress,
+            txHash: fields.bridge.txHash,
         };
     }
 

--- a/tests/components/RefundEvmTransaction.spec.ts
+++ b/tests/components/RefundEvmTransaction.spec.ts
@@ -1,0 +1,388 @@
+import type * as BridgeModule from "boltz-swaps/bridge";
+import type * as ClientModule from "boltz-swaps/client";
+import type { AlchemyCall } from "boltz-swaps/evm";
+import type * as ContractsModule from "boltz-swaps/evm/contracts";
+import type { Erc20SwapContract } from "boltz-swaps/evm/contracts";
+import { erc20SwapAbi } from "boltz-swaps/generated/evm-abis";
+import {
+    BridgeKind,
+    type LockupEvent,
+    SwapPosition,
+    SwapType,
+} from "boltz-swaps/types";
+import {
+    type Hex,
+    type TransactionRequest,
+    decodeFunctionData,
+    erc20Abi,
+    getAddress,
+    parseSignature,
+} from "viem";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { buildErc20RefundTransaction } from "../../src/components/RefundButton";
+import type { Signer } from "../../src/context/Web3";
+import {
+    type BridgeDetail,
+    type DexDetail,
+    GasAbstractionType,
+} from "../../src/utils/swapCreator";
+
+const {
+    quoteDexAmountIn,
+    quoteDexAmountOut,
+    encodeDexQuote,
+    requireDriverForRoute,
+    createRouterContract,
+} = vi.hoisted(() => ({
+    quoteDexAmountIn: vi.fn(),
+    quoteDexAmountOut: vi.fn(),
+    encodeDexQuote: vi.fn(),
+    requireDriverForRoute: vi.fn(),
+    createRouterContract: vi.fn(),
+}));
+
+vi.mock("boltz-swaps/client", async () => {
+    const actual =
+        await vi.importActual<typeof ClientModule>("boltz-swaps/client");
+    return {
+        ...actual,
+        quoteDexAmountIn,
+        quoteDexAmountOut,
+        encodeDexQuote,
+    };
+});
+
+vi.mock("boltz-swaps/bridge", async () => {
+    const actual =
+        await vi.importActual<typeof BridgeModule>("boltz-swaps/bridge");
+    return {
+        ...actual,
+        bridgeRegistry: { requireDriverForRoute },
+    };
+});
+
+vi.mock("boltz-swaps/evm/contracts", async () => {
+    const actual = await vi.importActual<typeof ContractsModule>(
+        "boltz-swaps/evm/contracts",
+    );
+    return {
+        ...actual,
+        createRouterContract,
+    };
+});
+
+const contractAddress = getAddress(
+    "0x1000000000000000000000000000000000000001",
+);
+const tokenAddress = getAddress("0x2000000000000000000000000000000000000002");
+const claimAddress = getAddress("0x3000000000000000000000000000000000000003");
+const gasAbstractionAddress = getAddress(
+    "0x4000000000000000000000000000000000000004",
+);
+const userWallet = getAddress("0x5000000000000000000000000000000000000005");
+const originalSender = getAddress("0x6000000000000000000000000000000000000006");
+const routerAddress = getAddress("0x7000000000000000000000000000000000000007");
+const dexTokenIn = getAddress("0x8000000000000000000000000000000000000008");
+
+const refundData: LockupEvent = {
+    preimageHash: `0x${"00".repeat(32)}` as const,
+    amount: 700_000_000_000_000n,
+    tokenAddress,
+    claimAddress,
+    refundAddress: gasAbstractionAddress,
+    timelock: 123n,
+    logIndex: 0,
+};
+
+const signature = parseSignature(
+    `0x${"11".repeat(32)}${"22".repeat(32)}1b` as const,
+);
+
+const transactionSigner = {} as Signer;
+const contract = { address: contractAddress } as Erc20SwapContract;
+
+const preDexDetails: DexDetail = {
+    position: SwapPosition.Pre,
+    quoteAmount: "40",
+    hops: [
+        {
+            type: SwapType.Chain,
+            from: "USDT0",
+            to: "TBTC",
+            dexDetails: {
+                chain: "ARB",
+                tokenIn: dexTokenIn,
+                tokenOut: tokenAddress,
+            },
+        },
+    ],
+};
+
+const preBridgeDetails: BridgeDetail = {
+    kind: BridgeKind.Oft,
+    position: SwapPosition.Pre,
+    sourceAsset: "USDT0-ETH",
+    destinationAsset: "USDT0",
+    txHash: `0x${"aa".repeat(32)}`,
+};
+
+type BuildOverrides = Partial<
+    Parameters<typeof buildErc20RefundTransaction>[0]
+>;
+
+const build = (overrides: BuildOverrides = {}) =>
+    buildErc20RefundTransaction({
+        gasAbstraction: GasAbstractionType.Signer,
+        transactionSigner,
+        contract,
+        refundData,
+        signature,
+        slippage: 0.5,
+        cooperative: true,
+        commitmentRefund: true,
+        ...overrides,
+    });
+
+// The two shapes the builder can return: a single transaction when there is
+// nothing to batch, or the calls of a gas-abstracted batch
+const buildTransaction = async (overrides: BuildOverrides = {}) => {
+    const result = await build(overrides);
+    expect(Array.isArray(result)).toBe(false);
+    return result as TransactionRequest;
+};
+
+const buildCalls = async (overrides: BuildOverrides = {}) => {
+    const result = await build(overrides);
+    expect(Array.isArray(result)).toBe(true);
+    return result as AlchemyCall[];
+};
+
+const decodeSwapCall = (call: { data?: Hex }) =>
+    decodeFunctionData({ abi: erc20SwapAbi, data: call.data! });
+
+const createBridgeDriver = () => ({
+    getTransactionSender: vi.fn().mockResolvedValue(originalSender),
+    getContract: vi.fn().mockResolvedValue({}),
+    getQuotedContract: vi.fn().mockResolvedValue({}),
+    quoteSend: vi.fn().mockResolvedValue({
+        msgFee: [0n, 0n],
+        sendParam: {},
+        minAmount: 38_000_000n,
+    }),
+    buildApprovalCall: vi.fn().mockResolvedValue({
+        to: tokenAddress,
+        value: "0",
+        data: "0xapproval",
+    }),
+    encodeRouterExecuteData: vi.fn().mockReturnValue("0xexec"),
+});
+
+describe("buildErc20RefundTransaction", () => {
+    let driver: ReturnType<typeof createBridgeDriver>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        quoteDexAmountIn.mockResolvedValue([
+            { quote: "39000000", data: "0xdeadbeef" },
+        ]);
+        encodeDexQuote.mockResolvedValue({
+            calls: [
+                {
+                    to: routerAddress,
+                    value: "0",
+                    data: "0x1234",
+                },
+            ],
+        });
+
+        createRouterContract.mockReturnValue({ address: routerAddress });
+        driver = createBridgeDriver();
+        requireDriverForRoute.mockReturnValue(driver);
+    });
+
+    test("throws when the token address is missing", async () => {
+        await expect(
+            build({
+                refundData: { ...refundData, tokenAddress: undefined },
+            }),
+        ).rejects.toThrow("missing token address for ERC20 refund");
+    });
+
+    test("throws when a cooperative refund has no signature", async () => {
+        await expect(build({ signature: undefined })).rejects.toThrow(
+            "missing cooperative refund signature",
+        );
+    });
+
+    test("returns a single transaction when gas abstraction is not signer-based", async () => {
+        const result = await buildTransaction({
+            gasAbstraction: GasAbstractionType.None,
+            destination: userWallet,
+        });
+
+        expect(result.to).toEqual(contractAddress);
+        expect(decodeSwapCall(result).functionName).toEqual(
+            "refundCooperative",
+        );
+    });
+
+    test("encodes commitment refunds without an explicit refund address", async () => {
+        const commitment = await buildTransaction({
+            gasAbstraction: GasAbstractionType.None,
+        });
+        const regular = await buildTransaction({
+            gasAbstraction: GasAbstractionType.None,
+            commitmentRefund: false,
+        });
+
+        // The commitment overload omits the refund address; msg.sender is
+        // the refund address
+        expect(decodeSwapCall(commitment).args).not.toContain(
+            gasAbstractionAddress,
+        );
+        expect(decodeSwapCall(regular).args).toContain(gasAbstractionAddress);
+    });
+
+    test("encodes a timeout refund without a signature", async () => {
+        const result = await buildTransaction({
+            gasAbstraction: GasAbstractionType.None,
+            cooperative: false,
+            signature: undefined,
+        });
+
+        expect(decodeSwapCall(result).functionName).toEqual("refund");
+    });
+
+    test("appends a transfer to the destination for plain refunds", async () => {
+        const calls = await buildCalls({ destination: userWallet });
+
+        expect(calls).toHaveLength(2);
+        expect(calls[0].to).toEqual(contractAddress);
+        expect(calls[1].to).toEqual(tokenAddress);
+
+        const transfer = decodeFunctionData({
+            abi: erc20Abi,
+            data: calls[1].data!,
+        });
+        expect(transfer.functionName).toEqual("transfer");
+        expect(transfer.args).toEqual([userWallet, refundData.amount]);
+    });
+
+    test("skips the transfer when the destination is the refund address", async () => {
+        const calls = await buildCalls({
+            destination: gasAbstractionAddress.toLowerCase(),
+        });
+
+        expect(calls).toHaveLength(1);
+    });
+
+    test("falls through to a bare refund when no destination is known", async () => {
+        // Documents the strand fallback: with no route and no destination the
+        // refund releases funds to the on-chain refund address only. Callers
+        // must gate on a known destination before sending this.
+        const result = await buildTransaction({ destination: undefined });
+
+        expect(result.to).toEqual(contractAddress);
+    });
+
+    test("routes a pre-DEX refund to the destination through the DEX", async () => {
+        const calls = await buildCalls({
+            dexDetails: preDexDetails,
+            destination: userWallet,
+        });
+
+        expect(calls).toHaveLength(2);
+        expect(calls[0].to).toEqual(contractAddress);
+        expect(calls[1].to).toEqual(routerAddress);
+
+        expect(quoteDexAmountIn).toHaveBeenCalledWith(
+            "ARB",
+            tokenAddress,
+            dexTokenIn,
+            refundData.amount,
+        );
+        expect(encodeDexQuote).toHaveBeenCalledWith(
+            "ARB",
+            userWallet,
+            refundData.amount,
+            expect.any(BigInt),
+            "0xdeadbeef",
+        );
+    });
+
+    test("throws for a routed refund without a destination", async () => {
+        await expect(
+            build({ dexDetails: preDexDetails, destination: undefined }),
+        ).rejects.toThrow("missing refund destination for routed refund");
+    });
+
+    test("throws for a pre-bridge refund without reverse DEX details", async () => {
+        await expect(
+            build({ bridge: preBridgeDetails, dexDetails: undefined }),
+        ).rejects.toThrow("missing reverse DEX details for pre-bridge refund");
+    });
+
+    test("bridges a pre-bridge refund back to the resolved original sender", async () => {
+        const calls = await buildCalls({
+            dexDetails: preDexDetails,
+            bridge: preBridgeDetails,
+        });
+
+        // refund + funding transfer to the router + router execute
+        expect(calls).toHaveLength(3);
+        expect(calls[0].to).toEqual(contractAddress);
+        expect(calls[1].to).toEqual(tokenAddress);
+        expect(calls[2].to).toEqual(routerAddress);
+        expect(calls[2].data).toEqual("0xexec");
+
+        expect(driver.getTransactionSender).toHaveBeenCalledWith(
+            preBridgeDetails.sourceAsset,
+            preBridgeDetails.txHash,
+        );
+        expect(driver.quoteSend).toHaveBeenCalledWith(
+            expect.anything(),
+            {
+                sourceAsset: preBridgeDetails.destinationAsset,
+                destinationAsset: preBridgeDetails.sourceAsset,
+            },
+            originalSender,
+            expect.any(BigInt),
+        );
+    });
+
+    test("delivers locally when the bridge transaction is unknown", async () => {
+        // Legacy restores may lack the bridge tx needed to resolve the
+        // original sender; the refund swaps to the destination instead of
+        // bridging back
+        const calls = await buildCalls({
+            dexDetails: preDexDetails,
+            bridge: { ...preBridgeDetails, txHash: undefined },
+            destination: userWallet,
+        });
+
+        expect(calls).toHaveLength(2);
+        expect(calls[0].to).toEqual(contractAddress);
+        expect(calls[1].to).toEqual(routerAddress);
+
+        expect(driver.getTransactionSender).not.toHaveBeenCalled();
+        expect(encodeDexQuote).toHaveBeenCalledWith(
+            "ARB",
+            userWallet,
+            refundData.amount,
+            expect.any(BigInt),
+            "0xdeadbeef",
+        );
+    });
+
+    test("throws without a bridge transaction or a destination", async () => {
+        await expect(
+            build({
+                dexDetails: preDexDetails,
+                bridge: { ...preBridgeDetails, txHash: undefined },
+                destination: undefined,
+            }),
+        ).rejects.toThrow("missing refund destination for routed refund");
+    });
+});

--- a/tests/pages/RescueEvm.spec.tsx
+++ b/tests/pages/RescueEvm.spec.tsx
@@ -297,7 +297,7 @@ describe("RescueEvm", () => {
         expect(screen.getByRole("button", { name: "Claim" })).toBeDisabled();
     });
 
-    test("enables a plain restored refund without a connected wallet", async () => {
+    test("refunds a plain restored lockup without a connected wallet", async () => {
         paramsMock.current.action = RskRescueMode.Refund;
         rescueSwaps.current = [
             {
@@ -315,6 +315,8 @@ describe("RescueEvm", () => {
 
         render(() => <RescueEvm />, { wrapper: contextWrapper });
 
+        // The lockup pays out to its own refund address, the user's wallet,
+        // so no destination is needed
         expect(
             await screen.findByRole("button", { name: "Refund" }),
         ).not.toBeDisabled();
@@ -325,11 +327,51 @@ describe("RescueEvm", () => {
         expect(mockGetLogsFromReceipt).toHaveBeenCalled();
     });
 
-    test("resolves the original funder for a pre-DEX refund without a wallet", async () => {
+    test("disables a commitment refund until a destination is known", async () => {
         paramsMock.current.action = RskRescueMode.Refund;
+        mockGetLogsFromReceipt.mockResolvedValue({
+            ...logData,
+            refundAddress: gasSigner.address,
+        });
         rescueSwaps.current = [
             {
                 ...logData,
+                refundAddress: gasSigner.address,
+                action: RskRescueMode.Refund,
+                currentHeight: 1_000n,
+                restoredSwap: {
+                    ...restoredSwap,
+                    type: SwapType.Chain,
+                    from: TBTC,
+                    to: "L-BTC",
+                },
+            },
+        ];
+
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        // The lockup pays out to the gas key and there is no route info to
+        // resolve the original sender from, so the refund must not run: it
+        // would strand funds on the gas-abstraction address
+        expect(
+            await screen.findByRole("button", { name: "Refund" }),
+        ).toBeDisabled();
+        expect(
+            screen.getByRole("button", { name: "Connect wallet" }),
+        ).toBeInTheDocument();
+        expect(mockResolveLockupTokenFunder).not.toHaveBeenCalled();
+    });
+
+    test("resolves the original funder for a pre-DEX refund without a wallet", async () => {
+        paramsMock.current.action = RskRescueMode.Refund;
+        mockGetLogsFromReceipt.mockResolvedValue({
+            ...logData,
+            refundAddress: gasSigner.address,
+        });
+        rescueSwaps.current = [
+            {
+                ...logData,
+                refundAddress: gasSigner.address,
                 action: RskRescueMode.Refund,
                 currentHeight: 1_000n,
                 restoredSwap: {
@@ -358,9 +400,54 @@ describe("RescueEvm", () => {
 
     test("does not resolve a funder for pre-bridge refunds", async () => {
         paramsMock.current.action = RskRescueMode.Refund;
+        mockGetLogsFromReceipt.mockResolvedValue({
+            ...logData,
+            refundAddress: gasSigner.address,
+        });
         rescueSwaps.current = [
             {
                 ...logData,
+                refundAddress: gasSigner.address,
+                action: RskRescueMode.Refund,
+                currentHeight: 1_000n,
+                restoredSwap: {
+                    ...restoredSwap,
+                    type: SwapType.Chain,
+                    from: TBTC,
+                    to: "L-BTC",
+                    dex: preDex,
+                    bridge: {
+                        kind: BridgeKind.Oft,
+                        position: SwapPosition.Pre,
+                        sourceAsset: "USDT0-ETH",
+                        destinationAsset: "USDT0",
+                        txHash: transactionHash,
+                    },
+                },
+            },
+        ];
+
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        expect(
+            await screen.findByRole("button", { name: "Refund" }),
+        ).not.toBeDisabled();
+        expect(
+            screen.queryByRole("button", { name: "Connect wallet" }),
+        ).toBeNull();
+        expect(mockResolveLockupTokenFunder).not.toHaveBeenCalled();
+    });
+
+    test("asks for a wallet when a pre-bridge restore lacks the bridge transaction", async () => {
+        paramsMock.current.action = RskRescueMode.Refund;
+        mockGetLogsFromReceipt.mockResolvedValue({
+            ...logData,
+            refundAddress: gasSigner.address,
+        });
+        rescueSwaps.current = [
+            {
+                ...logData,
+                refundAddress: gasSigner.address,
                 action: RskRescueMode.Refund,
                 currentHeight: 1_000n,
                 restoredSwap: {
@@ -381,21 +468,26 @@ describe("RescueEvm", () => {
 
         render(() => <RescueEvm />, { wrapper: contextWrapper });
 
+        // The original sender cannot be resolved without the bridge tx, so
+        // an explicit destination is required
         expect(
-            await screen.findByRole("button", { name: "Refund" }),
-        ).not.toBeDisabled();
-        expect(
-            screen.queryByRole("button", { name: "Connect wallet" }),
-        ).toBeNull();
+            await screen.findByRole("button", { name: "Connect wallet" }),
+        ).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Refund" })).toBeDisabled();
         expect(mockResolveLockupTokenFunder).not.toHaveBeenCalled();
     });
 
     test("asks for a wallet when the pre-DEX refund destination cannot be resolved", async () => {
         paramsMock.current.action = RskRescueMode.Refund;
         mockResolveLockupTokenFunder.mockResolvedValue(undefined);
+        mockGetLogsFromReceipt.mockResolvedValue({
+            ...logData,
+            refundAddress: gasSigner.address,
+        });
         rescueSwaps.current = [
             {
                 ...logData,
+                refundAddress: gasSigner.address,
                 action: RskRescueMode.Refund,
                 currentHeight: 1_000n,
                 restoredSwap: {

--- a/tests/pages/RescueEvm.spec.tsx
+++ b/tests/pages/RescueEvm.spec.tsx
@@ -10,7 +10,7 @@ import {
 import type { JSX } from "solid-js";
 import { vi } from "vitest";
 
-import { config } from "../../src/config";
+import { chooseUrl, config } from "../../src/config";
 import { TBTC } from "../../src/consts/Assets";
 import type * as RescueContextModule from "../../src/context/Rescue";
 import type * as Web3Module from "../../src/context/Web3";
@@ -26,6 +26,8 @@ const preimageHash =
     "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 const preimage =
     "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+const refundTransactionHash =
+    "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
 
 const {
     mockGetLogsFromReceipt,
@@ -157,8 +159,14 @@ vi.mock("../../src/components/ConnectWallet", () => ({
 }));
 
 vi.mock("../../src/components/RefundButton", () => ({
-    RefundEvm: (props: { disabled?: boolean }) => (
-        <button type="button" disabled={props.disabled}>
+    RefundEvm: (props: {
+        disabled?: boolean;
+        setRefundTxId: (id: string) => void;
+    }) => (
+        <button
+            type="button"
+            disabled={props.disabled}
+            onClick={() => props.setRefundTxId(refundTransactionHash)}>
             Refund
         </button>
     ),
@@ -436,6 +444,71 @@ describe("RescueEvm", () => {
             screen.queryByRole("button", { name: "Connect wallet" }),
         ).toBeNull();
         expect(mockResolveLockupTokenFunder).not.toHaveBeenCalled();
+    });
+
+    test("links a bridged back refund to the bridge explorer", async () => {
+        paramsMock.current.action = RskRescueMode.Refund;
+        mockGetLogsFromReceipt.mockResolvedValue({
+            ...logData,
+            refundAddress: gasSigner.address,
+        });
+        rescueSwaps.current = [
+            {
+                ...logData,
+                refundAddress: gasSigner.address,
+                action: RskRescueMode.Refund,
+                currentHeight: 1_000n,
+                restoredSwap: {
+                    ...restoredSwap,
+                    type: SwapType.Chain,
+                    from: TBTC,
+                    to: "L-BTC",
+                    dex: preDex,
+                    bridge: {
+                        kind: BridgeKind.Oft,
+                        position: SwapPosition.Pre,
+                        sourceAsset: "USDT0-ETH",
+                        destinationAsset: "USDT0",
+                        txHash: transactionHash,
+                    },
+                },
+            },
+        ];
+
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        fireEvent.click(await screen.findByRole("button", { name: "Refund" }));
+
+        expect(await screen.findByRole("link")).toHaveAttribute(
+            "href",
+            `${config.layerZeroExplorerUrl}/tx/${refundTransactionHash}`,
+        );
+    });
+
+    test("links a refund that stays on chain to the asset explorer", async () => {
+        paramsMock.current.action = RskRescueMode.Refund;
+        rescueSwaps.current = [
+            {
+                ...logData,
+                action: RskRescueMode.Refund,
+                currentHeight: 1_000n,
+                restoredSwap: {
+                    ...restoredSwap,
+                    type: SwapType.Chain,
+                    from: TBTC,
+                    to: "L-BTC",
+                },
+            },
+        ];
+
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        fireEvent.click(await screen.findByRole("button", { name: "Refund" }));
+
+        expect(await screen.findByRole("link")).toHaveAttribute(
+            "href",
+            `${chooseUrl(config.assets![TBTC]!.blockExplorerUrl)}/tx/${refundTransactionHash}`,
+        );
     });
 
     test("asks for a wallet when a pre-bridge restore lacks the bridge transaction", async () => {

--- a/tests/pages/externalRescueScan.spec.ts
+++ b/tests/pages/externalRescueScan.spec.ts
@@ -579,6 +579,22 @@ describe("external EVM rescue scan helpers", () => {
         ).toEqual(["L-BTC", "USDT0-SOL"]);
     });
 
+    test("shows the user-facing pair for restored submarine swaps", () => {
+        expect(
+            getEvmDisplayAssets({
+                ...baseEvent,
+                restoredSwap: {
+                    ...restoredSwap,
+                    type: SwapType.Submarine,
+                    from: "USDT0-POL",
+                    to: "BTC",
+                    bridge: undefined,
+                    dex: undefined,
+                },
+            }),
+        ).toEqual(["USDT0-POL", "LN"]);
+    });
+
     test("maps restored post-dex claims from restore transaction metadata only", () => {
         const transactionHash =
             "0x1111111111111111111111111111111111111111111111111111111111111111";

--- a/tests/status/SwapRefunded.spec.tsx
+++ b/tests/status/SwapRefunded.spec.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@solidjs/testing-library";
+import { BridgeKind, SwapPosition, SwapType } from "boltz-swaps/types";
+
+import { chooseUrl, config } from "../../src/config";
+import { config as mainnetConfig } from "../../src/configs/mainnet";
+import { USDC, USDT0 } from "../../src/consts/Assets";
+import SwapRefunded from "../../src/status/SwapRefunded";
+import type { SomeSwap } from "../../src/utils/swapCreator";
+import { TestComponent, contextWrapper, payContext } from "../helper";
+
+const refundTxId = "0xrefund";
+
+const oftBridge = {
+    kind: BridgeKind.Oft,
+    sourceAsset: "USDT0-POL",
+    destinationAsset: USDT0,
+};
+
+const cctpBridge = {
+    kind: BridgeKind.Cctp,
+    sourceAsset: "USDC-POL",
+    destinationAsset: USDC,
+};
+
+const swap = (assetSend: string, bridge?: object) =>
+    ({
+        type: SwapType.Submarine,
+        assetSend,
+        assetReceive: "BTC",
+        refundTx: refundTxId,
+        dex: { hops: [], position: SwapPosition.Pre, quoteAmount: 0 },
+        bridge,
+    }) as unknown as SomeSwap;
+
+const preBridgedSwap = (bridge: typeof oftBridge, txHash?: string) =>
+    swap(bridge.destinationAsset, {
+        ...bridge,
+        position: SwapPosition.Pre,
+        txHash,
+    });
+
+const assetExplorerLink = (asset: string) =>
+    `${chooseUrl(config.assets![asset]!.blockExplorerUrl)}/tx/${refundTxId}`;
+
+const expectLink = async (href: string) => {
+    expect(await screen.findByRole("link")).toHaveAttribute("href", href);
+};
+
+const renderRefunded = (refunded: SomeSwap) => {
+    render(
+        () => (
+            <>
+                <TestComponent />
+                <SwapRefunded refundTxId={refundTxId} />
+            </>
+        ),
+        { wrapper: contextWrapper },
+    );
+    payContext.setSwap(refunded);
+};
+
+describe("SwapRefunded", () => {
+    beforeEach(() => {
+        for (const { sourceAsset } of [oftBridge, cctpBridge]) {
+            config.assets![sourceAsset] ??= structuredClone(
+                mainnetConfig.assets![sourceAsset],
+            );
+        }
+    });
+
+    test("links a bridged back refund to the LayerZero explorer", async () => {
+        renderRefunded(preBridgedSwap(oftBridge, "0xbridge"));
+
+        await expectLink(`${config.layerZeroExplorerUrl}/tx/${refundTxId}`);
+    });
+
+    test("links a bridged back refund to the CCTP explorer", async () => {
+        renderRefunded(preBridgedSwap(cctpBridge, "0xbridge"));
+
+        await expectLink(
+            `${config.cctpExplorerUrl}/messages?transactionHash=${refundTxId}`,
+        );
+    });
+
+    test("links to the lockup chain explorer without a bridge back", async () => {
+        renderRefunded(preBridgedSwap(oftBridge));
+
+        await expectLink(assetExplorerLink(USDT0));
+    });
+
+    test("links to the lockup chain explorer without a bridge", async () => {
+        renderRefunded(swap(USDT0));
+
+        await expectLink(assetExplorerLink(USDT0));
+    });
+});

--- a/tests/utils/swapCreator.spec.ts
+++ b/tests/utils/swapCreator.spec.ts
@@ -3,6 +3,7 @@ import { BridgeKind, SwapPosition, SwapType } from "boltz-swaps/types";
 import { BTC, LBTC, LN, USDT0 } from "../../src/consts/Assets";
 import {
     type BridgeDetail,
+    type DexDetail,
     type SwapAssetRoute,
     type SwapBase,
     createLocalSwapId,
@@ -10,6 +11,7 @@ import {
     getFinalAssetSend,
     getPostBridgeDetail,
     getPreBridgeDetail,
+    getRefundBridgeDetail,
     noGasAbstraction,
 } from "../../src/utils/swapCreator";
 
@@ -72,6 +74,66 @@ describe("getPostBridgeDetail", () => {
 
     test("returns undefined when no bridge is provided", () => {
         expect(getPostBridgeDetail(undefined)).toBeUndefined();
+    });
+});
+
+describe("getRefundBridgeDetail", () => {
+    const makeDex = (position: SwapPosition): DexDetail => ({
+        hops: [],
+        position,
+        quoteAmount: 0,
+    });
+
+    const preDex = makeDex(SwapPosition.Pre);
+    const preBridgeWithTx = {
+        ...makeBridge("USDT0-POL", USDT0, SwapPosition.Pre),
+        txHash: "0xdead",
+    };
+
+    test("returns the pre-bridge when the forward bridge transaction is known", () => {
+        expect(
+            getRefundBridgeDetail({
+                dex: preDex,
+                bridge: preBridgeWithTx,
+            }),
+        ).toBe(preBridgeWithTx);
+    });
+
+    test("returns undefined without the forward bridge transaction", () => {
+        expect(
+            getRefundBridgeDetail({
+                dex: preDex,
+                bridge: makeBridge("USDT0-POL", USDT0, SwapPosition.Pre),
+            }),
+        ).toBeUndefined();
+    });
+
+    test("returns undefined without a pre-swap DEX route", () => {
+        expect(
+            getRefundBridgeDetail({ bridge: preBridgeWithTx }),
+        ).toBeUndefined();
+        expect(
+            getRefundBridgeDetail({
+                dex: makeDex(SwapPosition.Post),
+                bridge: preBridgeWithTx,
+            }),
+        ).toBeUndefined();
+    });
+
+    test("returns undefined for post-bridges", () => {
+        expect(
+            getRefundBridgeDetail({
+                dex: preDex,
+                bridge: {
+                    ...makeBridge(USDT0, "USDT0-POL", SwapPosition.Post),
+                    txHash: "0xdead",
+                },
+            }),
+        ).toBeUndefined();
+    });
+
+    test("returns undefined when no bridge is attached", () => {
+        expect(getRefundBridgeDetail({ dex: preDex })).toBeUndefined();
     });
 });
 

--- a/tests/utils/swapMetadata.spec.ts
+++ b/tests/utils/swapMetadata.spec.ts
@@ -95,6 +95,23 @@ describe("swapMetadata crypto", () => {
         expect(decrypted).toEqual(samplePayload);
     });
 
+    test("round-trips the bridge transaction hash", async () => {
+        const payload: SwapMetadataPayload = {
+            ...samplePayload,
+            bridge: {
+                ...samplePayload.bridge!,
+                txHash: "0xbridgetx",
+            },
+        };
+
+        const metadata = await encryptSwapMetadata(mnemonic, {
+            ...payload,
+            swapId,
+        });
+        const decrypted = await decryptSwapMetadata(mnemonic, swapId, metadata);
+        expect(decrypted.bridge?.txHash).toEqual("0xbridgetx");
+    });
+
     test("decrypts the golden vector (wire format is frozen)", async () => {
         await expect(
             decryptSwapMetadata(mnemonic, swapId, goldenVector),


### PR DESCRIPTION
Requires
- [x] https://github.com/BoltzExchange/regtest/pull/113
- [x] https://github.com/BoltzExchange/boltz-backend/pull/1468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional refund-address support for submarine swap creation, including automatic computation in certain pre-swap flows.
  * Improved rescue/refund metadata handling by switching bridge metadata from refund address to bridge tx hash.
  * Updated regtest configuration to enable USDT0-ETH sending and refreshed swap timing/coverage presets.
* **Bug Fixes**
  * Fixed external rescue final-asset display by ensuring swap type is applied during restored-result rendering.
  * Refined refund UI gating and destination resolution logic for gas-abstracted and pre-bridge/bridge-back scenarios.
* **Tests**
  * Added/updated unit, UI, and e2e coverage for refund-address payloads, restored swap metadata, refund transaction building, and external rescue scanning/refund flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->