### PR TITLE
fix: allow clicking on swaps while scan is still running

### DIFF
--- a/src/pages/external-rescue/useExternalRescueSearch.ts
+++ b/src/pages/external-rescue/useExternalRescueSearch.ts
@@ -17,7 +17,7 @@ import {
     createSignal,
     onCleanup,
 } from "solid-js";
-import { createStore } from "solid-js/store";
+import { createStore, reconcile } from "solid-js/store";
 import type { Address } from "viem";
 
 import type {
@@ -272,9 +272,12 @@ export const useExternalRescueSearch = () => {
         }));
     };
     const [currentResultPage, setCurrentResultPage] = createSignal(1);
-    const [currentResults, setCurrentResults] = createSignal<
+    const [currentResults, setCurrentResultsStore] = createStore<
         UnifiedRescueResult[]
     >([]);
+    const setCurrentResults = (results: UnifiedRescueResult[]) => {
+        setCurrentResultsStore(reconcile(results, { key: "key" }));
+    };
 
     let scanAbort: AbortController | undefined = undefined;
 
@@ -980,6 +983,8 @@ export const useExternalRescueSearch = () => {
             return;
         }
 
+        stopSearch();
+
         if (result.source === RescueResultSource.Evm) {
             navigate(
                 `/swap/rescue/evm/${result.swap.asset}/${result.swap.transactionHash}/${result.evmAction}`,
@@ -1021,7 +1026,7 @@ export const useExternalRescueSearch = () => {
         },
         results: {
             all: unifiedResults,
-            current: currentResults,
+            current: () => currentResults,
             currentEvmProgress,
             currentPage: currentResultPage,
             displaySlotCount: resultDisplaySlotCount,

--- a/tests/pages/RescueExternal.spec.tsx
+++ b/tests/pages/RescueExternal.spec.tsx
@@ -24,6 +24,7 @@ import {
     BtcSearchState,
     RescueResultSource,
 } from "../../src/pages/external-rescue/types";
+import { useExternalRescueSearch } from "../../src/pages/external-rescue/useExternalRescueSearch";
 import { ChatwootNotReadyError } from "../../src/utils/chatwoot";
 import { RescueAction } from "../../src/utils/rescue";
 import {
@@ -867,5 +868,92 @@ describe("Rescue", () => {
 
         fireEvent.click(scannedRow);
         expect(openResult).toHaveBeenCalledWith(scanned);
+    });
+
+    test("should keep result rows clickable while a running scan pushes fresh result arrays", () => {
+        const firstTxHash = `0x${"c".repeat(64)}`;
+        const secondTxHash = `0x${"d".repeat(64)}`;
+        const makeResult = (transactionHash: string, blockNumber: number) => ({
+            source: RescueResultSource.Evm,
+            key: `evm:refund:TBTC:${transactionHash}`,
+            action: RescueAction.Refund,
+            evmAction: RskRescueMode.Refund,
+            actionable: true,
+            sortValue: blockNumber,
+            swap: {
+                action: RskRescueMode.Refund,
+                asset: "TBTC",
+                blockNumber,
+                transactionHash,
+            },
+        });
+
+        const open = vi.fn();
+        let setCurrent!: (results: any[]) => void;
+
+        const Harness = () => {
+            const { results } = useExternalRescueSearch();
+            setCurrent = results.setCurrent;
+            return (
+                <Results
+                    state={
+                        {
+                            btc: {
+                                loadedSwaps: 0,
+                                searchState: BtcSearchState.Ready,
+                                listLoading: false,
+                            },
+                            evm: {
+                                unmatchedRefundSwaps: 0,
+                                unmatchedClaimSwaps: 0,
+                            },
+                            search: {
+                                hasSearched: true,
+                                isSearching: true,
+                            },
+                        } as any
+                    }
+                    results={
+                        {
+                            ...results,
+                            all: () => [makeResult(firstTxHash, 1)],
+                            open,
+                        } as any
+                    }
+                />
+            );
+        };
+
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Harness />
+                </>
+            ),
+            {
+                wrapper: contextWrapper,
+            },
+        );
+
+        const row = screen.getByTestId(
+            `swaplist-item-evm:refund:TBTC:${firstTxHash}`,
+        );
+
+        // a scan event pushes a fresh slice of equivalent objects
+        setCurrent([makeResult(firstTxHash, 1), makeResult(secondTxHash, 2)]);
+
+        expect(
+            screen.getByTestId(`swaplist-item-evm:refund:TBTC:${secondTxHash}`),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByTestId(`swaplist-item-evm:refund:TBTC:${firstTxHash}`),
+        ).toBe(row);
+
+        fireEvent.click(row);
+        expect(open).toHaveBeenCalledTimes(1);
+        expect(open.mock.calls[0][0].key).toBe(
+            `evm:refund:TBTC:${firstTxHash}`,
+        );
     });
 });

--- a/tests/pages/RescueExternal.spec.tsx
+++ b/tests/pages/RescueExternal.spec.tsx
@@ -1,4 +1,10 @@
-import { render, screen, waitFor, within } from "@solidjs/testing-library";
+import {
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+    within,
+} from "@solidjs/testing-library";
 import { userEvent } from "@testing-library/user-event";
 import { type RestorableSwap, getRestorableSwaps } from "boltz-swaps/client";
 import {
@@ -801,6 +807,7 @@ describe("Rescue", () => {
             },
         };
         const results = [enriched, scanned];
+        const openResult = vi.fn();
 
         render(
             () => (
@@ -832,7 +839,7 @@ describe("Rescue", () => {
                                 currentPage: () => 1,
                                 displaySlotCount: () => results.length,
                                 hasAny: () => true,
-                                open: vi.fn(),
+                                open: openResult,
                                 setCurrent: vi.fn(),
                                 setCurrentPage: vi.fn(),
                             } as any
@@ -850,9 +857,15 @@ describe("Rescue", () => {
             within(enrichedRow).getByText("restored-evm-swap"),
         ).toBeInTheDocument();
 
+        fireEvent.click(enrichedRow);
+        expect(openResult).toHaveBeenCalledWith(enriched);
+
         const scannedRow = screen.getByTestId(`swaplist-item-${scanned.key}`);
         expect(
             within(scannedRow).getByText("0xbbb...bbbbb"),
         ).toBeInTheDocument();
+
+        fireEvent.click(scannedRow);
+        expect(openResult).toHaveBeenCalledWith(scanned);
     });
 });


### PR DESCRIPTION
Closes #1573 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved external rescue search state handling to keep paginated results synchronized during updates.
  * A search is now stopped when trying to open a result that can’t be acted on.
  * Opening enriched and scanned results now correctly passes the selected result details.
* **Tests**
  * Added coverage to ensure existing result rows remain clickable while a running scan refreshes results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->