### PR TITLE
fix: patch swap metadata for commitment  swaps

### DIFF
--- a/e2e/arbitrum/commitment.spec.ts
+++ b/e2e/arbitrum/commitment.spec.ts
@@ -143,11 +143,43 @@ describeArbitrumE2e("Arbitrum commitment swap e2e", () => {
         await expect(invoiceSubmitButton).toBeEnabled({
             timeout: actionTimeout,
         });
+        const backendSwapId = page
+            .waitForResponse(
+                (response) => {
+                    const pathname = new URL(response.url()).pathname;
+                    return (
+                        response.request().method() === "POST" &&
+                        pathname === "/v2/swap/submarine"
+                    );
+                },
+                { timeout: actionTimeout },
+            )
+            .then(async (response) => {
+                const body = (await response.json()) as { id: string };
+                return body.id;
+            });
+        const metadataPatch = page.waitForResponse(
+            async (response) => {
+                const pathname = new URL(response.url()).pathname;
+                return (
+                    response.request().method() === "PATCH" &&
+                    pathname === `/v2/swap/${await backendSwapId}/metadata`
+                );
+            },
+            { timeout: actionTimeout },
+        );
         await invoiceSubmitButton.click();
 
+        const swapId = await backendSwapId;
+        expect(swapId).not.toBe(commitmentId);
         await expect
             .poll(() => getCurrentSwapId(page), { timeout: actionTimeout })
-            .not.toBe(commitmentId);
+            .toBe(swapId);
+        const metadataResponse = await metadataPatch;
+        expect(new URL(metadataResponse.url()).pathname).toEqual(
+            `/v2/swap/${swapId}/metadata`,
+        );
+        expect(metadataResponse.ok()).toBe(true);
         const downloadButton = page.getByRole("button", {
             name: dict.en.download_new_key,
         });

--- a/src/context/Web3.tsx
+++ b/src/context/Web3.tsx
@@ -151,6 +151,7 @@ const Web3SignerContext = createContext<{
 
     switchNetwork: (asset: string) => Promise<void>;
 
+    contractsLoading: Accessor<boolean>;
     getContractsForAsset: (asset: string) => Contracts | undefined;
     getEtherSwap: (asset: string) => EtherSwapContract;
     getErc20Swap: (asset: string) => Erc20SwapContract;
@@ -774,6 +775,7 @@ const Web3SignerProvider = (props: {
                 walletConnected,
                 setWalletConnected,
                 connectProviderForAddress,
+                contractsLoading: () => allContracts.loading,
                 getContractsForAsset,
                 getGasAbstractionSigner,
                 clearSigner: () => {

--- a/src/status/CommitmentCreated.tsx
+++ b/src/status/CommitmentCreated.tsx
@@ -53,6 +53,7 @@ import {
     createSubmarine,
     getPreBridgeDetail,
 } from "../utils/swapCreator";
+import { patchEncryptedSwapMetadata } from "../utils/swapMetadata";
 import { validateInvoice, validateResponse } from "../utils/validation";
 
 export type CommitmentAmounts = {
@@ -285,12 +286,18 @@ const CommitmentCreated = () => {
         notify,
         pairs,
         regularPairs,
+        rescueFile,
         separator,
         setSwapStorage,
         t,
     } = useGlobalContext();
     const { swap } = usePayContext();
-    const { getEtherSwap, getErc20Swap } = useWeb3Signer();
+    const {
+        contractsLoading,
+        getContractsForAsset,
+        getEtherSwap,
+        getErc20Swap,
+    } = useWeb3Signer();
     const commitment = createMemo(() => swap() as CommitmentSwap);
     const [invoice, setInvoice] = createSignal(
         untrack(() => commitment().originalDestination ?? ""),
@@ -340,13 +347,34 @@ const CommitmentCreated = () => {
         });
     });
 
+    const erc20SwapAddress = createMemo(
+        () =>
+            getContractsForAsset(commitment().assetSend)?.swapContracts
+                .ERC20Swap,
+    );
+    const missingErc20SwapError = createMemo(() => {
+        const current = commitment();
+        if (
+            current.commitmentLockupTxHash === undefined ||
+            pairs() === undefined ||
+            contractsLoading() ||
+            erc20SwapAddress() !== undefined
+        ) {
+            return undefined;
+        }
+        return `missing ERC20Swap contract for ${current.assetSend}`;
+    });
+
     const committedAmountsSource = createMemo(
         () => {
             const current = commitment();
             const currentPairs = pairs();
+            const currentErc20SwapAddress = erc20SwapAddress();
             if (
                 current.commitmentLockupTxHash === undefined ||
-                currentPairs === undefined
+                currentPairs === undefined ||
+                contractsLoading() ||
+                currentErc20SwapAddress === undefined
             ) {
                 return undefined;
             }
@@ -354,6 +382,7 @@ const CommitmentCreated = () => {
             return {
                 assetSend: current.assetSend,
                 commitmentLockupTxHash: current.commitmentLockupTxHash,
+                erc20SwapAddress: currentErc20SwapAddress,
                 initialReceiveAsset: current.initialReceiveAsset,
                 pairs: currentPairs,
                 regularPairs: regularPairs(),
@@ -365,6 +394,7 @@ const CommitmentCreated = () => {
                 previous?.assetSend === next?.assetSend &&
                 previous?.commitmentLockupTxHash ===
                     next?.commitmentLockupTxHash &&
+                previous?.erc20SwapAddress === next?.erc20SwapAddress &&
                 previous?.initialReceiveAsset === next?.initialReceiveAsset &&
                 previous?.pairs === next?.pairs &&
                 previous?.regularPairs === next?.regularPairs,
@@ -408,6 +438,7 @@ const CommitmentCreated = () => {
 
     const committedAmountsError = () =>
         loadError() ??
+        missingErc20SwapError() ??
         (committedAmounts.error === undefined
             ? undefined
             : formatError(committedAmounts.error));
@@ -514,7 +545,7 @@ const CommitmentCreated = () => {
                 getErc20Swap,
             );
 
-            await setSwapStorage({
+            const completedSwap = {
                 ...submarine,
                 getGasToken: current.getGasToken,
                 commitmentLockupTxHash: current.commitmentLockupTxHash,
@@ -522,7 +553,9 @@ const CommitmentCreated = () => {
                 signer: current.signer,
                 dex: current.dex,
                 bridge: current.bridge,
-            });
+            };
+            await setSwapStorage(completedSwap);
+            await patchEncryptedSwapMetadata(completedSwap, rescueFile());
             await deleteSwap(current.id);
             navigate(`/swap/${submarine.id}`);
         } catch (error) {

--- a/src/utils/swapMetadata.ts
+++ b/src/utils/swapMetadata.ts
@@ -6,11 +6,12 @@ import log from "loglevel";
 import type { EncodedHop } from "./Pair";
 import { formatError } from "./errors";
 import type { RescueFile } from "./rescueFile";
-import type {
-    BridgeDetail,
-    DexDetail,
-    SomeSwap,
-    SwapBase,
+import {
+    type BridgeDetail,
+    type DexDetail,
+    type SomeSwap,
+    type SwapBase,
+    isCommitmentSwap,
 } from "./swapCreator";
 
 type SwapMetadataBridge = Pick<
@@ -360,6 +361,10 @@ export const patchEncryptedSwapMetadata = async (
     swap: SomeSwap,
     rescueFile: RescueFile | null | undefined,
 ) => {
+    if (isCommitmentSwap(swap)) {
+        return;
+    }
+
     const payload = buildSwapMetadataPayloadFromSwap(swap);
     if (
         payload === undefined ||

--- a/tests/helper.tsx
+++ b/tests/helper.tsx
@@ -43,31 +43,35 @@ export const TestComponent = () => {
     return "";
 };
 
-export const contextWrapper = (props: { children: JSX.Element }) => {
-    const App = () => (
-        <GlobalProvider>
-            <FiatProvider>
-                <Web3SignerProvider noFetch={true}>
-                    <CreateProvider>
-                        <PayProvider>
-                            <RescueProvider>
-                                <Router>
-                                    <Route
-                                        path="/"
-                                        component={() => props.children}
-                                    />
-                                </Router>
-                            </RescueProvider>
-                        </PayProvider>
-                    </CreateProvider>
-                </Web3SignerProvider>
-            </FiatProvider>
-        </GlobalProvider>
-    );
+const createContextWrapper =
+    (noFetch: boolean) => (props: { children: JSX.Element }) => {
+        const App = () => (
+            <GlobalProvider>
+                <FiatProvider>
+                    <Web3SignerProvider noFetch={noFetch}>
+                        <CreateProvider>
+                            <PayProvider>
+                                <RescueProvider>
+                                    <Router>
+                                        <Route
+                                            path="/"
+                                            component={() => props.children}
+                                        />
+                                    </Router>
+                                </RescueProvider>
+                            </PayProvider>
+                        </CreateProvider>
+                    </Web3SignerProvider>
+                </FiatProvider>
+            </GlobalProvider>
+        );
 
-    return (
-        <Router root={App}>
-            <Route path="/" component={() => props.children} />
-        </Router>
-    );
-};
+        return (
+            <Router root={App}>
+                <Route path="/" component={() => props.children} />
+            </Router>
+        );
+    };
+
+export const contextWrapper = createContextWrapper(true);
+export const fetchingContextWrapper = createContextWrapper(false);

--- a/tests/status/CommitmentCreated.spec.tsx
+++ b/tests/status/CommitmentCreated.spec.tsx
@@ -1,13 +1,17 @@
-import { render, screen } from "@solidjs/testing-library";
+import { render, screen, waitFor } from "@solidjs/testing-library";
 import { BigNumber } from "bignumber.js";
-import { SwapPosition } from "boltz-swaps/types";
+import type { Pairs } from "boltz-swaps/client";
+import { SwapPosition, SwapType } from "boltz-swaps/types";
 import type { Hash, PublicClient, TransactionReceipt } from "viem";
 
+import type * as BoltzClientModule from "../../packages/boltz-swaps/src/client";
 import { config } from "../../src/config";
-import { USDT0 } from "../../src/consts/Assets";
+import { TBTC, USDT0 } from "../../src/consts/Assets";
 import { InvoiceValidation } from "../../src/consts/Enums";
+import { useGlobalContext } from "../../src/context/Global";
+import { usePayContext } from "../../src/context/Pay";
 import dict from "../../src/i18n/i18n";
-import {
+import CommitmentCreated, {
     type CommitmentAmounts,
     CommitmentLockupTransaction,
     calculateCommittedSubmarineAmounts,
@@ -16,12 +20,37 @@ import {
     waitForCommitmentLockupReceipt,
 } from "../../src/status/CommitmentCreated";
 import type Pair from "../../src/utils/Pair";
-import type { BridgeDetail } from "../../src/utils/swapCreator";
+import type { BridgeDetail, CommitmentSwap } from "../../src/utils/swapCreator";
 import { validateInvoice } from "../../src/utils/validation";
-import { contextWrapper } from "../helper";
+import { contextWrapper, fetchingContextWrapper } from "../helper";
 
 const invoice = "lnbcrt1mock";
 const invoiceSats = 40_720;
+const commitmentReceiptWait = vi.hoisted(() => vi.fn());
+const mockGetContracts = vi.hoisted(() =>
+    vi.fn<typeof BoltzClientModule.getContracts>(),
+);
+
+vi.mock("../../packages/boltz-swaps/src/client.ts", async () => {
+    const actual = await vi.importActual<typeof BoltzClientModule>(
+        "../../packages/boltz-swaps/src/client.ts",
+    );
+    return { ...actual, getContracts: mockGetContracts };
+});
+
+vi.mock("boltz-swaps/evm", async () => {
+    const actual = await vi.importActual("boltz-swaps/evm");
+    return {
+        ...actual,
+        createAssetProvider: () => ({
+            waitForTransactionReceipt: commitmentReceiptWait,
+        }),
+    };
+});
+
+vi.mock("../../src/components/RefundButton", () => ({
+    default: () => null,
+}));
 
 vi.mock("../../src/utils/validation", async () => {
     const actual = await vi.importActual("../../src/utils/validation");
@@ -43,6 +72,8 @@ describe("CommitmentCreated", () => {
         "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qqtzzqcxyaupvt8xstdrl8vlun9ch2t28a94hq80agu6usv02rxvetfm3c";
 
     afterEach(() => {
+        commitmentReceiptWait.mockReset();
+        mockGetContracts.mockReset();
         vi.restoreAllMocks();
     });
 
@@ -170,6 +201,87 @@ describe("CommitmentCreated", () => {
             waitForCommitmentLockupReceipt(provider, hash, 1, 0, 2),
         ).rejects.toThrow("rpc timeout");
         expect(provider.waitForTransactionReceipt).toHaveBeenCalledTimes(2);
+    });
+
+    const lockedCommitment = {
+        id: "commitment-id",
+        type: SwapType.Commitment,
+        assetSend: TBTC,
+        assetReceive: "LN",
+        initialReceiveAsset: "LN",
+        sourceAsset: "USDT0-POL",
+        sourceAmount: "1000000",
+        commitmentLockupTxHash: `0x${"1".repeat(64)}`,
+        gasAbstraction: { lockup: "signer", claim: "none" },
+    } as CommitmentSwap;
+
+    const contractRegistry = (erc20SwapAddress?: string) =>
+        ({
+            arbitrum: {
+                network: {
+                    chainId: config.assets?.[TBTC]?.network?.chainId,
+                    name: "Arbitrum",
+                },
+                swapContracts:
+                    erc20SwapAddress === undefined
+                        ? {}
+                        : { ERC20Swap: erc20SwapAddress },
+                supportedContracts: {},
+                tokens: {},
+            },
+        }) as never;
+
+    const CommitmentHarness = () => {
+        const global = useGlobalContext();
+        const pay = usePayContext();
+        global.setPairs({} as Pairs);
+        global.setRegularPairs({} as Pairs);
+        pay.setSwap(lockedCommitment);
+        return <CommitmentCreated />;
+    };
+
+    test("waits for the ERC20Swap registry, then reads the commitment lockup", async () => {
+        let resolveContracts: (contracts: never) => void = () => undefined;
+        mockGetContracts.mockImplementationOnce(
+            () =>
+                new Promise((resolve) => {
+                    resolveContracts = resolve;
+                }),
+        );
+        commitmentReceiptWait.mockImplementation(
+            () => new Promise(() => undefined),
+        );
+
+        render(() => <CommitmentHarness />, {
+            wrapper: fetchingContextWrapper,
+        });
+
+        expect(
+            await screen.findByTestId("loading-spinner"),
+        ).toBeInTheDocument();
+        expect(mockGetContracts).toHaveBeenCalledOnce();
+        expect(commitmentReceiptWait).not.toHaveBeenCalled();
+
+        resolveContracts(
+            contractRegistry("0x6398B76DF91C5eBe9f488e3656658E79284dDc0F"),
+        );
+
+        await waitFor(() =>
+            expect(commitmentReceiptWait).toHaveBeenCalledOnce(),
+        );
+    });
+
+    test("reports a loaded registry that is missing the ERC20Swap contract", async () => {
+        mockGetContracts.mockResolvedValueOnce(contractRegistry());
+
+        render(() => <CommitmentHarness />, {
+            wrapper: fetchingContextWrapper,
+        });
+
+        expect(
+            await screen.findByText("missing ERC20Swap contract for TBTC"),
+        ).toBeInTheDocument();
+        expect(commitmentReceiptWait).not.toHaveBeenCalled();
     });
 
     describe("CommitmentLockupTransaction", () => {

--- a/tests/utils/swapMetadata.spec.ts
+++ b/tests/utils/swapMetadata.spec.ts
@@ -362,6 +362,21 @@ describe("patchEncryptedSwapMetadata", () => {
         });
     });
 
+    test("does not patch commitment metadata with the temporary frontend id", async () => {
+        await patchEncryptedSwapMetadata(
+            {
+                type: SwapType.Commitment,
+                id: "temporary-frontend-id",
+                commitmentLockupTxHash: "0xcommitment",
+                dex: samplePayload.dex,
+                bridge: samplePayload.bridge,
+            } as never,
+            rescueFile,
+        );
+
+        expect(mocks.patchSwapMetadata).not.toHaveBeenCalled();
+    });
+
     test("does not patch tx identity without route metadata", async () => {
         await patchEncryptedSwapMetadata(
             {


### PR DESCRIPTION
Closes #1570

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Refund flows (gas-abstraction sweeps and EVM refunds) now support completing without a connected wallet using a valid manual destination address.
  - When connected, the refund destination is auto-filled and only offered on the eligible network.

- **Bug Fixes**
  - Commitment swap completion now saves the completed swap and updates encrypted swap metadata before redirecting.
  - Encrypted metadata patching is avoided for commitment swaps.

- **Tests**
  - Updated and expanded E2E/unit coverage for backend synchronization, destination inputs, loading/disabled states, and commitment/claim mapping.

- **Documentation**
  - Refined refund-related UI wording across supported locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->