### PR TITLE
fix: refund back to the original sender

### DIFF
--- a/src/components/RefundButton.tsx
+++ b/src/components/RefundButton.tsx
@@ -332,6 +332,10 @@ const buildRefundFollowUpCalls = async (
 ) => {
     let resolvedDestination = destination;
     const isPreBridge = bridge?.position === SwapPosition.Pre;
+    // Without the bridge transaction (legacy restores), the original sender
+    // cannot be resolved; deliver to the destination locally instead of
+    // bridging back
+    const bridgeBack = isPreBridge && bridge?.txHash !== undefined;
 
     if (isPreBridge) {
         if (
@@ -343,8 +347,9 @@ const buildRefundFollowUpCalls = async (
             );
         }
 
-        resolvedDestination =
-            bridge.refundAddress ?? (await resolveBridgeSender(bridge));
+        if (bridgeBack) {
+            resolvedDestination = await resolveBridgeSender(bridge);
+        }
     }
 
     if (dexDetails === undefined || dexDetails.position !== SwapPosition.Pre) {
@@ -365,7 +370,7 @@ const buildRefundFollowUpCalls = async (
         throw new Error("missing token address for refund");
     }
 
-    if (!isPreBridge) {
+    if (!bridgeBack) {
         const [quote] = await quoteDexAmountIn(
             quoteChain,
             refundData.tokenAddress,
@@ -409,7 +414,7 @@ const buildRefundFollowUpCalls = async (
     });
 };
 
-const buildErc20RefundTransaction = async ({
+export const buildErc20RefundTransaction = async ({
     gasAbstraction,
     transactionSigner,
     contract,

--- a/src/pages/RescueEvm.tsx
+++ b/src/pages/RescueEvm.tsx
@@ -197,10 +197,15 @@ const RefundState = (props: {
         return undefined;
     };
 
-    // Pre-bridge refunds resolve their destination from the bridge instead
+    // Pre-bridge refunds resolve their destination from the bridge instead;
+    // legacy restores may lack the bridge transaction needed to do so
     const needsResolvedDestination = () =>
         dexDetails()?.position === SwapPosition.Pre &&
         bridgeDetails()?.position !== SwapPosition.Pre;
+    const routeResolvesDestination = () =>
+        dexDetails()?.position === SwapPosition.Pre &&
+        bridgeDetails()?.position === SwapPosition.Pre &&
+        bridgeDetails()?.txHash !== undefined;
 
     const [resolvedFunder] = createResource(
         () => {
@@ -244,8 +249,23 @@ const RefundState = (props: {
         }
     };
 
+    // Only routed and commitment lockups pay out to the gas key; plain
+    // lockups refund straight to the user's wallet
+    const refundsToGasKey = () => {
+        const gasSigner = gasAbstraction()?.signer;
+        return (
+            gasSigner !== undefined &&
+            normalizeEvmId(props.refundData.refundAddress) ===
+                normalizeEvmId(gasSigner.address)
+        );
+    };
+
+    // Without a destination, a gas-abstracted refund would strand the funds
+    // on the gas-abstraction address instead of the user's wallet
     const destinationMissing = () =>
-        needsResolvedDestination() && destination() === undefined;
+        refundsToGasKey() &&
+        !routeResolvesDestination() &&
+        destination() === undefined;
 
     return (
         <>

--- a/src/utils/swapCreator.ts
+++ b/src/utils/swapCreator.ts
@@ -70,7 +70,6 @@ export type BridgeDetail = BridgeRoute & {
     details?: BridgeDetails;
     pendingSend?: PendingBridgeSend;
     evmSendCandidate?: PendingEvmBridgeSend;
-    refundAddress?: string;
 
     // Recovery state when a pre-bridge DEX quote falls short and the bridged
     // funds must be retried or refunded back to the original sender.

--- a/src/utils/swapMetadata.ts
+++ b/src/utils/swapMetadata.ts
@@ -16,7 +16,12 @@ import {
 
 type SwapMetadataBridge = Pick<
     BridgeDetail,
-    "sourceAsset" | "destinationAsset" | "kind" | "position" | "refundAddress"
+    | "sourceAsset"
+    | "destinationAsset"
+    | "kind"
+    | "position"
+    // Lets restored pre-bridge refunds resolve the original sender
+    | "txHash"
 >;
 type SwapMetadataDex = Pick<DexDetail, "hops" | "position" | "quoteAmount">;
 type SwapMetadataTxIdentity = Pick<
@@ -179,7 +184,7 @@ const parseSwapMetadataPlaintext = parseObject<SwapMetadataPlaintext>({
             destinationAsset: parseString,
             kind: parseEnum(BridgeKind),
             position: parseEnum(SwapPosition),
-            refundAddress: parseOptional(parseString),
+            txHash: parseOptional(parseString),
         }),
     ),
     lockupTx: parseOptional(parseString),
@@ -327,7 +332,7 @@ export const buildSwapMetadataPayload = (
             destinationAsset: fields.bridge.destinationAsset,
             kind: fields.bridge.kind,
             position: fields.bridge.position,
-            refundAddress: fields.bridge.refundAddress,
+            txHash: fields.bridge.txHash,
         };
     }
 

--- a/tests/components/RefundEvmTransaction.spec.ts
+++ b/tests/components/RefundEvmTransaction.spec.ts
@@ -1,0 +1,388 @@
+import type * as BridgeModule from "boltz-swaps/bridge";
+import type * as ClientModule from "boltz-swaps/client";
+import type { AlchemyCall } from "boltz-swaps/evm";
+import type * as ContractsModule from "boltz-swaps/evm/contracts";
+import type { Erc20SwapContract } from "boltz-swaps/evm/contracts";
+import { erc20SwapAbi } from "boltz-swaps/generated/evm-abis";
+import {
+    BridgeKind,
+    type LockupEvent,
+    SwapPosition,
+    SwapType,
+} from "boltz-swaps/types";
+import {
+    type Hex,
+    type TransactionRequest,
+    decodeFunctionData,
+    erc20Abi,
+    getAddress,
+    parseSignature,
+} from "viem";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { buildErc20RefundTransaction } from "../../src/components/RefundButton";
+import type { Signer } from "../../src/context/Web3";
+import {
+    type BridgeDetail,
+    type DexDetail,
+    GasAbstractionType,
+} from "../../src/utils/swapCreator";
+
+const {
+    quoteDexAmountIn,
+    quoteDexAmountOut,
+    encodeDexQuote,
+    requireDriverForRoute,
+    createRouterContract,
+} = vi.hoisted(() => ({
+    quoteDexAmountIn: vi.fn(),
+    quoteDexAmountOut: vi.fn(),
+    encodeDexQuote: vi.fn(),
+    requireDriverForRoute: vi.fn(),
+    createRouterContract: vi.fn(),
+}));
+
+vi.mock("boltz-swaps/client", async () => {
+    const actual =
+        await vi.importActual<typeof ClientModule>("boltz-swaps/client");
+    return {
+        ...actual,
+        quoteDexAmountIn,
+        quoteDexAmountOut,
+        encodeDexQuote,
+    };
+});
+
+vi.mock("boltz-swaps/bridge", async () => {
+    const actual =
+        await vi.importActual<typeof BridgeModule>("boltz-swaps/bridge");
+    return {
+        ...actual,
+        bridgeRegistry: { requireDriverForRoute },
+    };
+});
+
+vi.mock("boltz-swaps/evm/contracts", async () => {
+    const actual = await vi.importActual<typeof ContractsModule>(
+        "boltz-swaps/evm/contracts",
+    );
+    return {
+        ...actual,
+        createRouterContract,
+    };
+});
+
+const contractAddress = getAddress(
+    "0x1000000000000000000000000000000000000001",
+);
+const tokenAddress = getAddress("0x2000000000000000000000000000000000000002");
+const claimAddress = getAddress("0x3000000000000000000000000000000000000003");
+const gasAbstractionAddress = getAddress(
+    "0x4000000000000000000000000000000000000004",
+);
+const userWallet = getAddress("0x5000000000000000000000000000000000000005");
+const originalSender = getAddress("0x6000000000000000000000000000000000000006");
+const routerAddress = getAddress("0x7000000000000000000000000000000000000007");
+const dexTokenIn = getAddress("0x8000000000000000000000000000000000000008");
+
+const refundData: LockupEvent = {
+    preimageHash: `0x${"00".repeat(32)}` as const,
+    amount: 700_000_000_000_000n,
+    tokenAddress,
+    claimAddress,
+    refundAddress: gasAbstractionAddress,
+    timelock: 123n,
+    logIndex: 0,
+};
+
+const signature = parseSignature(
+    `0x${"11".repeat(32)}${"22".repeat(32)}1b` as const,
+);
+
+const transactionSigner = {} as Signer;
+const contract = { address: contractAddress } as Erc20SwapContract;
+
+const preDexDetails: DexDetail = {
+    position: SwapPosition.Pre,
+    quoteAmount: "40",
+    hops: [
+        {
+            type: SwapType.Chain,
+            from: "USDT0",
+            to: "TBTC",
+            dexDetails: {
+                chain: "ARB",
+                tokenIn: dexTokenIn,
+                tokenOut: tokenAddress,
+            },
+        },
+    ],
+};
+
+const preBridgeDetails: BridgeDetail = {
+    kind: BridgeKind.Oft,
+    position: SwapPosition.Pre,
+    sourceAsset: "USDT0-ETH",
+    destinationAsset: "USDT0",
+    txHash: `0x${"aa".repeat(32)}`,
+};
+
+type BuildOverrides = Partial<
+    Parameters<typeof buildErc20RefundTransaction>[0]
+>;
+
+const build = (overrides: BuildOverrides = {}) =>
+    buildErc20RefundTransaction({
+        gasAbstraction: GasAbstractionType.Signer,
+        transactionSigner,
+        contract,
+        refundData,
+        signature,
+        slippage: 0.5,
+        cooperative: true,
+        commitmentRefund: true,
+        ...overrides,
+    });
+
+// The two shapes the builder can return: a single transaction when there is
+// nothing to batch, or the calls of a gas-abstracted batch
+const buildTransaction = async (overrides: BuildOverrides = {}) => {
+    const result = await build(overrides);
+    expect(Array.isArray(result)).toBe(false);
+    return result as TransactionRequest;
+};
+
+const buildCalls = async (overrides: BuildOverrides = {}) => {
+    const result = await build(overrides);
+    expect(Array.isArray(result)).toBe(true);
+    return result as AlchemyCall[];
+};
+
+const decodeSwapCall = (call: { data?: Hex }) =>
+    decodeFunctionData({ abi: erc20SwapAbi, data: call.data! });
+
+const createBridgeDriver = () => ({
+    getTransactionSender: vi.fn().mockResolvedValue(originalSender),
+    getContract: vi.fn().mockResolvedValue({}),
+    getQuotedContract: vi.fn().mockResolvedValue({}),
+    quoteSend: vi.fn().mockResolvedValue({
+        msgFee: [0n, 0n],
+        sendParam: {},
+        minAmount: 38_000_000n,
+    }),
+    buildApprovalCall: vi.fn().mockResolvedValue({
+        to: tokenAddress,
+        value: "0",
+        data: "0xapproval",
+    }),
+    encodeRouterExecuteData: vi.fn().mockReturnValue("0xexec"),
+});
+
+describe("buildErc20RefundTransaction", () => {
+    let driver: ReturnType<typeof createBridgeDriver>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        quoteDexAmountIn.mockResolvedValue([
+            { quote: "39000000", data: "0xdeadbeef" },
+        ]);
+        encodeDexQuote.mockResolvedValue({
+            calls: [
+                {
+                    to: routerAddress,
+                    value: "0",
+                    data: "0x1234",
+                },
+            ],
+        });
+
+        createRouterContract.mockReturnValue({ address: routerAddress });
+        driver = createBridgeDriver();
+        requireDriverForRoute.mockReturnValue(driver);
+    });
+
+    test("throws when the token address is missing", async () => {
+        await expect(
+            build({
+                refundData: { ...refundData, tokenAddress: undefined },
+            }),
+        ).rejects.toThrow("missing token address for ERC20 refund");
+    });
+
+    test("throws when a cooperative refund has no signature", async () => {
+        await expect(build({ signature: undefined })).rejects.toThrow(
+            "missing cooperative refund signature",
+        );
+    });
+
+    test("returns a single transaction when gas abstraction is not signer-based", async () => {
+        const result = await buildTransaction({
+            gasAbstraction: GasAbstractionType.None,
+            destination: userWallet,
+        });
+
+        expect(result.to).toEqual(contractAddress);
+        expect(decodeSwapCall(result).functionName).toEqual(
+            "refundCooperative",
+        );
+    });
+
+    test("encodes commitment refunds without an explicit refund address", async () => {
+        const commitment = await buildTransaction({
+            gasAbstraction: GasAbstractionType.None,
+        });
+        const regular = await buildTransaction({
+            gasAbstraction: GasAbstractionType.None,
+            commitmentRefund: false,
+        });
+
+        // The commitment overload omits the refund address; msg.sender is
+        // the refund address
+        expect(decodeSwapCall(commitment).args).not.toContain(
+            gasAbstractionAddress,
+        );
+        expect(decodeSwapCall(regular).args).toContain(gasAbstractionAddress);
+    });
+
+    test("encodes a timeout refund without a signature", async () => {
+        const result = await buildTransaction({
+            gasAbstraction: GasAbstractionType.None,
+            cooperative: false,
+            signature: undefined,
+        });
+
+        expect(decodeSwapCall(result).functionName).toEqual("refund");
+    });
+
+    test("appends a transfer to the destination for plain refunds", async () => {
+        const calls = await buildCalls({ destination: userWallet });
+
+        expect(calls).toHaveLength(2);
+        expect(calls[0].to).toEqual(contractAddress);
+        expect(calls[1].to).toEqual(tokenAddress);
+
+        const transfer = decodeFunctionData({
+            abi: erc20Abi,
+            data: calls[1].data!,
+        });
+        expect(transfer.functionName).toEqual("transfer");
+        expect(transfer.args).toEqual([userWallet, refundData.amount]);
+    });
+
+    test("skips the transfer when the destination is the refund address", async () => {
+        const calls = await buildCalls({
+            destination: gasAbstractionAddress.toLowerCase(),
+        });
+
+        expect(calls).toHaveLength(1);
+    });
+
+    test("falls through to a bare refund when no destination is known", async () => {
+        // Documents the strand fallback: with no route and no destination the
+        // refund releases funds to the on-chain refund address only. Callers
+        // must gate on a known destination before sending this.
+        const result = await buildTransaction({ destination: undefined });
+
+        expect(result.to).toEqual(contractAddress);
+    });
+
+    test("routes a pre-DEX refund to the destination through the DEX", async () => {
+        const calls = await buildCalls({
+            dexDetails: preDexDetails,
+            destination: userWallet,
+        });
+
+        expect(calls).toHaveLength(2);
+        expect(calls[0].to).toEqual(contractAddress);
+        expect(calls[1].to).toEqual(routerAddress);
+
+        expect(quoteDexAmountIn).toHaveBeenCalledWith(
+            "ARB",
+            tokenAddress,
+            dexTokenIn,
+            refundData.amount,
+        );
+        expect(encodeDexQuote).toHaveBeenCalledWith(
+            "ARB",
+            userWallet,
+            refundData.amount,
+            expect.any(BigInt),
+            "0xdeadbeef",
+        );
+    });
+
+    test("throws for a routed refund without a destination", async () => {
+        await expect(
+            build({ dexDetails: preDexDetails, destination: undefined }),
+        ).rejects.toThrow("missing refund destination for routed refund");
+    });
+
+    test("throws for a pre-bridge refund without reverse DEX details", async () => {
+        await expect(
+            build({ bridge: preBridgeDetails, dexDetails: undefined }),
+        ).rejects.toThrow("missing reverse DEX details for pre-bridge refund");
+    });
+
+    test("bridges a pre-bridge refund back to the resolved original sender", async () => {
+        const calls = await buildCalls({
+            dexDetails: preDexDetails,
+            bridge: preBridgeDetails,
+        });
+
+        // refund + funding transfer to the router + router execute
+        expect(calls).toHaveLength(3);
+        expect(calls[0].to).toEqual(contractAddress);
+        expect(calls[1].to).toEqual(tokenAddress);
+        expect(calls[2].to).toEqual(routerAddress);
+        expect(calls[2].data).toEqual("0xexec");
+
+        expect(driver.getTransactionSender).toHaveBeenCalledWith(
+            preBridgeDetails.sourceAsset,
+            preBridgeDetails.txHash,
+        );
+        expect(driver.quoteSend).toHaveBeenCalledWith(
+            expect.anything(),
+            {
+                sourceAsset: preBridgeDetails.destinationAsset,
+                destinationAsset: preBridgeDetails.sourceAsset,
+            },
+            originalSender,
+            expect.any(BigInt),
+        );
+    });
+
+    test("delivers locally when the bridge transaction is unknown", async () => {
+        // Legacy restores may lack the bridge tx needed to resolve the
+        // original sender; the refund swaps to the destination instead of
+        // bridging back
+        const calls = await buildCalls({
+            dexDetails: preDexDetails,
+            bridge: { ...preBridgeDetails, txHash: undefined },
+            destination: userWallet,
+        });
+
+        expect(calls).toHaveLength(2);
+        expect(calls[0].to).toEqual(contractAddress);
+        expect(calls[1].to).toEqual(routerAddress);
+
+        expect(driver.getTransactionSender).not.toHaveBeenCalled();
+        expect(encodeDexQuote).toHaveBeenCalledWith(
+            "ARB",
+            userWallet,
+            refundData.amount,
+            expect.any(BigInt),
+            "0xdeadbeef",
+        );
+    });
+
+    test("throws without a bridge transaction or a destination", async () => {
+        await expect(
+            build({
+                dexDetails: preDexDetails,
+                bridge: { ...preBridgeDetails, txHash: undefined },
+                destination: undefined,
+            }),
+        ).rejects.toThrow("missing refund destination for routed refund");
+    });
+});

--- a/tests/pages/RescueEvm.spec.tsx
+++ b/tests/pages/RescueEvm.spec.tsx
@@ -297,7 +297,7 @@ describe("RescueEvm", () => {
         expect(screen.getByRole("button", { name: "Claim" })).toBeDisabled();
     });
 
-    test("enables a plain restored refund without a connected wallet", async () => {
+    test("refunds a plain restored lockup without a connected wallet", async () => {
         paramsMock.current.action = RskRescueMode.Refund;
         rescueSwaps.current = [
             {
@@ -315,6 +315,8 @@ describe("RescueEvm", () => {
 
         render(() => <RescueEvm />, { wrapper: contextWrapper });
 
+        // The lockup pays out to its own refund address, the user's wallet,
+        // so no destination is needed
         expect(
             await screen.findByRole("button", { name: "Refund" }),
         ).not.toBeDisabled();
@@ -325,11 +327,51 @@ describe("RescueEvm", () => {
         expect(mockGetLogsFromReceipt).toHaveBeenCalled();
     });
 
-    test("resolves the original funder for a pre-DEX refund without a wallet", async () => {
+    test("disables a commitment refund until a destination is known", async () => {
         paramsMock.current.action = RskRescueMode.Refund;
+        mockGetLogsFromReceipt.mockResolvedValue({
+            ...logData,
+            refundAddress: gasSigner.address,
+        });
         rescueSwaps.current = [
             {
                 ...logData,
+                refundAddress: gasSigner.address,
+                action: RskRescueMode.Refund,
+                currentHeight: 1_000n,
+                restoredSwap: {
+                    ...restoredSwap,
+                    type: SwapType.Chain,
+                    from: TBTC,
+                    to: "L-BTC",
+                },
+            },
+        ];
+
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        // The lockup pays out to the gas key and there is no route info to
+        // resolve the original sender from, so the refund must not run: it
+        // would strand funds on the gas-abstraction address
+        expect(
+            await screen.findByRole("button", { name: "Refund" }),
+        ).toBeDisabled();
+        expect(
+            screen.getByRole("button", { name: "Connect wallet" }),
+        ).toBeInTheDocument();
+        expect(mockResolveLockupTokenFunder).not.toHaveBeenCalled();
+    });
+
+    test("resolves the original funder for a pre-DEX refund without a wallet", async () => {
+        paramsMock.current.action = RskRescueMode.Refund;
+        mockGetLogsFromReceipt.mockResolvedValue({
+            ...logData,
+            refundAddress: gasSigner.address,
+        });
+        rescueSwaps.current = [
+            {
+                ...logData,
+                refundAddress: gasSigner.address,
                 action: RskRescueMode.Refund,
                 currentHeight: 1_000n,
                 restoredSwap: {
@@ -358,9 +400,54 @@ describe("RescueEvm", () => {
 
     test("does not resolve a funder for pre-bridge refunds", async () => {
         paramsMock.current.action = RskRescueMode.Refund;
+        mockGetLogsFromReceipt.mockResolvedValue({
+            ...logData,
+            refundAddress: gasSigner.address,
+        });
         rescueSwaps.current = [
             {
                 ...logData,
+                refundAddress: gasSigner.address,
+                action: RskRescueMode.Refund,
+                currentHeight: 1_000n,
+                restoredSwap: {
+                    ...restoredSwap,
+                    type: SwapType.Chain,
+                    from: TBTC,
+                    to: "L-BTC",
+                    dex: preDex,
+                    bridge: {
+                        kind: BridgeKind.Oft,
+                        position: SwapPosition.Pre,
+                        sourceAsset: "USDT0-ETH",
+                        destinationAsset: "USDT0",
+                        txHash: transactionHash,
+                    },
+                },
+            },
+        ];
+
+        render(() => <RescueEvm />, { wrapper: contextWrapper });
+
+        expect(
+            await screen.findByRole("button", { name: "Refund" }),
+        ).not.toBeDisabled();
+        expect(
+            screen.queryByRole("button", { name: "Connect wallet" }),
+        ).toBeNull();
+        expect(mockResolveLockupTokenFunder).not.toHaveBeenCalled();
+    });
+
+    test("asks for a wallet when a pre-bridge restore lacks the bridge transaction", async () => {
+        paramsMock.current.action = RskRescueMode.Refund;
+        mockGetLogsFromReceipt.mockResolvedValue({
+            ...logData,
+            refundAddress: gasSigner.address,
+        });
+        rescueSwaps.current = [
+            {
+                ...logData,
+                refundAddress: gasSigner.address,
                 action: RskRescueMode.Refund,
                 currentHeight: 1_000n,
                 restoredSwap: {
@@ -381,21 +468,26 @@ describe("RescueEvm", () => {
 
         render(() => <RescueEvm />, { wrapper: contextWrapper });
 
+        // The original sender cannot be resolved without the bridge tx, so
+        // an explicit destination is required
         expect(
-            await screen.findByRole("button", { name: "Refund" }),
-        ).not.toBeDisabled();
-        expect(
-            screen.queryByRole("button", { name: "Connect wallet" }),
-        ).toBeNull();
+            await screen.findByRole("button", { name: "Connect wallet" }),
+        ).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Refund" })).toBeDisabled();
         expect(mockResolveLockupTokenFunder).not.toHaveBeenCalled();
     });
 
     test("asks for a wallet when the pre-DEX refund destination cannot be resolved", async () => {
         paramsMock.current.action = RskRescueMode.Refund;
         mockResolveLockupTokenFunder.mockResolvedValue(undefined);
+        mockGetLogsFromReceipt.mockResolvedValue({
+            ...logData,
+            refundAddress: gasSigner.address,
+        });
         rescueSwaps.current = [
             {
                 ...logData,
+                refundAddress: gasSigner.address,
                 action: RskRescueMode.Refund,
                 currentHeight: 1_000n,
                 restoredSwap: {

--- a/tests/utils/swapMetadata.spec.ts
+++ b/tests/utils/swapMetadata.spec.ts
@@ -95,6 +95,23 @@ describe("swapMetadata crypto", () => {
         expect(decrypted).toEqual(samplePayload);
     });
 
+    test("round-trips the bridge transaction hash", async () => {
+        const payload: SwapMetadataPayload = {
+            ...samplePayload,
+            bridge: {
+                ...samplePayload.bridge!,
+                txHash: "0xbridgetx",
+            },
+        };
+
+        const metadata = await encryptSwapMetadata(mnemonic, {
+            ...payload,
+            swapId,
+        });
+        const decrypted = await decryptSwapMetadata(mnemonic, swapId, metadata);
+        expect(decrypted.bridge?.txHash).toEqual("0xbridgetx");
+    });
+
     test("decrypts the golden vector (wire format is frozen)", async () => {
         await expect(
             decryptSwapMetadata(mnemonic, swapId, goldenVector),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Swap metadata now preserves the bridge transaction hash for round-tripping.

- **Bug Fixes**
  - Refund destination gating is now more accurate when the route already resolves the destination.
  - ERC-20 refunds remain disabled until required destination/original-sender info is available.
  - Pre-bridge refund flows resolve and proceed more reliably, including wallet-free scenarios.

- **Tests**
  - Added unit coverage for ERC-20 refund transaction building and refund-destination cases.
  - Added encryption/decryption test coverage for bridge transaction hashes.
  - Added/expanded Arbitrum end-to-end scenarios for pre-bridge refunds and OFT delivery, including commitment failure and cooperative refunds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->