### PR TITLE
fix: show EVM-source chain swaps as claimable in rescue flow

### DIFF
--- a/boltz.conf.patch
+++ b/boltz.conf.patch
@@ -70,34 +70,3 @@ index 63c2646..0c2bb9d 100755
  
  [[currencies]]
  symbol = "BTC"
-diff --git a/regtest/images/boltz-backend/arbitrum.conf b/regtest/images/boltz-backend/arbitrum.conf
-index 82a8593..96f705d 100644
---- a/regtest/images/boltz-backend/arbitrum.conf
-+++ b/regtest/images/boltz-backend/arbitrum.conf
-@@ -29,6 +29,26 @@ swapTypes = ["chain"]
-   swapMaximal = 2880
-   swapTaproot = 10080
- 
-+# Reverse swaps (LN -> TBTC) power the reverse DEX swap e2e coverage.
-+[[pairs]]
-+base = "TBTC"
-+quote = "BTC"
-+rate = 1
-+fee = 0
-+swapInFee = 0
-+
-+maxSwapAmount = 1_000_000
-+minSwapAmount = 2_500
-+
-+swapTypes = ["reverse"]
-+
-+  [pairs.timeoutDelta]
-+  chain = 1440
-+  reverse = 1440
-+  swapMinimal = 1440
-+  swapMaximal = 2880
-+  swapTaproot = 10080
-+
- [arbitrum]
- networkName = "Arbitrum"
- providerEndpoint = "ws://anvil-arb:8545"

--- a/e2e/arbitrum/evmSourceChainClaimRescue.spec.ts
+++ b/e2e/arbitrum/evmSourceChainClaimRescue.spec.ts
@@ -1,0 +1,215 @@
+import type { Page } from "@playwright/test";
+import { SwapType } from "boltz-swaps/types";
+import { createWalletClient, http, parseUnits } from "viem";
+
+import { config } from "../../src/config";
+import dict from "../../src/i18n/i18n";
+import { getRestorableSwaps } from "../boltzClient";
+import { injectWalletProvider } from "../fixtures/ethereum";
+import {
+    generateBitcoinBlock,
+    generateLiquidBlock,
+    getLiquidAddress,
+} from "../utils";
+import {
+    actionTimeout,
+    approveAndSend,
+    arbitrumE2eChain,
+    arbitrumRpcUrl,
+    clearBrowserStorage,
+    clearEoaDelegation,
+    createSwap,
+    describeArbitrumE2e,
+    expect,
+    expectArbitrumWalletReady,
+    fullFlowTestTimeout,
+    fundArbitrumStablesE2eWallet,
+    getArbitrumWalletAddress,
+    getRegtestTokenAddress,
+    scanAndSelectExternalResult,
+    test,
+    usdt0EthSendAmount,
+    waitForDexQuote,
+    waitForLockupTxHash,
+    waitForMetadataPatch,
+    waitForStablePairHash,
+} from "./shared";
+
+const walletIndex = 2;
+
+// Keep the original page from revealing the preimage before the browser state
+// is cleared. ClaimRescue must be the code path that broadcasts the L-BTC claim.
+const blockAutomaticLiquidClaim = async (page: Page) => {
+    await page.route("**/v2/swap/chain/*/claim", (route) => route.abort());
+    await page.route("**/v2/chain/L-BTC/transaction", (route) => route.abort());
+
+    for (const explorer of config.assets?.["L-BTC"]?.blockExplorerApis ?? []) {
+        for (const base of [explorer.normal, explorer.tor]) {
+            if (base !== undefined) {
+                await page.route(`${base}/tx`, (route) => route.abort());
+            }
+        }
+    }
+};
+
+const waitForClaimableRestore = async (
+    rescueFilePath: string,
+    swapId: string,
+) => {
+    let restoredStatus = "";
+
+    await expect
+        .poll(
+            async () => {
+                try {
+                    const restored = (
+                        await getRestorableSwaps(rescueFilePath)
+                    ).find((swap) => swap.id === swapId);
+                    restoredStatus = restored?.status ?? "";
+                    return restoredStatus;
+                } catch {
+                    return "";
+                }
+            },
+            {
+                timeout: actionTimeout,
+                message:
+                    "the restored EVM-source chain swap has an L-BTC server lockup",
+            },
+        )
+        .toMatch(/^transaction\.server\.(?:mempool|confirmed)$/);
+
+    if (restoredStatus === "transaction.server.mempool") {
+        await generateLiquidBlock();
+        await expect
+            .poll(
+                async () => {
+                    const restored = (
+                        await getRestorableSwaps(rescueFilePath)
+                    ).find((swap) => swap.id === swapId);
+                    return restored?.status ?? "";
+                },
+                {
+                    timeout: actionTimeout,
+                    message:
+                        "the restored EVM-source chain swap server lockup confirms",
+                },
+            )
+            .toBe("transaction.server.confirmed");
+    }
+
+    const restored = (await getRestorableSwaps(rescueFilePath)).find(
+        (swap) => swap.id === swapId,
+    );
+    expect(restored).toMatchObject({
+        id: swapId,
+        type: SwapType.Chain,
+        from: "TBTC",
+        to: "L-BTC",
+    });
+    expect(restored?.claimDetails).toBeDefined();
+    expect(restored?.refundDetails).toBeUndefined();
+};
+
+describeArbitrumE2e("Arbitrum EVM-source chain claim rescue e2e", () => {
+    test.beforeEach(async () => {
+        await generateBitcoinBlock();
+        await generateLiquidBlock();
+    });
+
+    test("restores and claims the L-BTC leg instead of showing the linked EVM refund", async ({
+        arbitrum,
+        context,
+        page,
+    }, testInfo) => {
+        test.setTimeout(fullFlowTestTimeout);
+
+        const rescueFilePath = testInfo.outputPath("rescue-file.json");
+        const walletAddress = await getArbitrumWalletAddress(
+            arbitrum.publicClient,
+            walletIndex,
+        );
+
+        await fundArbitrumStablesE2eWallet(
+            arbitrum.publicClient,
+            walletAddress,
+        );
+        await expectArbitrumWalletReady(arbitrum.publicClient, walletAddress);
+        await clearEoaDelegation(arbitrum.publicClient, walletAddress);
+        await injectWalletProvider({
+            page,
+            publicClient: arbitrum.publicClient,
+            walletClient: createWalletClient({
+                account: walletAddress,
+                chain: arbitrumE2eChain,
+                transport: http(arbitrumRpcUrl(), {
+                    timeout: actionTimeout,
+                }),
+            }),
+            chain: arbitrumE2eChain,
+        });
+        await blockAutomaticLiquidClaim(page);
+
+        await waitForDexQuote({
+            tokenIn: getRegtestTokenAddress("USDT0"),
+            tokenOut: getRegtestTokenAddress("TBTC"),
+            amountIn: parseUnits("39.996", 6),
+            label: "USDT0 -> TBTC",
+        });
+        await waitForStablePairHash("chain", "TBTC", "L-BTC");
+
+        const swapId = await createSwap(
+            page,
+            "USDT0",
+            "L-BTC",
+            await getLiquidAddress(),
+            usdt0EthSendAmount,
+            { walletAddress, rescueFilePath },
+        );
+        const metadataPatch = waitForMetadataPatch(page, swapId);
+
+        await approveAndSend(page, walletAddress);
+        await waitForLockupTxHash(page, swapId);
+        await metadataPatch;
+
+        await clearBrowserStorage(page);
+        await page.goto("about:blank");
+        await waitForClaimableRestore(rescueFilePath, swapId);
+
+        // Routes are page-scoped, so this fresh page can broadcast the rescue
+        // claim while the original page remains unable to auto-claim.
+        const rescuePage = await context.newPage();
+        try {
+            await scanAndSelectExternalResult({
+                page: rescuePage,
+                swapId,
+                rescueFilePath,
+                action: dict.en.claim,
+                assets: ["USDT", "LBTC"],
+            });
+
+            const claimAddress = await getLiquidAddress();
+            await rescuePage.getByTestId("onchainAddress").fill(claimAddress);
+
+            const claimButton = rescuePage.getByRole("button", {
+                name: dict.en.claim,
+                exact: true,
+            });
+            await expect(claimButton).toBeEnabled({
+                timeout: actionTimeout,
+            });
+            await claimButton.click();
+
+            await expect(rescuePage.getByTestId("claimed")).toBeVisible({
+                timeout: actionTimeout,
+            });
+            await expect(
+                rescuePage.getByRole("link", {
+                    name: "Open Claim Transaction",
+                }),
+            ).toBeVisible();
+        } finally {
+            await rescuePage.close();
+        }
+    });
+});

--- a/src/pages/ClaimRescue.tsx
+++ b/src/pages/ClaimRescue.tsx
@@ -1,3 +1,4 @@
+import { sha256 } from "@noble/hashes/sha2.js";
 import { hex } from "@scure/base";
 import { useParams } from "@solidjs/router";
 import { OutputType } from "boltz-core";
@@ -34,7 +35,7 @@ import SwapHeader from "../components/SwapHeader";
 import { getSwapIconAssets } from "../components/SwapIcons";
 import { hiddenInformation } from "../components/settings/PrivacyMode";
 import SettingsMenu from "../components/settings/SettingsMenu";
-import { type AssetType, LN } from "../consts/Assets";
+import { type AssetType, LN, isEvmAsset } from "../consts/Assets";
 import { useCreateContext } from "../context/Create";
 import { useGlobalContext } from "../context/Global";
 import { useRescueContext } from "../context/Rescue";
@@ -46,7 +47,23 @@ import { extractAddress } from "../utils/invoice";
 import { derivePreimageFromRescueKey, getXpub } from "../utils/rescueFile";
 import type { ChainSwap, ReverseSwap, SomeSwap } from "../utils/swapCreator";
 
-const mapClaimableSwap = ({
+export const verifyClaimPreimage = (
+    preimage: Uint8Array,
+    expectedHash?: string,
+) => {
+    if (expectedHash === undefined) {
+        return;
+    }
+
+    const normalizedExpectedHash = expectedHash
+        .replace(/^0x/i, "")
+        .toLowerCase();
+    if (hex.encode(sha256(preimage)) !== normalizedExpectedHash) {
+        throw new Error("derived claim preimage does not match restored swap");
+    }
+};
+
+export const mapClaimableSwap = ({
     swap,
     pair,
 }: {
@@ -76,7 +93,7 @@ const mapClaimableSwap = ({
 
     if (swap.type === SwapType.Chain) {
         const refund = swap.refundDetails;
-        if (refund === undefined) {
+        if (refund === undefined && !isEvmAsset(swap.from)) {
             return undefined;
         }
         return {
@@ -90,16 +107,20 @@ const mapClaimableSwap = ({
                     unconfidentialExtraFee),
             version: OutputType.Taproot,
             claimPrivateKeyIndex: claim.keyIndex,
-            refundPrivateKeyIndex: refund.keyIndex,
-            refundPrivateKey: refund.serverPublicKey,
             claimDetails: {
                 ...claim,
                 swapTree: claim.tree,
             } as ChainSwapDetails,
-            lockupDetails: {
-                ...refund,
-                swapTree: refund.tree,
-            } as ChainSwapDetails,
+            ...(refund === undefined
+                ? {}
+                : {
+                      refundPrivateKeyIndex: refund.keyIndex,
+                      refundPrivateKey: refund.serverPublicKey,
+                      lockupDetails: {
+                          ...refund,
+                          swapTree: refund.tree,
+                      } as ChainSwapDetails,
+                  }),
         };
     } else if (swap.type === SwapType.Reverse) {
         return {
@@ -213,13 +234,16 @@ const ClaimRescue = () => {
                     throw Error(`failed to find a chain pair for ${params.id}`);
                 }
 
-                const derivedKey = hex.encode(
-                    derivePreimageFromRescueKey(
-                        rescue,
-                        claimDetails.keyIndex,
-                        restorableSwap.to as AssetType,
-                    ),
+                const derivedPreimage = derivePreimageFromRescueKey(
+                    rescue,
+                    claimDetails.keyIndex,
+                    restorableSwap.to as AssetType,
                 );
+                verifyClaimPreimage(
+                    derivedPreimage,
+                    restorableSwap.preimageHash,
+                );
+                const derivedKey = hex.encode(derivedPreimage);
 
                 return mapClaimableSwap({
                     swap: {

--- a/src/pages/GasAbstractionSweepRescue.tsx
+++ b/src/pages/GasAbstractionSweepRescue.tsx
@@ -16,6 +16,7 @@ import { getAddress } from "viem";
 import BlockExplorer, {
     BlockExplorerTargetKind,
 } from "../components/BlockExplorer";
+import ConnectWallet from "../components/ConnectWallet";
 import ContractTransaction from "../components/ContractTransaction";
 import LoadingSpinner from "../components/LoadingSpinner";
 import SettingsCog from "../components/settings/SettingsCog";
@@ -126,15 +127,15 @@ const GasAbstractionSweepRescue = () => {
 
     return (
         <div class="frame">
+            <SettingsCog />
+            <SettingsMenu />
+            <h2 class="frame-title" style={{ "margin-bottom": "6px" }}>
+                {t("refund")} {cropString(params.address, 15, 5)}
+            </h2>
+            <hr />
             <Show
                 when={signer() !== undefined}
-                fallback={<h2>{t("no_wallet")}</h2>}>
-                <SettingsCog />
-                <SettingsMenu />
-                <h2 class="frame-title" style={{ "margin-bottom": "6px" }}>
-                    {t("refund")} {cropString(params.address, 15, 5)}
-                </h2>
-                <hr />
+                fallback={<ConnectWallet asset={params.asset} />}>
                 <Switch>
                     <Match when={rescueFile() === undefined}>
                         <h3>{t("refund_scan_required")}</h3>

--- a/src/pages/RefundRescue.tsx
+++ b/src/pages/RefundRescue.tsx
@@ -26,10 +26,11 @@ import RefundEta from "../components/RefundEta";
 import SwapHeader from "../components/SwapHeader";
 import { getSwapIconAssets } from "../components/SwapIcons";
 import SettingsMenu from "../components/settings/SettingsMenu";
-import type {
-    AssetType,
-    RefundableAssetType,
-    blockChainsAssets,
+import {
+    type AssetType,
+    type RefundableAssetType,
+    type blockChainsAssets,
+    isEvmAsset,
 } from "../consts/Assets";
 import { swapStatusFailed } from "../consts/SwapStatus";
 import { useGlobalContext } from "../context/Global";
@@ -74,7 +75,7 @@ export const mapSwap = (
         }
         case SwapType.Chain: {
             const refund = swap.refundDetails;
-            if (refund === undefined) {
+            if (refund === undefined && !isEvmAsset(swap.from)) {
                 return undefined;
             }
             const { claimDetails, refundDetails, ...rest } = swap;
@@ -84,13 +85,16 @@ export const mapSwap = (
                 assetSend: swap.from,
                 assetReceive: swap.to,
                 version: OutputType.Taproot,
-                refundPrivateKeyIndex: refund.keyIndex,
-
                 claimPrivateKeyIndex: claimDetails?.keyIndex,
-                lockupDetails: {
-                    ...refundDetails,
-                    swapTree: refund.tree,
-                } as ChainSwapDetails,
+                ...(refund === undefined
+                    ? {}
+                    : {
+                          refundPrivateKeyIndex: refund.keyIndex,
+                          lockupDetails: {
+                              ...refundDetails,
+                              swapTree: refund.tree,
+                          } as ChainSwapDetails,
+                      }),
             };
         }
         case SwapType.Reverse: {
@@ -159,6 +163,21 @@ const RefundRescue = () => {
         restoredSwap()?.refundDetails?.transaction?.id ??
         swapStatusTransaction()?.id ??
         refundableLockupTransactionId();
+
+    const lockupExplorerId = () => {
+        const currentSwap = swap();
+        if (currentSwap === null) {
+            return undefined;
+        }
+        if (currentSwap.lockupTx !== undefined) {
+            return currentSwap.lockupTx;
+        }
+        return currentSwap.type === SwapType.Submarine
+            ? currentSwap.address
+            : currentSwap.type === SwapType.Chain
+              ? currentSwap.lockupDetails?.lockupAddress
+              : undefined;
+    };
 
     const failureTitle = (): DictKey | undefined => {
         switch (swapStatus()) {
@@ -304,27 +323,24 @@ const RefundRescue = () => {
                                 timeoutBlockHeight={timeoutBlockHeight}
                                 asset={swap()!.assetSend}
                             />
-                            <BlockExplorer
-                                asset={swap()!.assetSend}
-                                typeLabel={
-                                    swap()!.lockupTx !== undefined
-                                        ? "lockup_tx"
-                                        : "lockup_address"
-                                }
-                                kind={
-                                    swap()!.lockupTx !== undefined
-                                        ? BlockExplorerTargetKind.Tx
-                                        : BlockExplorerTargetKind.Address
-                                }
-                                id={
-                                    swap()!.lockupTx !== undefined
-                                        ? swap()!.lockupTx!
-                                        : swap()!.type === SwapType.Submarine
-                                          ? (swap() as SubmarineSwap).address
-                                          : (swap() as ChainSwap).lockupDetails
-                                                .lockupAddress
-                                }
-                            />
+                            <Show when={lockupExplorerId()}>
+                                {(id) => (
+                                    <BlockExplorer
+                                        asset={swap()!.assetSend}
+                                        typeLabel={
+                                            swap()!.lockupTx !== undefined
+                                                ? "lockup_tx"
+                                                : "lockup_address"
+                                        }
+                                        kind={
+                                            swap()!.lockupTx !== undefined
+                                                ? BlockExplorerTargetKind.Tx
+                                                : BlockExplorerTargetKind.Address
+                                        }
+                                        id={id()}
+                                    />
+                                )}
+                            </Show>
                             <button
                                 class="btn btn-light"
                                 data-testid="backBtn"

--- a/src/pages/external-rescue/useExternalRescueSearch.ts
+++ b/src/pages/external-rescue/useExternalRescueSearch.ts
@@ -147,6 +147,11 @@ type RestoreSwapAssets = {
     to?: string;
 };
 
+type RestoreRescueResult = Extract<
+    UnifiedRescueResult,
+    { source: RescueResultSource.Restore }
+>;
+
 export const getRestorePreimageHash = (swap: { preimageHash?: string }) =>
     normalizeEvmId(swap.preimageHash);
 
@@ -302,9 +307,24 @@ export const useExternalRescueSearch = () => {
         ...enrichedEvmRefundSwaps(),
         ...enrichedEvmClaimSwaps(),
     ]);
-    const shouldDeferEvmResult = (swap: EvmRescueResult) =>
-        state.btc.searchState === BtcSearchState.Loading &&
-        swap.restoredSwap === undefined;
+    // The id of the original swap a commitment lockup refund belongs to,
+    // when the rescue scan restored that swap; undefined otherwise
+    const restoredOriginalSwapId = (swap: EvmRescueResult) =>
+        swap.action === RskRescueMode.Refund &&
+        isEmptyPreimageHash(swap.preimageHash)
+            ? swap.restoredSwap?.id
+            : undefined;
+    const shouldDeferEvmResult = (swap: EvmRescueResult) => {
+        const restoreLoading =
+            state.btc.searchState === BtcSearchState.Loading ||
+            btcRescueList.loading;
+
+        if (restoredOriginalSwapId(swap) !== undefined) {
+            return restoreLoading;
+        }
+
+        return restoreLoading && swap.restoredSwap === undefined;
+    };
     const visibleEvmSwaps = createMemo(() =>
         allEvmSwaps().filter((swap) => !shouldDeferEvmResult(swap)),
     );
@@ -372,12 +392,9 @@ export const useExternalRescueSearch = () => {
         () =>
             new Set(
                 visibleEvmSwaps()
-                    .flatMap((swap) => [
-                        swap.preimageHash,
-                        swap.restoredSwap?.preimageHash,
-                    ])
+                    .map((swap) => swap.preimageHash)
                     .filter(
-                        (preimageHash): preimageHash is string =>
+                        (preimageHash) =>
                             normalizeEvmId(preimageHash) !== "" &&
                             !isEmptyPreimageHash(preimageHash),
                     )
@@ -388,9 +405,9 @@ export const useExternalRescueSearch = () => {
         shouldShowEvmRestoreResult(swap, evmRescuePreimageHashes());
 
     const unifiedResults = createMemo(() => {
-        const btcResults: UnifiedRescueResult[] = (btcRescueList() ?? [])
+        const restoreResults: RestoreRescueResult[] = (btcRescueList() ?? [])
             .filter(shouldShowRestoreResult)
-            .map((swap): UnifiedRescueResult => {
+            .map((swap): RestoreRescueResult => {
                 const action = swap.action ?? RescueAction.Pending;
                 return {
                     source: RescueResultSource.Restore,
@@ -401,8 +418,30 @@ export const useExternalRescueSearch = () => {
                     swap,
                 };
             });
-        const evmResults: UnifiedRescueResult[] = visibleEvmSwaps().map(
-            (swap) => {
+        const linkedEvmRefundRestoreIds = new Set(
+            visibleEvmSwaps()
+                .map(restoredOriginalSwapId)
+                .filter((id) => id !== undefined),
+        );
+        const btcResults = restoreResults.filter(
+            (result) =>
+                result.action === RescueAction.Claim ||
+                !linkedEvmRefundRestoreIds.has(result.swap.id),
+        );
+        const claimableRestoreIds = new Set(
+            restoreResults
+                .filter((result) => result.action === RescueAction.Claim)
+                .map((result) => result.swap.id),
+        );
+        const evmResults: UnifiedRescueResult[] = visibleEvmSwaps()
+            .filter((swap) => {
+                const restoreId = restoredOriginalSwapId(swap);
+                return (
+                    restoreId === undefined ||
+                    !claimableRestoreIds.has(restoreId)
+                );
+            })
+            .map((swap) => {
                 const action = getEvmRescueAction(swap);
                 return {
                     source: RescueResultSource.Evm,
@@ -413,8 +452,7 @@ export const useExternalRescueSearch = () => {
                     sortValue: swap.blockNumber,
                     swap,
                 };
-            },
-        );
+            });
         const sweepResults: UnifiedRescueResult[] =
             state.evm.sweepableBalances.map((swap) => ({
                 source: RescueResultSource.Sweep,

--- a/src/utils/rescue.ts
+++ b/src/utils/rescue.ts
@@ -26,6 +26,7 @@ import {
     LBTC,
     type RefundableAssetType,
     type blockChainsAssets,
+    isEvmAsset,
     refundableAssets,
 } from "../consts/Assets";
 import {
@@ -410,7 +411,12 @@ export const createRescueList = async (
     return await Promise.all(
         swaps.map(async (swap) => {
             try {
-                const utxos = isRefundableSwapType(swap)
+                // EVM-source chain swaps are claimed on their UTXO destination,
+                // but their source refund is handled by the EVM rescue flow.
+                // They do not have UTXO refund details to inspect here.
+                const isUtxoRefundable =
+                    isRefundableSwapType(swap) && !isEvmAsset(swap.assetSend);
+                const utxos = isUtxoRefundable
                     ? await getRescuableUTXOs(swap)
                     : [];
 
@@ -429,7 +435,7 @@ export const createRescueList = async (
 
                 // Prioritize refunding for expired swaps with UTXOs
                 if (
-                    isRefundableSwapType(swap) &&
+                    isUtxoRefundable &&
                     blockHeight !== undefined &&
                     hasSwapTimedOut(swap, blockHeight) &&
                     utxos.length > 0
@@ -459,7 +465,7 @@ export const createRescueList = async (
                         status !== swapStatusPending.TransactionClaimPending,
                 );
                 if (
-                    isRefundableSwapType(swap) &&
+                    isUtxoRefundable &&
                     !pendingFromUserPerspective.includes(status) &&
                     utxos.length > 0
                 ) {

--- a/tests/pages/ClaimRescue.spec.tsx
+++ b/tests/pages/ClaimRescue.spec.tsx
@@ -1,9 +1,22 @@
+import { sha256 } from "@noble/hashes/sha2.js";
+import { hex } from "@scure/base";
 import type * as SolidRouter from "@solidjs/router";
 import { render, screen, waitFor } from "@solidjs/testing-library";
+import { OutputType } from "boltz-core";
+import type {
+    ChainPairTypeTaproot,
+    RestorableSwap,
+    SwapStatusResponse,
+} from "boltz-swaps/client";
+import { SwapType } from "boltz-swaps/types";
 import { vi } from "vitest";
 
+import { LBTC, TBTC } from "../../src/consts/Assets";
 import dict from "../../src/i18n/i18n";
-import ClaimRescue from "../../src/pages/ClaimRescue";
+import ClaimRescue, {
+    mapClaimableSwap,
+    verifyClaimPreimage,
+} from "../../src/pages/ClaimRescue";
 import { TestComponent, contextWrapper } from "../helper";
 
 const swapId = "claimRescueSwap";
@@ -17,6 +30,63 @@ vi.mock("@solidjs/router", async () => {
 });
 
 describe("ClaimRescue", () => {
+    test("verifies a rescue-derived claim preimage against the restored hash", () => {
+        const preimage = Uint8Array.from({ length: 32 }, (_, index) => index);
+        const expectedHash = hex.encode(sha256(preimage));
+
+        expect(() =>
+            verifyClaimPreimage(preimage, `0x${expectedHash.toUpperCase()}`),
+        ).not.toThrow();
+        expect(() => verifyClaimPreimage(preimage, "00".repeat(32))).toThrow(
+            "derived claim preimage does not match restored swap",
+        );
+    });
+
+    test("constructs an L-BTC claim when the EVM source has no UTXO refund details", () => {
+        const tree = {
+            claimLeaf: { output: "claim", version: 0xc0 },
+            refundLeaf: { output: "refund", version: 0xc0 },
+        };
+        const swap: RestorableSwap &
+            Pick<SwapStatusResponse, "transaction"> & { preimage: string } = {
+            id: swapId,
+            type: SwapType.Chain,
+            status: "transaction.server.confirmed",
+            createdAt: 1,
+            from: TBTC,
+            to: LBTC,
+            preimage: "11".repeat(32),
+            transaction: { id: "server-lock", hex: "00" },
+            claimDetails: {
+                amount: 10_000,
+                blindingKey: "22".repeat(32),
+                keyIndex: 7,
+                lockupAddress: "lq1claim",
+                serverPublicKey: `02${"33".repeat(32)}`,
+                timeoutBlockHeight: 1_000,
+                tree,
+            },
+        };
+        const pair = {
+            fees: { minerFees: { user: { claim: 2 } } },
+        } as ChainPairTypeTaproot;
+
+        const mapped = mapClaimableSwap({ swap, pair });
+        expect(mapped).toMatchObject({
+            type: SwapType.Chain,
+            assetSend: TBTC,
+            assetReceive: LBTC,
+            version: OutputType.Taproot,
+            claimPrivateKeyIndex: 7,
+            claimDetails: {
+                ...swap.claimDetails,
+                swapTree: tree,
+            },
+        });
+        expect(mapped).not.toHaveProperty("lockupDetails");
+        expect(mapped).not.toHaveProperty("refundPrivateKeyIndex");
+    });
+
     test("renders the error UI without crashing when the swap cannot be constructed", async () => {
         // No rescue file in the default context, so the fetcher throws
         render(

--- a/tests/pages/GasAbstractionSweepRescue.spec.tsx
+++ b/tests/pages/GasAbstractionSweepRescue.spec.tsx
@@ -120,6 +120,16 @@ vi.mock("../../src/components/ContractTransaction", () => ({
         );
     },
 }));
+vi.mock("../../src/components/ConnectWallet", () => ({
+    default: (props: { asset: string }) => (
+        <button
+            data-asset={props.asset}
+            data-testid="connect-wallet"
+            onClick={() => setSigner(makeSigner(otherAddress))}>
+            Connect wallet
+        </button>
+    ),
+}));
 
 vi.mock("../../src/components/BlockExplorer", () => ({
     BlockExplorerTargetKind: { Tx: "tx", Address: "address" },
@@ -166,13 +176,16 @@ const resetState = () => {
 };
 
 describe("GasAbstractionSweepRescue", () => {
-    test("shows the no-wallet fallback when the signer is undefined", async () => {
+    test("shows the wallet connection control when the signer is undefined", async () => {
         resetState();
         setRescueFile({ mnemonic: "test" } as RescueFile);
 
         renderPage();
 
-        expect(await screen.findByText(i18n.en.no_wallet)).toBeInTheDocument();
+        const connectWallet = await screen.findByTestId("connect-wallet");
+        expect(connectWallet).toHaveAttribute("data-asset", USDT0);
+        expect(screen.queryByText(i18n.en.no_wallet)).toBeNull();
+        expect(screen.queryByTestId("contract-transaction")).toBeNull();
     });
 
     test("prompts to scan with the rescue file when none is loaded", async () => {
@@ -186,21 +199,20 @@ describe("GasAbstractionSweepRescue", () => {
         ).toBeInTheDocument();
     });
 
-    test("re-runs the resource when the signer arrives after mount", async () => {
+    test("shows the refund flow after connecting a wallet", async () => {
         resetState();
+        const user = userEvent.setup();
         setRescueFile({ mnemonic: "test" } as RescueFile);
         getGasAbstractionSigner.mockReturnValue(makeSigner(validAddress));
-        balanceOf.mockResolvedValue(0n);
+        balanceOf.mockResolvedValue(1_000_000n);
 
         renderPage();
 
-        // initial render: signer undefined → no_wallet fallback
-        expect(await screen.findByText(i18n.en.no_wallet)).toBeInTheDocument();
+        const connectWallet = await screen.findByTestId("connect-wallet");
         expect(getGasAbstractionSigner).not.toHaveBeenCalled();
 
-        setSigner(makeSigner(validAddress));
+        await user.click(connectWallet);
 
-        // resource fetches once the source signal becomes truthy
         await waitFor(() =>
             expect(getGasAbstractionSigner).toHaveBeenCalledWith(
                 USDT0,
@@ -208,8 +220,9 @@ describe("GasAbstractionSweepRescue", () => {
             ),
         );
         expect(
-            await screen.findByText(i18n.en.connected_wallet_no_swaps),
-        ).toBeInTheDocument();
+            await screen.findByTestId("contract-tx-button"),
+        ).toHaveTextContent(i18n.en.refund);
+        expect(screen.queryByTestId("connect-wallet")).toBeNull();
     });
 
     test("errors when the URL asset is not sweepable", async () => {

--- a/tests/pages/RefundRescue.spec.tsx
+++ b/tests/pages/RefundRescue.spec.tsx
@@ -6,23 +6,28 @@ import { SwapType } from "boltz-swaps/types";
 import type { JSX } from "solid-js";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { BTC, LBTC, RBTC } from "../../src/consts/Assets";
+import { BTC, LBTC, RBTC, TBTC } from "../../src/consts/Assets";
 import type * as RescueContextModule from "../../src/context/Rescue";
 import dict from "../../src/i18n/i18n";
 import RefundRescue, { mapSwap } from "../../src/pages/RefundRescue";
 import type { RescueFile } from "../../src/utils/rescueFile";
-import { TestComponent, contextWrapper } from "../helper";
+import type { ChainSwap } from "../../src/utils/swapCreator";
+import { TestComponent, contextWrapper, payContext } from "../helper";
 
 const {
+    mockGetCurrentBlockHeight,
     mockGetSwapStatus,
     mockGetRescuableUTXOs,
     restorableSwaps,
+    waitForSwapTimeoutState,
     pageSwapId,
     lockupTxId,
 } = vi.hoisted(() => ({
+    mockGetCurrentBlockHeight: vi.fn(),
     mockGetSwapStatus: vi.fn(),
     mockGetRescuableUTXOs: vi.fn(),
     restorableSwaps: { current: [] as RestorableSwap[] },
+    waitForSwapTimeoutState: { current: false },
     pageSwapId: "refundRescuePage",
     lockupTxId:
         "813c90372c9b774396c66099cf8015f9510a8ba5686cbb78d8e848959fe7bb5d",
@@ -33,6 +38,11 @@ vi.mock("@solidjs/router", async () => {
     return {
         ...actual,
         useParams: () => ({ id: pageSwapId }),
+        useLocation: () => ({
+            state: waitForSwapTimeoutState.current
+                ? { waitForSwapTimeout: true }
+                : undefined,
+        }),
     };
 });
 
@@ -48,6 +58,7 @@ vi.mock("../../src/utils/rescue", async () => {
     const actual = await vi.importActual("../../src/utils/rescue");
     return {
         ...actual,
+        getCurrentBlockHeight: mockGetCurrentBlockHeight,
         getRescuableUTXOs: mockGetRescuableUTXOs,
     };
 });
@@ -112,6 +123,10 @@ const failedRestorable: RestorableSwap = {
 const openLockupTxLabel = dict.en.blockexplorer.replace(
     "{{ typeLabel }}",
     dict.en.blockexplorer_lockup_tx,
+);
+const openLockupAddressLabel = dict.en.blockexplorer.replace(
+    "{{ typeLabel }}",
+    dict.en.blockexplorer_lockup_address,
 );
 
 describe("mapSwap", () => {
@@ -221,6 +236,27 @@ describe("mapSwap", () => {
         expect(mapped).not.toHaveProperty("claimDetails");
         expect(mapped).not.toHaveProperty("refundDetails");
     });
+
+    test("maps an EVM-source chain swap without UTXO refund details", () => {
+        const swap: RestorableSwap = {
+            ...baseSwap,
+            type: SwapType.Chain,
+            from: TBTC,
+            to: LBTC,
+            claimDetails: { ...baseDetails, keyIndex: 11 },
+        };
+
+        const mapped = mapSwap(swap);
+        expect(mapped).toMatchObject({
+            type: SwapType.Chain,
+            assetSend: TBTC,
+            assetReceive: LBTC,
+            version: OutputType.Taproot,
+            claimPrivateKeyIndex: 11,
+        });
+        expect(mapped).not.toHaveProperty("lockupDetails");
+        expect(mapped).not.toHaveProperty("refundPrivateKeyIndex");
+    });
 });
 
 describe("RefundRescue", () => {
@@ -238,6 +274,7 @@ describe("RefundRescue", () => {
     beforeEach(() => {
         vi.clearAllMocks();
         restorableSwaps.current = [];
+        waitForSwapTimeoutState.current = false;
         mockGetSwapStatus.mockResolvedValue({
             status: failedRestorable.status,
             failureReason: "invoice expired",
@@ -299,5 +336,42 @@ describe("RefundRescue", () => {
         expect(
             screen.queryByRole("link", { name: openLockupTxLabel }),
         ).not.toBeInTheDocument();
+    });
+
+    test("hides the lockup address link if a waiting chain swap loses its lockup details", async () => {
+        waitForSwapTimeoutState.current = true;
+        restorableSwaps.current = [
+            {
+                ...baseSwap,
+                id: pageSwapId,
+                type: SwapType.Chain,
+                from: BTC,
+                to: LBTC,
+                refundDetails: { ...baseDetails },
+            },
+        ];
+        mockGetCurrentBlockHeight.mockResolvedValue({ [BTC]: 100 });
+
+        renderPage();
+
+        expect(
+            await screen.findByRole("link", {
+                name: openLockupAddressLabel,
+            }),
+        ).toBeInTheDocument();
+
+        payContext.setSwap({
+            ...payContext.swap()!,
+            lockupDetails: undefined,
+        } as unknown as ChainSwap);
+
+        await waitFor(() => {
+            expect(
+                screen.queryByRole("link", {
+                    name: openLockupAddressLabel,
+                }),
+            ).not.toBeInTheDocument();
+        });
+        expect(screen.getByTestId("backBtn")).toBeInTheDocument();
     });
 });

--- a/tests/pages/RescueExternalEvmScan.spec.tsx
+++ b/tests/pages/RescueExternalEvmScan.spec.tsx
@@ -1066,6 +1066,165 @@ describe("Rescue EVM scan", () => {
         });
     });
 
+    test.each([
+        {
+            name: "prioritizes a restored L-BTC claim over its linked EVM refund",
+            rescueAction: "claim",
+        },
+        {
+            name: "prioritizes a linked EVM refund over its pending restore",
+            rescueAction: "pending",
+        },
+    ])("$name", async ({ rescueAction }) => {
+        const user = userEvent.setup();
+        const mnemonic =
+            "awake father sword slab matrix myth cargo lock river thumb inspire speed";
+        const swapId = "Gr4Xq54A4Sse";
+        const commitmentTxHash =
+            "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+        vi.stubEnv("VITE_ARBITRUM_LOG_SCAN_ENDPOINT", "http://localhost:8547");
+
+        const restoredSwap: RestorableSwap = {
+            id: swapId,
+            type: SwapType.Chain,
+            status: "transaction.server.mempool",
+            createdAt: 1782787562,
+            from: TBTC,
+            to: "L-BTC",
+            preimageHash:
+                "c75a1b92ece410e13823372edceb1fc148c37d36586c2ccd8b2c78dac1556a8e",
+            claimDetails: {
+                amount: 13_341,
+                blindingKey:
+                    "c43345f5cbf63cd5be4044c0eb7b0991cc2465599fcf2e8d6127ec3847943dc4",
+                keyIndex: 71,
+                lockupAddress: "claim-lockup",
+                serverPublicKey:
+                    "03bb779740ad43c9337bf89a23062a8564b2cf5a75fd7e317a352965ee1b4a51b2",
+                timeoutBlockHeight: 3953207,
+                transaction: {
+                    id: "6ba69b919aaf28f5ec746f97cde06da136c77390082de0b52674954b58a51aa1",
+                    vout: 1,
+                },
+                tree: {
+                    claimLeaf: { version: 196, output: "51" },
+                    refundLeaf: { version: 196, output: "51" },
+                },
+            },
+            metadata: await encryptSwapMetadata(mnemonic, {
+                swapId,
+                commitmentLockupTxHash: commitmentTxHash,
+                dex: {
+                    hops: [
+                        {
+                            type: SwapType.Dex,
+                            from: USDT0,
+                            to: TBTC,
+                        },
+                    ],
+                    position: SwapPosition.Pre,
+                    quoteAmount: 13_334,
+                },
+                bridge: {
+                    sourceAsset: "USDT0-POL",
+                    destinationAsset: USDT0,
+                    kind: BridgeKind.Oft,
+                    position: SwapPosition.Pre,
+                },
+            }),
+        };
+        mockGetRestorableSwaps.mockResolvedValueOnce([restoredSwap]);
+        mockCreateRescueList.mockImplementation(
+            (swaps: Record<string, unknown>[]) =>
+                Promise.resolve(
+                    swaps.map((swap) => ({ ...swap, action: rescueAction })),
+                ),
+        );
+        mockScanLockupEvents.mockImplementation(async function* (
+            ...args: unknown[]
+        ) {
+            await Promise.resolve();
+            const config = args[2] as {
+                action?: RskRescueMode;
+                asset?: string;
+            };
+            const events =
+                config.action === RskRescueMode.Refund && config.asset === TBTC
+                    ? [
+                          {
+                              asset: TBTC,
+                              blockNumber: 100,
+                              transactionHash: commitmentTxHash,
+                              preimageHash: `0x${"00".repeat(32)}`,
+                              amount: 13_500_000_000_000n,
+                              claimAddress:
+                                  "0x0000000000000000000000000000000000000001",
+                              refundAddress:
+                                  "0x0000000000000000000000000000000000000002",
+                              timelock: 123n,
+                          },
+                      ]
+                    : [];
+            yield {
+                derivedKeys: undefined,
+                events,
+                progress: 1,
+                unmatchedSwaps: 0,
+            };
+        });
+
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Rescue />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        const uploadInput = await screen.findByTestId("refundUpload");
+        const rescueFile = new File(["{}"], "rescue.json", {
+            type: "application/json",
+        });
+        (rescueFile as File & { text: () => Promise<string> }).text = () =>
+            Promise.resolve(JSON.stringify({ mnemonic }));
+
+        await user.upload(uploadInput, rescueFile);
+        await user.click(screen.getByRole("button", { name: i18n.en.rescue }));
+
+        const restoreRowId = `swaplist-item-${swapId}`;
+        const refundRowId =
+            `swaplist-item-evm:${RskRescueMode.Refund}:` +
+            `${TBTC}:${commitmentTxHash}`;
+
+        if (rescueAction === "claim") {
+            const claimRow = await screen.findByTestId(
+                restoreRowId,
+                undefined,
+                { timeout: 5_000 },
+            );
+            expect(claimRow).not.toHaveClass("disabled");
+            expect(claimRow).toHaveTextContent(i18n.en.claim);
+            expect(screen.queryByTestId(refundRowId)).toBeNull();
+        } else {
+            const refundRow = await screen.findByTestId(
+                refundRowId,
+                undefined,
+                { timeout: 5_000 },
+            );
+            expect(refundRow).not.toHaveClass("disabled");
+            expect(refundRow).toHaveTextContent(i18n.en.refund);
+            expect(screen.queryByTestId(restoreRowId)).toBeNull();
+        }
+
+        expect(
+            document.querySelectorAll(
+                ".rescue-external-results .swaplist-item",
+            ),
+        ).toHaveLength(1);
+    });
+
     test("scans WBTC and TBTC on Arbitrum", async () => {
         const user = userEvent.setup();
         vi.stubEnv("VITE_ARBITRUM_LOG_SCAN_ENDPOINT", "http://localhost:8547");

--- a/tests/utils/rescue.spec.ts
+++ b/tests/utils/rescue.spec.ts
@@ -1,7 +1,7 @@
 import { SwapType } from "boltz-swaps/types";
 import { type Mock, beforeEach, vi } from "vitest";
 
-import { BTC, LBTC, RBTC } from "../../src/consts/Assets";
+import { BTC, LBTC, RBTC, TBTC } from "../../src/consts/Assets";
 import {
     swapStatusFailed,
     swapStatusFinal,
@@ -15,6 +15,7 @@ import {
     isSwapClaimable,
 } from "../../src/utils/rescue";
 import type {
+    ChainSwap,
     ReverseSwap,
     SomeSwap,
     SubmarineSwap,
@@ -283,9 +284,33 @@ describe("rescue", () => {
                 ...overrides,
             }) as SubmarineSwap;
 
+        const createMockChainSwap = (
+            overrides: Partial<ChainSwap> = {},
+        ): ChainSwap =>
+            ({
+                type: SwapType.Chain,
+                ...overrides,
+            }) as ChainSwap;
+
         test("should return empty array for empty swaps array", async () => {
             const result = await createRescueList([], zeroConf);
             expect(result).toEqual([]);
+        });
+
+        test("claims an EVM-source chain swap without UTXO refund details", async () => {
+            const swap = createMockChainSwap({
+                id: "evm-source-chain-swap",
+                assetSend: TBTC,
+                assetReceive: LBTC,
+                status: swapStatusPending.TransactionServerConfirmed,
+            });
+
+            const result = await createRescueList([swap], zeroConf);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].action).toBe(RescueAction.Claim);
+            expect(mockGetSwapUTXOs).not.toHaveBeenCalled();
+            expect(mockGetLockupTransaction).not.toHaveBeenCalled();
         });
 
         test("should return Successful action for final status swaps without UTXOs", async () => {


### PR DESCRIPTION
USDT/C-> X chain swaps would not show up as "claimable" during Rescue. This PR fixes this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rescue handling for EVM-source chain swaps missing UTXO refund details.
  - Added claim preimage verification to prevent mismatched rescue data from being used.
  - Refined external rescue result filtering/prioritization to avoid duplicate or conflicting actions.
  - Corrected lockup explorer link visibility and targeting across rescue flows.
- **User Experience**
  - Show a clear wallet connection prompt when a signer is unavailable.
  - Enhanced the manual rescue/claim experience for restored EVM-related swaps (including the claim transaction link).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->