### PR TITLE
fix: reserve fee for unconfidential Liquid claims

### DIFF
--- a/e2e/chainSwaps/chainSwaps.spec.ts
+++ b/e2e/chainSwaps/chainSwaps.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 import BigNumber from "bignumber.js";
 
+import { LBTC } from "../../src/consts/Assets";
 import { btcToSat, satToBtc } from "../../src/utils/denomination";
 import {
     bitcoinSendToAddress,
@@ -12,9 +13,11 @@ import {
     generateBitcoinBlock,
     generateInvoiceWithRoutingHint,
     generateLiquidBlock,
+    getAddressUtxos,
     getBitcoinAddress,
     getBitcoinWalletTx,
     getLiquidAddress,
+    getLiquidUnconfidentialAddress,
     setDisableAllSigners,
     verifyRescueFile,
 } from "../utils";
@@ -153,6 +156,71 @@ test.describe("Chain swap", () => {
         expect(await elementsGetReceivedByAddress(liquidAddress, 0)).toBe(
             bip21Amount.toNumber(),
         );
+    });
+
+    // The claim reserves the unconfidential surcharge out of its output, so the
+    // swap has to request that much more for the payee to land the full amount
+    test("BTC/LN with Magic Routing Hint to an unconfidential address", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        await page.locator("div[class='asset asset-BTC'] div").click();
+        await page.getByTestId("select-LN").click();
+
+        const liquidAddress = await getLiquidUnconfidentialAddress();
+        const invoice = await generateInvoiceWithRoutingHint(
+            liquidAddress,
+            btcToSat(BigNumber("0.0009")).toNumber(),
+        );
+        await page.locator("input[data-testid='invoice']").fill(invoice);
+
+        const bip21 = new URL((await fetchBip21Invoice(invoice)).bip21);
+        const bip21AmountSats = btcToSat(
+            BigNumber(bip21.searchParams.get("amount") ?? 0),
+        ).toNumber();
+
+        await page.getByTestId("create-swap-button").click();
+        await verifyRescueFile(page);
+
+        await expect(
+            page.locator("span[class='optimized-route']"),
+        ).toBeVisible();
+
+        await page.locator("p[data-testid='copy-box']").click();
+        const copyAddress = await page.evaluate(() =>
+            navigator.clipboard.readText(),
+        );
+
+        await page
+            .getByTestId("pay-onchain-buttons")
+            .getByText("amount")
+            .click();
+        const sendAmount = await page.evaluate(() =>
+            navigator.clipboard.readText(),
+        );
+
+        await bitcoinSendToAddress(
+            copyAddress,
+            satToBtc(BigNumber(sendAmount)).toString(),
+        );
+        await generateBitcoinBlock();
+
+        await expect(
+            page.locator("div[data-status='transaction.claimed']"),
+        ).toBeVisible({ timeout: 15_000 });
+        await generateLiquidBlock();
+
+        await expect
+            .poll(
+                async () =>
+                    (await getAddressUtxos(LBTC, liquidAddress)).reduce(
+                        (sum, utxo) => sum + (utxo.value ?? 0),
+                        0,
+                    ),
+                { timeout: 30_000 },
+            )
+            .toBe(bip21AmountSats);
     });
 
     test("L-BTC/BTC with zeroConf toggle automatically claims swap", async ({

--- a/e2e/chainSwaps/quoteAcceptanceCrash.spec.ts
+++ b/e2e/chainSwaps/quoteAcceptanceCrash.spec.ts
@@ -99,7 +99,7 @@ test.describe("ChainSwap replacement quote acceptance crash", () => {
         const quoteAmount: number = (await (await quoteFetched).json()).amount;
 
         const claimFee = await getLbtcBtcClaimFee();
-        const expectedReceive = quoteAmount - claimFee - 1;
+        const expectedReceive = quoteAmount - claimFee;
 
         // Let the acceptance POST reach the backend, but never deliver the
         // response to the app: the crash window between the server accepting

--- a/e2e/chainSwaps/zeroAmount.spec.ts
+++ b/e2e/chainSwaps/zeroAmount.spec.ts
@@ -60,7 +60,7 @@ test.describe("Chain Swap 0-amount", () => {
         const txInfo = JSON.parse(await getElementsWalletTx(txId!));
         expectApproxBtcAmount(
             txInfo.amount.bitcoin.toString(),
-            "0.00997297",
+            "0.00997298",
             amountBufferSats,
         );
     });

--- a/e2e/reverseSwap.spec.ts
+++ b/e2e/reverseSwap.spec.ts
@@ -5,11 +5,13 @@ import { SwapType } from "boltz-swaps/types";
 import { calculateSendAmount } from "../src/utils/calculate";
 import { btcToSat, satToBtc } from "../src/utils/denomination";
 import {
+    elementsGetDecodedTransaction,
     expectApproxAmount,
     expectApproxBtcAmount,
     generateBitcoinBlock,
     getBitcoinAddress,
     getBitcoinWalletTx,
+    getLiquidUnconfidentialAddress,
     getReversePairFees,
     payInvoiceLnd,
     payInvoiceLndBackground,
@@ -84,6 +86,66 @@ test.describe("reverseSwap", () => {
 
         const txInfo = JSON.parse(await getBitcoinWalletTx(txId!));
         expectApproxBtcAmount(txInfo.amount.toString(), receiveAmount);
+    });
+
+    test("Reverse swap LN/L-BTC to an unconfidential address", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        await page
+            .locator(
+                "div:nth-child(3) > .asset-wrap > .asset > .asset-selection > .arrow-down",
+            )
+            .click();
+        await page.getByTestId("select-L-BTC").click();
+
+        const receiveAmount = "0.001";
+        await page.getByTestId("receiveAmount").fill(receiveAmount);
+
+        const claimAddress = await getLiquidUnconfidentialAddress();
+        expect(claimAddress.startsWith("ert1")).toBe(true);
+        await page.getByTestId("onchainAddress").fill(claimAddress);
+
+        await page.getByTestId("create-swap-button").click();
+
+        await page.locator("span[class='btn']").click();
+        const invoice = await page.evaluate(() =>
+            navigator.clipboard.readText(),
+        );
+        await payInvoiceLnd(invoice);
+
+        const txIdLink = page.getByText("open claim transaction");
+        await expect(txIdLink).toBeVisible({ timeout: 30_000 });
+
+        // Liquid claim links carry a "#blinded=" fragment; strip it for the txid
+        const txId = (await txIdLink.getAttribute("href"))!
+            .split("/")
+            .pop()!
+            .split("#")[0];
+
+        const tx = await elementsGetDecodedTransaction(txId);
+
+        const claimed = tx.vout.find(
+            (out) => out.scriptPubKey.address === claimAddress,
+        );
+        expect(claimed).toBeDefined();
+        expect(btcToSat(BigNumber(claimed!.value!)).toNumber()).toEqual(
+            btcToSat(BigNumber(receiveAmount)).toNumber(),
+        );
+
+        // boltz-core injects it because no other output is blinded
+        expect(
+            tx.vout.filter((out) => out.scriptPubKey.type === "nulldata"),
+        ).toHaveLength(1);
+
+        const fee = tx.vout.find((out) => out.scriptPubKey.type === "fee");
+        expect(fee).toBeDefined();
+
+        // Elements relays at 0.1 sat/vbyte with truncating division
+        expect(
+            btcToSat(BigNumber(fee!.value!)).toNumber(),
+        ).toBeGreaterThanOrEqual(Math.floor(tx.discountvsize! / 10));
     });
 
     test("LN/BTC with zeroConf toggle automatically claims swap", async ({

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -79,6 +79,13 @@ export const getBitcoinAddress = (): Promise<string> =>
 export const getLiquidAddress = (): Promise<string> =>
     execCommand("elements-cli-sim-client getnewaddress");
 
+export const getLiquidUnconfidentialAddress = async (): Promise<string> => {
+    const info = await execCommand(
+        `elements-cli-sim-client getaddressinfo ${await getLiquidAddress()}`,
+    );
+    return (JSON.parse(info) as { unconfidential: string }).unconfidential;
+};
+
 export const bitcoinSendToAddress = (
     address: string,
     amount: string,
@@ -123,6 +130,12 @@ type DecodedTransaction = {
         vout: number;
         txinwitness?: string[];
     }[];
+    // Elements only; blinded outputs carry no `value`
+    vout: {
+        value?: number;
+        scriptPubKey: { type: string; address?: string };
+    }[];
+    discountvsize?: number;
 };
 
 type Unspent = {
@@ -480,6 +493,18 @@ export const getCurrentSwapId = (page: Page): string => {
     const url = new URL(page.url());
     return url.pathname.split("/").pop() ?? "";
 };
+
+// Esplora indexes by script, so this also resolves the unconfidential form of
+// a wallet address; `value` is absent for blinded outputs
+export const getAddressUtxos = async (
+    asset: AssetType,
+    address: string,
+): Promise<{ txid: string; vout: number; value?: number }[]> =>
+    (
+        await axios.get<{ txid: string; vout: number; value?: number }[]>(
+            `${config.assets![asset].blockExplorerApis![0].normal}/address/${address}/utxo`,
+        )
+    ).data;
 
 export const waitForUTXOs = async (
     asset: AssetType,

--- a/packages/boltz-swaps/integration/regtest.ts
+++ b/packages/boltz-swaps/integration/regtest.ts
@@ -64,6 +64,15 @@ export const getBitcoinAddress = (): Promise<string> =>
 export const getLiquidAddress = (): Promise<string> =>
     execInScripts("elements-cli-sim-client getnewaddress");
 
+export const getLiquidUnconfidentialAddress = async (): Promise<string> => {
+    const address = await getLiquidAddress();
+    const info = await execInScripts(
+        `elements-cli-sim-client getaddressinfo ${address}`,
+    );
+    const { unconfidential } = JSON.parse(info) as { unconfidential: string };
+    return unconfidential;
+};
+
 export const bitcoinSendToAddress = (
     address: string,
     coins: string,
@@ -142,6 +151,29 @@ export const waitForTxConfirmed = async (
         }
         await sleep(300);
     }
+};
+
+type EsploraVout = {
+    scriptpubkey_type: string;
+    scriptpubkey_address?: string;
+    value?: number;
+};
+
+export type EsploraTransaction = {
+    txid: string;
+    fee: number;
+    vout: EsploraVout[];
+};
+
+export const getEsploraTransaction = async (
+    asset: string,
+    txid: string,
+): Promise<EsploraTransaction> => {
+    const res = await fetch(`${ESPLORA_API[asset]}/tx/${txid}`);
+    if (!res.ok) {
+        throw new Error(`could not fetch ${asset} tx ${txid}: ${res.status}`);
+    }
+    return (await res.json()) as EsploraTransaction;
 };
 
 export const waitForAddressUtxos = async (

--- a/packages/boltz-swaps/integration/reverseSwap.regtest.spec.ts
+++ b/packages/boltz-swaps/integration/reverseSwap.regtest.spec.ts
@@ -5,12 +5,15 @@ import { createBoltzClient, getPairs } from "boltz-swaps";
 import { SwapStatus, isFailureStatus, isFinalStatus } from "boltz-swaps/status";
 import { SwapType } from "boltz-swaps/types";
 
+import { liquidUnconfidentialClaimExtra } from "../src/utxo/claim.ts";
 import {
     BOLTZ_API_URL,
     generateBitcoinBlock,
     generateLiquidBlock,
     getBitcoinAddress,
+    getEsploraTransaction,
     getLiquidAddress,
+    getLiquidUnconfidentialAddress,
     payInvoiceInBackground,
     setBackendSignersDisabled,
     sleep,
@@ -144,6 +147,91 @@ describe("reverse swap integration (regtest)", () => {
     test("LN -> L-BTC: cooperative reverse claim", async () => {
         await runReverseSwap({ to: "L-BTC" });
     }, 120_000);
+
+    describe("LN -> L-BTC: claim to an unconfidential address", () => {
+        const setUpClaim = async () => {
+            const claimKeys = makeKeys();
+            const preimage = crypto.getRandomValues(new Uint8Array(32));
+            const claimAddress = await getLiquidUnconfidentialAddress();
+            expect(claimAddress.startsWith("ert1")).toBe(true);
+
+            const pair = await reversePair("L-BTC");
+            const created = await boltz.swap.reverse.create({
+                from: "BTC",
+                to: "L-BTC",
+                invoiceAmount: 100_000,
+                preimageHash: hex.encode(sha256(preimage)),
+                pairHash: pair.hash,
+                claimPublicKey: hex.encode(claimKeys.publicKey),
+                claimAddress,
+            });
+
+            payInvoiceInBackground(created.invoice);
+            await waitUntilClaimable(created.id, "L-BTC", 90_000);
+
+            return {
+                claimKeys,
+                claimAddress,
+                created,
+                claimFee: pair.fees.minerFees.claim,
+                execute: (receiveAmount: number) =>
+                    boltz.swap.reverse.execute({
+                        createdSwap: created,
+                        to: "L-BTC",
+                        preimage: hex.encode(preimage),
+                        receiveAmount,
+                        claimAddress,
+                        claimKeys,
+                    }),
+            };
+        };
+
+        test("is accepted by Elements and pays the surcharge out of the claim output", async () => {
+            const { created, claimAddress, claimFee, execute } =
+                await setUpClaim();
+            const receiveAmount = created.onchainAmount - claimFee;
+
+            const result = await execute(receiveAmount);
+            expect(result.claimTransactionId).toMatch(/^[0-9a-f]{64}$/);
+
+            await generateLiquidBlock();
+            await waitForTxConfirmed("L-BTC", result.claimTransactionId);
+
+            const utxos = await waitForAddressUtxos("L-BTC", claimAddress);
+            const claimed = utxos.find(
+                (utxo) => utxo.txid === result.claimTransactionId,
+            );
+            expect(claimed).toBeDefined();
+            expect(claimed!.value).toBe(
+                receiveAmount - liquidUnconfidentialClaimExtra,
+            );
+            expect(result.receiveAmount).toBe(BigInt(claimed!.value));
+
+            const tx = await getEsploraTransaction(
+                "L-BTC",
+                result.claimTransactionId,
+            );
+            expect(tx.vout).toHaveLength(3);
+            expect(
+                tx.vout.filter((out) => out.scriptpubkey_type === "op_return"),
+            ).toHaveLength(1);
+            expect(tx.fee).toBe(claimFee + liquidUnconfidentialClaimExtra - 1);
+        }, 120_000);
+
+        // Shrinking the budget by the surcharge cancels it out, reproducing the
+        // pre-fix fee. Guards the test above against passing for free.
+        test("would be rejected without the surcharge", async () => {
+            const { created, claimFee, execute } = await setUpClaim();
+            const receiveAmount =
+                created.onchainAmount -
+                claimFee +
+                liquidUnconfidentialClaimExtra;
+
+            await expect(execute(receiveAmount)).rejects.toThrow(
+                /min relay fee not met/i,
+            );
+        }, 120_000);
+    });
 
     test("LN -> BTC: uncooperative reverse claim when the server refuses to co-sign", async () => {
         try {

--- a/packages/boltz-swaps/src/chain.ts
+++ b/packages/boltz-swaps/src/chain.ts
@@ -17,9 +17,11 @@ import type { ECKeys, UtxoAsset } from "./utxo/index.ts";
 
 export type UtxoClaimKeys = {
     claimKeys: ECKeys;
-    // Net amount (in sats) to deliver to the claim address; the gap to the
-    // gross lockup (`claimDetails.amount`) funds the claim transaction fee,
-    // typically the chain pair's `minerFees.user.claim`.
+    // Amount (in sats) requested at the claim address; the gap to the gross
+    // lockup (`claimDetails.amount`) funds the claim transaction fee, typically
+    // the chain pair's `minerFees.user.claim`. An unconfidential Liquid
+    // destination reserves up to `liquidUnconfidentialClaimExtra` more out of
+    // it, so the result's `receiveAmount` is what actually lands.
     receiveAmount: number;
     blindingKey?: string;
     cooperativeSource?: {
@@ -127,7 +129,7 @@ const claimUtxoDestination = async (
     await broadcastApiTransaction(asset, result.transactionHex);
     return {
         transactionHash: result.transactionId,
-        receiveAmount: BigInt(receiveAmount),
+        receiveAmount: BigInt(result.claimedAmount),
     };
 };
 

--- a/packages/boltz-swaps/src/reverse.ts
+++ b/packages/boltz-swaps/src/reverse.ts
@@ -19,7 +19,10 @@ export type ReverseExecuteArgs<A extends string = string> = {
     createdSwap: ReverseCreatedResponse;
     to: A;
     preimage: string;
-    // Net amount to the claim address; the gap to the gross lockup funds the fee.
+    // Amount requested at the claim address; the gap to the gross lockup funds
+    // the fee. An unconfidential Liquid destination reserves up to
+    // `liquidUnconfidentialClaimExtra` more out of it, so the result's
+    // `receiveAmount` is what actually lands.
     receiveAmount: number;
     claimAddress: string;
     claimKeys?: ECKeys;
@@ -156,6 +159,6 @@ export const executeReverseSwap = async <A extends string = string>(
     await broadcastApiTransaction(to, result.transactionHex);
     return {
         claimTransactionId: result.transactionId,
-        receiveAmount: BigInt(receiveAmount),
+        receiveAmount: BigInt(result.claimedAmount),
     };
 };

--- a/packages/boltz-swaps/src/utxo/claim.ts
+++ b/packages/boltz-swaps/src/utxo/claim.ts
@@ -73,6 +73,8 @@ export type ChainSwapUtxoClaimParams = {
 export type ChainSwapUtxoClaimResult = {
     transactionHex: string;
     transactionId: string;
+    // Value of the claim output, which is `receiveAmount` less any surcharge
+    claimedAmount: number;
 };
 
 export type ReverseUtxoClaimParams = {
@@ -182,7 +184,7 @@ const buildAdjustedTaprootClaim = async (params: {
     ] as unknown as (ClaimDetails & { blindingPrivateKey?: Uint8Array })[];
 
     const decoded = decodeAddress(asset, params.claimAddress, network);
-    const claimTx = await createAdjustedClaim(
+    const { claimTx, claimedAmount } = await createAdjustedClaim(
         asset,
         params.receiveAmount,
         details,
@@ -193,7 +195,7 @@ const buildAdjustedTaprootClaim = async (params: {
         decoded.blindingKey,
     );
 
-    return { claimTx, details, tweaked, boltzPublicKey };
+    return { claimTx, claimedAmount, details, tweaked, boltzPublicKey };
 };
 
 type ClaimBuild = Awaited<ReturnType<typeof buildAdjustedTaprootClaim>>;
@@ -214,13 +216,14 @@ const claimCooperativeUtxo = async (
     const cooperative = params.cooperative ?? true;
     const { asset, network } = params;
 
-    const { claimTx, details, tweaked, boltzPublicKey } =
+    const { claimTx, claimedAmount, details, tweaked, boltzPublicKey } =
         await buildAdjustedTaprootClaim({ ...params, cooperative });
 
     if (!cooperative) {
         return {
             transactionHex: txToHex(claimTx),
             transactionId: txToId(claimTx),
+            claimedAmount,
         };
     }
 
@@ -244,6 +247,7 @@ const claimCooperativeUtxo = async (
         return {
             transactionHex: txToHex(claimTx),
             transactionId: txToId(claimTx),
+            claimedAmount,
         };
     } catch (e) {
         getLogger().warn(warnLabel, e);
@@ -321,6 +325,45 @@ export const claimReverseUtxo = (
         "Uncooperative reverse Taproot claim because",
     );
 
+// Spending blinded inputs into an unconfidential destination leaves no blinded
+// output, so boltz-core injects a blinded 1 sat OP_RETURN and funds it by
+// paying `fee - 1`. That sat, plus what the extra output costs at Liquid's
+// 0.1 sat/vbyte floor: it adds 45 discounted vbytes, and because the floor
+// truncates, `floor((v + 45) / 10) - floor(v / 10)` is 4 or 5 depending on
+// `v % 10`. 6 is the minimum that covers every alignment, not a padded value.
+export const liquidUnconfidentialClaimExtra = 6;
+
+// The surcharge comes out of the claim output, so the amount that lands is
+// `receiveAmount` minus this. Returns 0 for an address that cannot be decoded:
+// the claim would throw before reaching the surcharge anyway.
+export const unconfidentialClaimSurcharge = (
+    asset: string,
+    claimAddress: string,
+    network: UtxoNetwork,
+): number => {
+    if (asset !== LBTC) {
+        return 0;
+    }
+
+    try {
+        return decodeAddress(asset, claimAddress, network).blindingKey ===
+            undefined
+            ? liquidUnconfidentialClaimExtra
+            : 0;
+    } catch {
+        return 0;
+    }
+};
+
+const needsBlindedOpReturn = (
+    asset: string,
+    claimDetails: { blindingPrivateKey?: Uint8Array }[],
+    blindingKey?: Buffer,
+) =>
+    asset === LBTC &&
+    blindingKey === undefined &&
+    claimDetails.some((details) => details.blindingPrivateKey !== undefined);
+
 const createAdjustedClaim = async (
     asset: string,
     receiveAmount: number,
@@ -343,20 +386,39 @@ const createAdjustedClaim = async (
         inputSum += await getOutputAmount(asset, details as never);
     }
 
-    const feeBudget = Math.floor(inputSum - receiveAmount);
-    if (feeBudget < 0) {
+    // Comes out of the claim output: boltz-core sizes it as `inputSum - fee`
+    const extra = needsBlindedOpReturn(asset, claimDetails, blindingKey)
+        ? liquidUnconfidentialClaimExtra
+        : 0;
+
+    const feeBudget = Math.floor(inputSum - receiveAmount) + extra;
+    if (feeBudget < extra) {
         throw new Error(
             `cannot construct claim transaction: receiveAmount ${receiveAmount} exceeds available input sum ${inputSum}`,
         );
     }
+    if (extra > 0) {
+        if (inputSum - feeBudget <= 0) {
+            throw new Error(
+                `cannot construct claim transaction: receiveAmount ${receiveAmount} does not cover the ${extra} sat surcharge of an unconfidential destination`,
+            );
+        }
+
+        getLogger().debug(
+            `Reserved ${extra} sat for the blinded OP_RETURN of an unconfidential ${asset} claim`,
+        );
+    }
     const constructClaimTransaction = getConstructClaimTransaction(asset);
 
-    return constructClaimTransaction(
-        claimDetails,
-        destination,
-        feeBudget,
-        true,
-        liquidNetwork,
-        blindingKey,
-    );
+    return {
+        claimTx: constructClaimTransaction(
+            claimDetails,
+            destination,
+            feeBudget,
+            true,
+            liquidNetwork,
+            blindingKey,
+        ),
+        claimedAmount: receiveAmount - extra,
+    };
 };

--- a/packages/boltz-swaps/src/utxo/index.ts
+++ b/packages/boltz-swaps/src/utxo/index.ts
@@ -15,6 +15,8 @@ export {
     claimChainSwapUtxo,
     claimReverseUtxo,
     createCooperativeSourceClaimSignature,
+    liquidUnconfidentialClaimExtra,
+    unconfidentialClaimSurcharge,
 } from "./claim.ts";
 export {
     type RefundLockup,

--- a/packages/boltz-swaps/tests/chainUtxo.spec.ts
+++ b/packages/boltz-swaps/tests/chainUtxo.spec.ts
@@ -70,6 +70,9 @@ beforeEach(() => {
     claimUtxoMock.mockResolvedValue({
         transactionHex: "rawtxhex",
         transactionId: "claim-txid",
+        // Deliberately not the requested amount: the result must report what
+        // the claim output actually carries
+        claimedAmount: 49_794,
     });
     setBoltzSwapsConfig({ network: "regtest" });
 });
@@ -80,7 +83,7 @@ describe("executeChainSwap: UTXO destination", () => {
 
         expect(result).toEqual({
             claimTransactionId: "claim-txid",
-            receiveAmount: 49_800n,
+            receiveAmount: 49_794n,
         });
         expect(claimUtxoMock).toHaveBeenCalledTimes(1);
         expect(claimUtxoMock).toHaveBeenCalledWith(

--- a/packages/boltz-swaps/tests/reverse.spec.ts
+++ b/packages/boltz-swaps/tests/reverse.spec.ts
@@ -115,6 +115,9 @@ beforeEach(() => {
     claimReverseUtxoMock.mockResolvedValue({
         transactionHex: "rawtxhex",
         transactionId: "claim-txid",
+        // Deliberately not the requested amount: the result must report what
+        // the claim output actually carries
+        claimedAmount: 49_794,
     });
     buildSwapContractsForAssetMock.mockResolvedValue({
         etherSwap: { address: "0xe" },
@@ -216,7 +219,7 @@ describe("executeReverseSwap: UTXO destination", () => {
 
         expect(result).toEqual({
             claimTransactionId: "claim-txid",
-            receiveAmount: 49_800n,
+            receiveAmount: 49_794n,
         });
         expect(claimReverseUtxoMock).toHaveBeenCalledTimes(1);
         expect(claimReverseUtxoMock).toHaveBeenCalledWith(

--- a/packages/boltz-swaps/tests/utxo/claim.spec.ts
+++ b/packages/boltz-swaps/tests/utxo/claim.spec.ts
@@ -8,6 +8,7 @@ import {
     type CooperativeSourceClaimInput,
     claimChainSwapUtxo,
     createCooperativeSourceClaimSignature,
+    liquidUnconfidentialClaimExtra,
 } from "../../src/utxo/claim.ts";
 import type * as MusigModule from "../../src/utxo/musig.ts";
 import type * as TransactionModule from "../../src/utxo/transaction.ts";
@@ -244,6 +245,7 @@ describe("claimChainSwapUtxo cooperative happy path", () => {
         expect(result).toEqual({
             transactionHex: "cohex",
             transactionId: "coid",
+            claimedAmount: 50_000,
         });
     });
 
@@ -325,6 +327,7 @@ describe("createCooperativeSourceClaimSignature eligibility", () => {
         expect(result).toEqual({
             transactionHex: "cohex",
             transactionId: "coid",
+            claimedAmount: 50_000,
         });
     });
 
@@ -357,6 +360,7 @@ describe("createCooperativeSourceClaimSignature eligibility", () => {
         expect(result).toEqual({
             transactionHex: "cohex",
             transactionId: "coid",
+            claimedAmount: 50_000,
         });
     });
 });
@@ -382,6 +386,7 @@ describe("uncooperative fallback", () => {
         expect(result).toEqual({
             transactionHex: "cohex",
             transactionId: "coid",
+            claimedAmount: 50_000,
         });
     });
 });
@@ -399,6 +404,7 @@ describe("non-cooperative branch", () => {
         expect(result).toEqual({
             transactionHex: "cohex",
             transactionId: "coid",
+            claimedAmount: 50_000,
         });
     });
 });
@@ -484,6 +490,86 @@ describe("L-BTC specific paths", () => {
         expect(constructClaimTransaction.mock.calls[0][5]).toBe(
             decodedBlindingKey,
         );
+    });
+
+    test("reserves the unconfidential surcharge when blinded inputs go to an unconfidential destination", async () => {
+        mocks.getOutputAmount.mockResolvedValue(60_000);
+        mocks.decodeAddress.mockReturnValue({
+            script: new Uint8Array([0x00, 0x14]),
+            blindingKey: undefined,
+        });
+
+        await claimChainSwapUtxo(
+            baseParams({
+                asset: "L-BTC",
+                cooperative: false,
+                blindingKey: "ffeedd",
+                receiveAmount: 50_000,
+            }),
+        );
+
+        expect(constructClaimTransaction.mock.calls[0][2]).toBe(
+            10_000 + liquidUnconfidentialClaimExtra,
+        );
+    });
+
+    test("does not reserve the surcharge for a confidential destination", async () => {
+        mocks.getOutputAmount.mockResolvedValue(60_000);
+        mocks.decodeAddress.mockReturnValue({
+            script: new Uint8Array([0x00, 0x14]),
+            blindingKey: Buffer.from("aabbcc", "hex"),
+        });
+
+        await claimChainSwapUtxo(
+            baseParams({
+                asset: "L-BTC",
+                cooperative: false,
+                blindingKey: "ffeedd",
+                receiveAmount: 50_000,
+            }),
+        );
+
+        expect(constructClaimTransaction.mock.calls[0][2]).toBe(10_000);
+    });
+
+    test("does not reserve the surcharge when the inputs are not blinded", async () => {
+        mocks.getOutputAmount.mockResolvedValue(60_000);
+        mocks.decodeAddress.mockReturnValue({
+            script: new Uint8Array([0x00, 0x14]),
+            blindingKey: undefined,
+        });
+
+        await claimChainSwapUtxo(
+            baseParams({
+                asset: "L-BTC",
+                cooperative: false,
+                blindingKey: undefined,
+                receiveAmount: 50_000,
+            }),
+        );
+
+        expect(constructClaimTransaction.mock.calls[0][2]).toBe(10_000);
+    });
+
+    test("rejects a claim too small to absorb the unconfidential surcharge", async () => {
+        // Whole lockup is the receive amount: nothing left for the surcharge
+        mocks.getOutputAmount.mockResolvedValue(liquidUnconfidentialClaimExtra);
+        mocks.decodeAddress.mockReturnValue({
+            script: new Uint8Array([0x00, 0x14]),
+            blindingKey: undefined,
+        });
+
+        await expect(
+            claimChainSwapUtxo(
+                baseParams({
+                    asset: "L-BTC",
+                    cooperative: false,
+                    blindingKey: "ffeedd",
+                    receiveAmount: liquidUnconfidentialClaimExtra,
+                }),
+            ),
+        ).rejects.toThrow(/does not cover the .* sat surcharge/);
+        expect(constructClaimTransaction).not.toHaveBeenCalled();
     });
 
     test("BTC asset skips secp init and leaves blindingPrivateKey and liquid network undefined", async () => {

--- a/packages/boltz-swaps/tests/utxo/claimReverse.spec.ts
+++ b/packages/boltz-swaps/tests/utxo/claimReverse.spec.ts
@@ -197,6 +197,7 @@ describe("claimReverseUtxo cooperative happy path", () => {
         expect(result).toEqual({
             transactionHex: "cohex",
             transactionId: "coid",
+            claimedAmount: 50_000,
         });
     });
 });
@@ -215,6 +216,7 @@ describe("claimReverseUtxo uncooperative fallback", () => {
         expect(result).toEqual({
             transactionHex: "cohex",
             transactionId: "coid",
+            claimedAmount: 50_000,
         });
     });
 });
@@ -230,6 +232,7 @@ describe("claimReverseUtxo non-cooperative branch", () => {
         expect(result).toEqual({
             transactionHex: "cohex",
             transactionId: "coid",
+            claimedAmount: 50_000,
         });
     });
 });

--- a/packages/boltz-swaps/tests/utxo/claimUnconfidential.spec.ts
+++ b/packages/boltz-swaps/tests/utxo/claimUnconfidential.spec.ts
@@ -1,0 +1,236 @@
+import { secp256k1 } from "@noble/curves/secp256k1.js";
+import { OutputType } from "boltz-core";
+import { Buffer } from "buffer";
+import {
+    Blinder,
+    Creator,
+    CreatorInput,
+    Extractor,
+    Finalizer,
+    type Transaction as LiquidTransaction,
+    Pset,
+    Updater,
+    ZKPGenerator,
+    ZKPValidator,
+    confidential,
+    networks,
+    witnessStackToScriptWitness,
+} from "liquidjs-lib";
+
+import { liquidUnconfidentialClaimExtra } from "../../src/utxo/claim.ts";
+import { utxoSecp } from "../../src/utxo/lazy.ts";
+import { getConstructClaimTransaction } from "../../src/utxo/transaction.ts";
+
+const network = networks.regtest;
+
+const LOCKUP_VALUE = 100_000;
+
+// Elements prices transactions at 0.1 sat/vbyte with truncating division
+const minRelayFee = (vsize: number) => Math.floor((100 * vsize) / 1000);
+
+const p2tr = (xOnlyPubkey: Uint8Array) =>
+    Buffer.concat([Buffer.of(0x51, 0x20), Buffer.from(xOnlyPubkey)]);
+
+const explicitValue = (value: number) => {
+    const buf = Buffer.alloc(9);
+    buf.writeUInt8(1, 0);
+    buf.writeBigUInt64BE(BigInt(value), 1);
+    return buf;
+};
+
+// Stands in for the server lockup; never broadcast, so its input can be fake
+const buildBlindedLockup = (
+    secp: unknown,
+    script: Buffer,
+    blindingPublicKey: Buffer,
+) => {
+    const pset = Creator.newPset();
+    const updater = new Updater(pset);
+
+    pset.addInput(
+        new CreatorInput(
+            Buffer.from(secp256k1.utils.randomSecretKey()).toString("hex"),
+            0,
+            0xffffffff,
+        ).toPartialInput(),
+    );
+    updater.addInWitnessUtxo(0, {
+        asset: Buffer.concat([
+            Buffer.of(0x01),
+            Buffer.from(network.assetHash, "hex").reverse(),
+        ]),
+        value: explicitValue(LOCKUP_VALUE + 1_000),
+        nonce: Buffer.of(0x00),
+        script,
+    });
+    updater.addInSighashType(0, 0);
+    updater.addOutputs([
+        {
+            script,
+            blindingPublicKey,
+            asset: network.assetHash,
+            amount: LOCKUP_VALUE,
+            blinderIndex: 0,
+        },
+        { amount: 1_000, asset: network.assetHash },
+    ]);
+
+    const generator = new ZKPGenerator(
+        secp as never,
+        ZKPGenerator.WithBlindingKeysOfInputs([undefined as never]),
+    );
+    const outputBlindingArgs = generator.blindOutputs(
+        pset,
+        Pset.ECCKeysGenerator((secp as { ecc: never }).ecc),
+    );
+    new Blinder(
+        pset,
+        generator.unblindInputs(pset),
+        new ZKPValidator(secp as never),
+        generator,
+    ).blindLast({ outputBlindingArgs });
+
+    new Finalizer(pset).finalizeInput(0, () => ({
+        finalScriptWitness: witnessStackToScriptWitness([Buffer.alloc(64)]),
+    }));
+
+    return Extractor.extract(pset);
+};
+
+const feeOutputValue = (tx: LiquidTransaction) => {
+    const feeOutput = tx.outs.find((out) => out.script.length === 0);
+    expect(feeOutput).toBeDefined();
+    return confidential.confidentialValueToSatoshi(
+        Buffer.from(feeOutput!.value),
+    );
+};
+
+const explicitOutputValue = (tx: LiquidTransaction, script: Buffer) => {
+    const out = tx.outs.find((o) => Buffer.from(o.script).equals(script));
+    expect(out).toBeDefined();
+    return confidential.confidentialValueToSatoshi(Buffer.from(out!.value));
+};
+
+describe("unconfidential Liquid claims", () => {
+    let claimToConfidential: LiquidTransaction;
+    let claimToUnconfidential: LiquidTransaction;
+    let claimToUnconfidentialWithExtra: LiquidTransaction;
+    let destinationScript: Buffer;
+    let feeBudget: number;
+    let receiveAmount: number;
+
+    beforeAll(async () => {
+        const { secpZkp } = await utxoSecp.get();
+
+        const swapKey = secp256k1.utils.randomSecretKey();
+        const swapPublicKey = secp256k1.getPublicKey(swapKey, true).slice(1);
+        const swapScript = p2tr(swapPublicKey);
+
+        const lockupBlindingKey = secp256k1.utils.randomSecretKey();
+        const lockupTx = buildBlindedLockup(
+            secpZkp,
+            swapScript,
+            Buffer.from(secp256k1.getPublicKey(lockupBlindingKey, true)),
+        );
+
+        destinationScript = p2tr(
+            secp256k1
+                .getPublicKey(secp256k1.utils.randomSecretKey(), true)
+                .slice(1),
+        );
+        const destinationBlindingKey = Buffer.from(
+            secp256k1.getPublicKey(secp256k1.utils.randomSecretKey(), true),
+        );
+
+        // A fresh copy per construction: boltz-core mutates what it is given
+        const details = () => [
+            {
+                ...lockupTx.outs[0],
+                vout: 0,
+                transactionId: lockupTx.getId(),
+                type: OutputType.Taproot,
+                cooperative: true,
+                privateKey: swapKey,
+                internalKey: swapPublicKey,
+                blindingPrivateKey: Buffer.from(lockupBlindingKey),
+                preimage: Buffer.alloc(32),
+            },
+        ];
+
+        const constructClaim = getConstructClaimTransaction("L-BTC");
+        const construct = (fee: number, blindingKey?: Buffer) =>
+            constructClaim(
+                details() as never,
+                destinationScript,
+                fee,
+                true,
+                network,
+                blindingKey,
+            ) as LiquidTransaction;
+
+        // Size does not depend on the fee, so measure first, then budget what
+        // the server would quote for the confidential shape: the bare minimum
+        feeBudget = minRelayFee(
+            construct(1_000, destinationBlindingKey).virtualSize(true),
+        );
+        receiveAmount = LOCKUP_VALUE - feeBudget;
+
+        claimToConfidential = construct(feeBudget, destinationBlindingKey);
+        claimToUnconfidential = construct(feeBudget);
+        claimToUnconfidentialWithExtra = construct(
+            feeBudget + liquidUnconfidentialClaimExtra,
+        );
+    });
+
+    test("pays the full fee to a confidential destination", () => {
+        expect(claimToConfidential.outs).toHaveLength(2);
+        expect(feeOutputValue(claimToConfidential)).toEqual(feeBudget);
+    });
+
+    test("silently pays one sat less to an unconfidential destination", () => {
+        expect(claimToUnconfidential.outs).toHaveLength(3);
+        expect(feeOutputValue(claimToUnconfidential)).toEqual(feeBudget - 1);
+    });
+
+    test("the surcharge covers the OP_RETURN at every vsize alignment", () => {
+        const sizeDelta =
+            claimToUnconfidential.virtualSize(true) -
+            claimToConfidential.virtualSize(true);
+
+        // Truncation makes the required-fee delta depend on vsize % 10, and
+        // this fixture only measures one alignment
+        const worstCase = Math.max(
+            ...Array.from(
+                { length: 10 },
+                (_, remainder) =>
+                    minRelayFee(1_000 + remainder + sizeDelta) -
+                    minRelayFee(1_000 + remainder),
+            ),
+        );
+
+        expect(liquidUnconfidentialClaimExtra).toEqual(worstCase + 1);
+    });
+
+    test("takes the surcharge out of the claim output, not the fee", () => {
+        expect(feeOutputValue(claimToUnconfidentialWithExtra)).toEqual(
+            feeBudget + liquidUnconfidentialClaimExtra - 1,
+        );
+        expect(
+            explicitOutputValue(
+                claimToUnconfidentialWithExtra,
+                destinationScript,
+            ),
+        ).toEqual(receiveAmount - liquidUnconfidentialClaimExtra);
+    });
+
+    test("meets the min relay fee, which it would not without the surcharge", () => {
+        const required = minRelayFee(
+            claimToUnconfidentialWithExtra.virtualSize(true),
+        );
+
+        expect(feeOutputValue(claimToUnconfidential)).toBeLessThan(required);
+        expect(
+            feeOutputValue(claimToUnconfidentialWithExtra),
+        ).toBeGreaterThanOrEqual(required);
+    });
+});

--- a/packages/boltz-swaps/tests/utxo/claimUnconfidentialEndToEnd.spec.ts
+++ b/packages/boltz-swaps/tests/utxo/claimUnconfidentialEndToEnd.spec.ts
@@ -1,0 +1,238 @@
+import { secp256k1 } from "@noble/curves/secp256k1.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { hex } from "@scure/base";
+import { SwapTreeSerializer } from "boltz-core";
+import { reverseSwapTree } from "boltz-core/liquid";
+import { Buffer } from "buffer";
+import {
+    Blinder,
+    Creator,
+    CreatorInput,
+    Extractor,
+    Finalizer,
+    address as LiquidAddress,
+    type Transaction as LiquidTransaction,
+    Pset,
+    Updater,
+    ZKPGenerator,
+    ZKPValidator,
+    confidential,
+    networks,
+    witnessStackToScriptWitness,
+} from "liquidjs-lib";
+
+import {
+    claimReverseUtxo,
+    liquidUnconfidentialClaimExtra,
+} from "../../src/utxo/claim.ts";
+import { utxoSecp } from "../../src/utxo/lazy.ts";
+import { createMusig, tweakMusig } from "../../src/utxo/musig.ts";
+import { getTransaction } from "../../src/utxo/transaction.ts";
+
+const network = networks.regtest;
+
+const LOCKUP_VALUE = 100_000;
+const RECEIVE_AMOUNT = 99_970;
+const INTENDED_FEE = LOCKUP_VALUE - RECEIVE_AMOUNT;
+
+const keyPair = () => {
+    const privateKey = secp256k1.utils.randomSecretKey();
+    return { privateKey, publicKey: secp256k1.getPublicKey(privateKey, true) };
+};
+
+const explicitValue = (value: number) => {
+    const buf = Buffer.alloc(9);
+    buf.writeUInt8(1, 0);
+    buf.writeBigUInt64BE(BigInt(value), 1);
+    return buf;
+};
+
+const sat = (value: Uint8Array) =>
+    confidential.confidentialValueToSatoshi(Buffer.from(value));
+
+// Pays the tweaked musig key so `detectSwap` finds it; never broadcast
+const buildBlindedLockup = (
+    secp: unknown,
+    lockupScript: Buffer,
+    blindingPublicKey: Buffer,
+) => {
+    const pset = Creator.newPset();
+    const updater = new Updater(pset);
+
+    pset.addInput(
+        new CreatorInput(
+            Buffer.from(secp256k1.utils.randomSecretKey()).toString("hex"),
+            0,
+            0xffffffff,
+        ).toPartialInput(),
+    );
+    updater.addInWitnessUtxo(0, {
+        asset: Buffer.concat([
+            Buffer.of(0x01),
+            Buffer.from(network.assetHash, "hex").reverse(),
+        ]),
+        value: explicitValue(LOCKUP_VALUE + 1_000),
+        nonce: Buffer.of(0x00),
+        script: lockupScript,
+    });
+    updater.addInSighashType(0, 0);
+    updater.addOutputs([
+        {
+            script: lockupScript,
+            blindingPublicKey,
+            asset: network.assetHash,
+            amount: LOCKUP_VALUE,
+            blinderIndex: 0,
+        },
+        { amount: 1_000, asset: network.assetHash },
+    ]);
+
+    const generator = new ZKPGenerator(
+        secp as never,
+        ZKPGenerator.WithBlindingKeysOfInputs([undefined as never]),
+    );
+    const outputBlindingArgs = generator.blindOutputs(
+        pset,
+        Pset.ECCKeysGenerator((secp as { ecc: never }).ecc),
+    );
+    new Blinder(
+        pset,
+        generator.unblindInputs(pset),
+        new ZKPValidator(secp as never),
+        generator,
+    ).blindLast({ outputBlindingArgs });
+
+    new Finalizer(pset).finalizeInput(0, () => ({
+        finalScriptWitness: witnessStackToScriptWitness([Buffer.alloc(64)]),
+    }));
+
+    return Extractor.extract(pset);
+};
+
+describe("claimReverseUtxo to an unconfidential Liquid address", () => {
+    let claimTo: (confidentialDestination: boolean) => Promise<{
+        tx: LiquidTransaction;
+        claimedAmount: number;
+        destinationScript: Buffer;
+    }>;
+
+    beforeAll(async () => {
+        const { secpZkp } = await utxoSecp.get();
+
+        const claimKeys = keyPair();
+        const serverKeys = keyPair();
+        const preimage = Buffer.alloc(32, 9);
+        const lockupBlindingKey = secp256k1.utils.randomSecretKey();
+
+        const tree = reverseSwapTree(
+            sha256(preimage),
+            claimKeys.publicKey,
+            serverKeys.publicKey,
+            1_000,
+        );
+        const tweaked = tweakMusig(
+            "L-BTC",
+            createMusig(claimKeys, serverKeys.publicKey),
+            tree.tree,
+        );
+        const lockupScript = Buffer.concat([
+            Buffer.of(0x51, 0x20),
+            Buffer.from(tweaked.aggPubkey),
+        ]);
+
+        const lockupTx = buildBlindedLockup(
+            secpZkp,
+            lockupScript,
+            Buffer.from(secp256k1.getPublicKey(lockupBlindingKey, true)),
+        );
+
+        const destinationScript = Buffer.concat([
+            Buffer.of(0x00, 0x14),
+            Buffer.alloc(20, 3),
+        ]);
+        const unconfidentialAddress = LiquidAddress.fromOutputScript(
+            destinationScript,
+            network,
+        );
+        const confidentialAddress = LiquidAddress.toConfidential(
+            unconfidentialAddress,
+            Buffer.from(
+                secp256k1.getPublicKey(secp256k1.utils.randomSecretKey(), true),
+            ),
+        );
+
+        claimTo = async (confidentialDestination: boolean) => {
+            const result = await claimReverseUtxo({
+                id: "e2e",
+                asset: "L-BTC",
+                network: "regtest",
+                serverPublicKey: hex.encode(serverKeys.publicKey),
+                swapTree: SwapTreeSerializer.serializeSwapTree(tree) as never,
+                blindingKey: hex.encode(lockupBlindingKey),
+                claimKeys,
+                preimage,
+                claimAddress: confidentialDestination
+                    ? confidentialAddress
+                    : unconfidentialAddress,
+                receiveAmount: RECEIVE_AMOUNT,
+                lockupTxHex: lockupTx.toHex(),
+                // Skips the server round trip; the fee arithmetic is the same
+                cooperative: false,
+            });
+
+            return {
+                tx: getTransaction("L-BTC").fromHex(
+                    result.transactionHex,
+                ) as LiquidTransaction,
+                claimedAmount: result.claimedAmount,
+                destinationScript,
+            };
+        };
+    });
+
+    test("leaves a confidential claim untouched", async () => {
+        const { tx, claimedAmount } = await claimTo(true);
+
+        expect(tx.outs).toHaveLength(2);
+        expect(sat(tx.outs.find((o) => o.script.length === 0)!.value)).toEqual(
+            INTENDED_FEE,
+        );
+        expect(claimedAmount).toEqual(RECEIVE_AMOUNT);
+    });
+
+    test("reserves the surcharge out of the claim output", async () => {
+        const { tx, claimedAmount, destinationScript } = await claimTo(false);
+
+        expect(tx.outs).toHaveLength(3);
+
+        const claimOutput = tx.outs.find((o) =>
+            Buffer.from(o.script).equals(destinationScript),
+        );
+        const opReturn = tx.outs.find(
+            (o) => o.script.length === 1 && o.script[0] === 0x6a,
+        );
+        const feeOutput = tx.outs.find((o) => o.script.length === 0);
+
+        expect(claimOutput).toBeDefined();
+        expect(opReturn).toBeDefined();
+
+        expect(sat(claimOutput!.value)).toEqual(
+            RECEIVE_AMOUNT - liquidUnconfidentialClaimExtra,
+        );
+        expect(claimedAmount).toEqual(sat(claimOutput!.value));
+        expect(sat(feeOutput!.value)).toEqual(
+            INTENDED_FEE + liquidUnconfidentialClaimExtra - 1,
+        );
+    });
+
+    // Only checkable unconfidential: a confidential claim output is blinded
+    test("conserves the lockup value", async () => {
+        const { tx } = await claimTo(false);
+
+        const explicitTotal = tx.outs
+            .filter((out) => out.value[0] === 1)
+            .reduce((sum, out) => sum + sat(out.value), 0);
+        // boltz-core hardcodes the blinded OP_RETURN at 1 sat
+        expect(explicitTotal + 1).toEqual(LOCKUP_VALUE);
+    });
+});

--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -45,7 +45,6 @@ import Pair, {
     type EncodedHop,
     toDexAmount,
 } from "../utils/Pair";
-import { calculateSendAmount } from "../utils/calculate";
 import { canCommitSubmarineSendAmount } from "../utils/commitmentSwap";
 import { validateAddress as validateOnchainAddress } from "../utils/compat";
 import {
@@ -60,7 +59,10 @@ import { handleCreateSwapError } from "../utils/handleCreateSwapError";
 import type { HardwareSigner } from "../utils/hardware/HardwareSigner";
 import { getDestinationAddress, getPair } from "../utils/helper";
 import { getAssetByBip21Prefix } from "../utils/invoice";
-import { findMagicRoutingHint } from "../utils/magicRoutingHint";
+import {
+    findMagicRoutingHint,
+    magicRoutingHintAmounts,
+} from "../utils/magicRoutingHint";
 import { estimateFeesPerGas } from "../utils/provider";
 import { gasTopUpSupported } from "../utils/quoter";
 import { canSendAsset } from "../utils/selectableAsset";
@@ -733,21 +735,18 @@ const CreateButton = () => {
                             throw new Error("invalid_bip21_amount");
                         }
 
-                        const mrhSendAmount = calculateSendAmount(
+                        const mrhAmounts = magicRoutingHintAmounts(
+                            chainPair,
                             bip21AmountSats,
-                            chainPair.fees.percentage,
-                            chainPair.fees.minerFees.server +
-                                chainPair.fees.minerFees.user.claim,
-                            SwapType.Chain,
+                            bip21Asset,
+                            chainAddress,
                         );
 
                         const savedFees = getMagicRoutingHintSavedFees({
                             pairs,
                             assetSend,
-                            addressValid,
-                            onchainAddress,
-                            sendAmount: () => mrhSendAmount,
-                            assetReceive: () => bip21Asset,
+                            sendAmount: () => mrhAmounts.sendAmount,
+                            unconfidentialExtra: mrhAmounts.surcharge,
                         });
 
                         if (BigNumber(savedFees).isLessThanOrEqualTo(0)) {
@@ -767,8 +766,8 @@ const CreateButton = () => {
                             ),
                         );
                         setOnchainAddress(chainAddress);
-                        setReceiveAmount(bip21AmountSats);
-                        setSendAmount(mrhSendAmount);
+                        setReceiveAmount(mrhAmounts.receiveAmount);
+                        setSendAmount(mrhAmounts.sendAmount);
 
                         log.debug("Creating MRH swap");
                         const mrhRescue = rescueFile();

--- a/src/components/Fees.tsx
+++ b/src/components/Fees.tsx
@@ -10,21 +10,16 @@ import {
 } from "solid-js";
 
 import { config } from "../config";
-import { LBTC } from "../consts/Assets";
 import { useCreateContext } from "../context/Create";
 import { useGlobalContext } from "../context/Global";
 import { useWeb3Signer } from "../context/Web3";
-import { isConfidentialAddress } from "../utils/compat";
 import { GasAbstractionType } from "../utils/swapCreator";
+import { claimSurchargeForAddress } from "../utils/unconfidential";
 import { getClaimAddress } from "./CreateButton";
 import FeesCollapse from "./FeesCollapse";
 import Denomination from "./settings/Denomination";
 
 const ppmFactor = 10_000;
-
-// When sending to an unconfidential address, we need to add an extra
-// confidential OP_RETURN output with 1 sat inside
-export const unconfidentialExtra = 5;
 
 const gasAbstractionExtraGasCost = 157_000n;
 
@@ -47,7 +42,8 @@ export const getFeeHighlightClass = (
     return "";
 };
 
-export const isToUnconfidentialLiquid = ({
+// Mirrored in the quote so the amount shown is the amount that lands
+export const quoteClaimSurcharge = ({
     assetReceive,
     addressValid,
     onchainAddress,
@@ -55,10 +51,10 @@ export const isToUnconfidentialLiquid = ({
     assetReceive: Accessor<string>;
     addressValid: Accessor<boolean>;
     onchainAddress: Accessor<string>;
-}) =>
-    assetReceive() === LBTC &&
-    addressValid() &&
-    !isConfidentialAddress(onchainAddress());
+}): number =>
+    addressValid()
+        ? claimSurchargeForAddress(assetReceive(), onchainAddress())
+        : 0;
 
 export const RoutingFee = () => {
     const { t } = useGlobalContext();
@@ -166,16 +162,13 @@ const Fees = () => {
 
             case SwapType.Reverse:
             case SwapType.Chain: {
-                let fee = pair().minerFees;
-                if (
-                    isToUnconfidentialLiquid({
+                const fee =
+                    pair().minerFees +
+                    quoteClaimSurcharge({
                         assetReceive,
                         addressValid,
                         onchainAddress,
-                    })
-                ) {
-                    fee += unconfidentialExtra;
-                }
+                    });
 
                 updateMinerFee(fee);
                 break;

--- a/src/components/OptimizedRoute.tsx
+++ b/src/components/OptimizedRoute.tsx
@@ -17,10 +17,6 @@ import { calculateBoltzFeeOnSend } from "../utils/calculate";
 import { formatAmount, formatDenomination } from "../utils/denomination";
 import { getPair, isMobile } from "../utils/helper";
 import type { ChainSwap } from "../utils/swapCreator";
-import {
-    unconfidentialExtra as extraFee,
-    isToUnconfidentialLiquid,
-} from "./Fees";
 import Tooltip from "./settings/Tooltip";
 
 const getTotalChainFees = ({
@@ -109,25 +105,13 @@ export const getMagicRoutingHintSavedFees = ({
     pairs,
     assetSend,
     sendAmount,
-    assetReceive,
-    addressValid,
-    onchainAddress,
+    unconfidentialExtra,
 }: {
     pairs: Accessor<Pairs | undefined>;
     assetSend: Accessor<string>;
     sendAmount: Accessor<BigNumber>;
-    assetReceive: Accessor<string>;
-    addressValid: Accessor<boolean>;
-    onchainAddress: Accessor<string>;
+    unconfidentialExtra: number;
 }) => {
-    const unconfidentialExtra = isToUnconfidentialLiquid({
-        assetReceive,
-        addressValid,
-        onchainAddress,
-    })
-        ? extraFee
-        : 0;
-
     const chainFee = getTotalChainFees({
         pairs,
         sendAmount,

--- a/src/context/Pay.tsx
+++ b/src/context/Pay.tsx
@@ -211,7 +211,7 @@ const PayProvider = (props: { children: JSX.Element }) => {
             ...output,
             blindingPrivateKey: parseBlindingKey(swap, false),
         } as never);
-        const receiveAmount = lockupAmount - (claimFee + 1);
+        const receiveAmount = lockupAmount - claimFee;
         if (receiveAmount <= 0) {
             throw new Error(
                 `recovered receive amount is not positive for swap ${swap.id}`,

--- a/src/pages/ClaimRescue.tsx
+++ b/src/pages/ClaimRescue.tsx
@@ -26,10 +26,6 @@ import {
 import BlockExplorer, {
     BlockExplorerTargetKind,
 } from "../components/BlockExplorer";
-import {
-    isToUnconfidentialLiquid,
-    unconfidentialExtra,
-} from "../components/Fees";
 import LoadingSpinner from "../components/LoadingSpinner";
 import SwapHeader from "../components/SwapHeader";
 import { getSwapIconAssets } from "../components/SwapIcons";
@@ -83,14 +79,6 @@ export const mapClaimableSwap = ({
         return undefined;
     }
 
-    const unconfidentialExtraFee = isToUnconfidentialLiquid({
-        assetReceive: () => swap.to,
-        addressValid: () => true,
-        onchainAddress: () => claim.lockupAddress,
-    })
-        ? unconfidentialExtra
-        : 0;
-
     if (swap.type === SwapType.Chain) {
         const refund = swap.refundDetails;
         if (refund === undefined && !isEvmAsset(swap.from)) {
@@ -103,8 +91,7 @@ export const mapClaimableSwap = ({
             assetReceive: swap.to,
             receiveAmount:
                 claim.amount -
-                ((pair as ChainPairTypeTaproot).fees.minerFees.user.claim +
-                    unconfidentialExtraFee),
+                (pair as ChainPairTypeTaproot).fees.minerFees.user.claim,
             version: OutputType.Taproot,
             claimPrivateKeyIndex: claim.keyIndex,
             claimDetails: {
@@ -135,8 +122,7 @@ export const mapClaimableSwap = ({
             swapTree: claim.tree,
             receiveAmount:
                 claim.amount -
-                ((pair as ReversePairTypeTaproot).fees.minerFees.claim +
-                    unconfidentialExtraFee),
+                (pair as ReversePairTypeTaproot).fees.minerFees.claim,
         };
     }
 

--- a/src/status/TransactionClaimed.tsx
+++ b/src/status/TransactionClaimed.tsx
@@ -28,6 +28,7 @@ import {
     getFinalAssetReceive,
     getPostBridgeDetail,
 } from "../utils/swapCreator";
+import { claimSurchargeForSwap } from "../utils/unconfidential";
 import Broadcasting from "./Broadcasting";
 
 const paymentValidationUrl = (invoice: string, preimage: string): string => {
@@ -93,12 +94,16 @@ const TransactionClaimed = (props: { bridgeStatusLink?: JSX.Element }) => {
 
     const receiveAmount = () => {
         const current = swap() as ChainSwap | ReverseSwap | SubmarineSwap;
+
+        // A post-position DEX output is denominated in the DEX asset, while the
+        // surcharge only ever comes out of the Boltz claim output
+        const amount =
+            current.dex?.position === SwapPosition.Post
+                ? (current.dex.quoteAmount ?? 0)
+                : (current.receiveAmount ?? 0) - claimSurchargeForSwap(current);
+
         return formatAmount(
-            BigNumber(
-                (current.dex?.position === SwapPosition.Post
-                    ? current.dex.quoteAmount
-                    : current.receiveAmount) ?? 0,
-            ),
+            BigNumber(amount),
             denomination(),
             separator(),
             getFinalAssetReceive(current),

--- a/src/status/TransactionLockupFailed.tsx
+++ b/src/status/TransactionLockupFailed.tsx
@@ -45,12 +45,15 @@ import {
     getFinalAssetReceive,
     getFinalAssetSend,
 } from "../utils/swapCreator";
+import { claimSurchargeForSwap } from "../utils/unconfidential";
 import SwapRefunded from "./SwapRefunded";
 
 type ReplacementQuote = {
     sentAmount: number;
     quote: number;
     receiveAmount: number;
+    // What the claim will deliver; `receiveAmount` is what it requests
+    landedReceiveAmount: number;
 };
 
 const applyReplacementQuote = (
@@ -146,7 +149,7 @@ const TransactionLockupFailed = (props: {
             const claimFee =
                 currentPairs[SwapType.Chain][chainSwap.assetSend][
                     chainSwap.assetReceive
-                ].fees.minerFees.user.claim + 1;
+                ].fees.minerFees.user.claim;
 
             const lockupTxHex = transactions.userLock.transaction.hex;
             let sentAmountSource = "swap.sendAmount";
@@ -194,6 +197,14 @@ const TransactionLockupFailed = (props: {
                   )
                 : boltzReceiveAmount;
 
+            // The surcharge comes out of the Boltz claim output; when a
+            // post-position DEX or bridge follows, the amount above is its
+            // output in a different asset
+            const surcharge =
+                getFinalAssetReceive(chainSwap) === chainSwap.assetReceive
+                    ? claimSurchargeForSwap(chainSwap)
+                    : 0;
+
             log.info(
                 `Prepared replacement quote for chain swap ${chainSwap.id}`,
                 {
@@ -205,6 +216,7 @@ const TransactionLockupFailed = (props: {
                         claimFee,
                         chainSwap.assetReceive,
                     ),
+                    surcharge,
                     boltzReceiveAmount: formatSwapAmountForLog(
                         boltzReceiveAmount,
                         chainSwap.assetReceive,
@@ -227,6 +239,7 @@ const TransactionLockupFailed = (props: {
                 quote: quote.amount,
                 sentAmount: outputAmount,
                 receiveAmount: receiveAmount.toNumber(),
+                landedReceiveAmount: receiveAmount.minus(surcharge).toNumber(),
             };
         } catch (e) {
             log.warn(
@@ -401,7 +414,7 @@ const TransactionLockupFailed = (props: {
                         <ImArrowDown size={15} style={{ opacity: 0.5 }} />
                         <Amount
                             label={"will_receive"}
-                            amount={newQuote()!.receiveAmount}
+                            amount={newQuote()!.landedReceiveAmount}
                             asset={getFinalAssetReceive(swap() as ChainSwap)}
                         />
                     </div>

--- a/src/utils/magicRoutingHint.ts
+++ b/src/utils/magicRoutingHint.ts
@@ -1,7 +1,37 @@
+import type BigNumber from "bignumber.js";
 import bolt11, { type RoutingInfo } from "bolt11";
+import type { ChainPairTypeTaproot } from "boltz-swaps/client";
+import { SwapType } from "boltz-swaps/types";
 import log from "loglevel";
 
+import { calculateSendAmount } from "./calculate";
+import { claimSurchargeForAddress } from "./unconfidential";
+
 const magicRoutingHintConstant = "0846c900051c0000";
+
+// The claim reserves the surcharge out of its output, so the swap has to
+// request that much more for the payee to land the amount they invoiced.
+export const magicRoutingHintAmounts = (
+    chainPair: ChainPairTypeTaproot,
+    bip21AmountSats: BigNumber,
+    bip21Asset: string,
+    chainAddress: string,
+) => {
+    const surcharge = claimSurchargeForAddress(bip21Asset, chainAddress);
+    const receiveAmount = bip21AmountSats.plus(surcharge);
+
+    return {
+        surcharge,
+        receiveAmount,
+        sendAmount: calculateSendAmount(
+            receiveAmount,
+            chainPair.fees.percentage,
+            chainPair.fees.minerFees.server +
+                chainPair.fees.minerFees.user.claim,
+            SwapType.Chain,
+        ),
+    };
+};
 
 export const findMagicRoutingHint = (invoice: string) => {
     try {

--- a/src/utils/unconfidential.ts
+++ b/src/utils/unconfidential.ts
@@ -1,0 +1,29 @@
+import { SwapType } from "boltz-swaps/types";
+import {
+    type UtxoNetwork,
+    unconfidentialClaimSurcharge,
+} from "boltz-swaps/utxo";
+
+import { config } from "../config";
+import { parseBlindingKey } from "./helper";
+import type { SomeSwap } from "./swapCreator";
+
+export const claimSurchargeForAddress = (
+    assetReceive: string,
+    claimAddress: string | undefined,
+): number =>
+    claimAddress === undefined || claimAddress === ""
+        ? 0
+        : unconfidentialClaimSurcharge(
+              assetReceive,
+              claimAddress,
+              config.network as UtxoNetwork,
+          );
+
+// The claim only injects the OP_RETURN when it spends blinded inputs, which is
+// what the lockup blinding key stands for
+export const claimSurchargeForSwap = (swap: SomeSwap): number =>
+    (swap.type === SwapType.Reverse || swap.type === SwapType.Chain) &&
+    parseBlindingKey(swap, false) !== undefined
+        ? claimSurchargeForAddress(swap.assetReceive, swap.claimAddress)
+        : 0;

--- a/tests/components/Fees.spec.tsx
+++ b/tests/components/Fees.spec.tsx
@@ -3,6 +3,7 @@ import { BigNumber } from "bignumber.js";
 import { getPairs } from "boltz-swaps/client";
 import { weiToSatoshi } from "boltz-swaps/evm";
 import { SwapType } from "boltz-swaps/types";
+import { liquidUnconfidentialClaimExtra } from "boltz-swaps/utxo";
 
 import Fees from "../../src/components/Fees";
 import { config as runtimeConfig } from "../../src/config";
@@ -222,7 +223,7 @@ describe("Fees component", () => {
         });
     });
 
-    test("should increase the miner fee for reverse swaps by 1 when sending to an unconfidential Liquid address", () => {
+    test("should increase the miner fee for reverse swaps when sending to an unconfidential Liquid address", () => {
         render(
             () => (
                 <>
@@ -241,11 +242,13 @@ describe("Fees component", () => {
 
         const fees = pairs.reverse[BTC][LBTC].fees;
         expect(signals.minerFee()).toEqual(
-            fees.minerFees.lockup + fees.minerFees.claim + 5,
+            fees.minerFees.lockup +
+                fees.minerFees.claim +
+                liquidUnconfidentialClaimExtra,
         );
     });
 
-    test("should increase the miner fee for chain swaps by 1 when sending to an unconfidential Liquid address", () => {
+    test("should increase the miner fee for chain swaps when sending to an unconfidential Liquid address", () => {
         render(
             () => (
                 <>
@@ -265,8 +268,33 @@ describe("Fees component", () => {
 
         const fees = pairs.chain[BTC][LBTC].fees;
         expect(signals.minerFee()).toEqual(
-            fees.minerFees.server + fees.minerFees.user.claim + 5,
+            fees.minerFees.server +
+                fees.minerFees.user.claim +
+                liquidUnconfidentialClaimExtra,
         );
+    });
+
+    // The surcharge is added to the quoted miner fee here and subtracted from
+    // the persisted amount at the display sites, with no compile-time link
+    test("quotes exactly the surcharge less than the persisted amount", () => {
+        const fees = pairs.reverse[BTC][LBTC].fees;
+        const minerFees = fees.minerFees.lockup + fees.minerFees.claim;
+        const sendAmount = BigNumber(1_000_000);
+
+        const persisted = calculateReceiveAmount(
+            sendAmount,
+            fees.percentage,
+            minerFees,
+            SwapType.Reverse,
+        );
+        const quoted = calculateReceiveAmount(
+            sendAmount,
+            fees.percentage,
+            minerFees + liquidUnconfidentialClaimExtra,
+            SwapType.Reverse,
+        );
+
+        expect(quoted).toEqual(persisted.minus(liquidUnconfidentialClaimExtra));
     });
 
     test("should apply minimalBatched limit for liquid submarine swaps", async () => {

--- a/tests/context/Pay.spec.tsx
+++ b/tests/context/Pay.spec.tsx
@@ -159,7 +159,7 @@ describe("PayProvider claimSwap", () => {
         expect(fetchPairs).toHaveBeenCalledTimes(1);
         expect(claim).toHaveBeenCalledTimes(1);
         const claimedSwap = claim.mock.calls[0][1] as ChainSwap;
-        expect(claimedSwap.receiveAmount).toBe(5_000 - 101);
+        expect(claimedSwap.receiveAmount).toBe(5_000 - 100);
         expect(claimedSwap.claimDetails.amount).toBe(5_000);
         expect(notify).toHaveBeenCalledWith("success", "swap_completed");
     });

--- a/tests/status/TransactionClaimed.spec.tsx
+++ b/tests/status/TransactionClaimed.spec.tsx
@@ -51,6 +51,68 @@ describe("TransactionClaimed", () => {
         ).resolves.not.toBeUndefined();
     });
 
+    // The sat denomination groups digits with spaces
+    const claimedAmountText = async () =>
+        (await screen.findByText(/You successfully received/u))
+            .textContent!.match(/received ([\d ]+)/u)![1]
+            .replaceAll(" ", "");
+
+    const liquidRegtest = {
+        unconfidential: "ert1q0k9g02evldg5eylnd8lrch0awd05u89p9len8l",
+        confidential:
+            "el1qqgept38a77emd94r554av0ptj4eelxnx5z9wekxmynd2qe4wvunhylv2s74je763fjflx60783wl6u6lfcw2zjc5pm5n3gq32",
+    };
+
+    // `receiveAmount` is what the claim requests; an unconfidential Liquid
+    // destination reserves the surcharge out of it
+    test.each`
+        name                        | swap                                                                                                                                                                 | shown
+        ${"unconfidential L-BTC"}   | ${{ type: SwapType.Reverse, assetReceive: LBTC, claimTx: "txid", claimAddress: liquidRegtest.unconfidential, blindingKey: "00".repeat(32), receiveAmount: 100_000 }} | ${"99994"}
+        ${"confidential L-BTC"}     | ${{ type: SwapType.Reverse, assetReceive: LBTC, claimTx: "txid", claimAddress: liquidRegtest.confidential, blindingKey: "00".repeat(32), receiveAmount: 100_000 }}   | ${"100000"}
+        ${"L-BTC without blinding"} | ${{ type: SwapType.Reverse, assetReceive: LBTC, claimTx: "txid", claimAddress: liquidRegtest.unconfidential, receiveAmount: 100_000 }}                               | ${"100000"}
+        ${"BTC"}                    | ${{ type: SwapType.Reverse, assetReceive: BTC, claimTx: "txid", claimAddress: "bcrt1qxyz", receiveAmount: 100_000 }}                                                 | ${"100000"}
+    `("shows the landed amount for $name", async ({ swap, shown }) => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <TransactionClaimed />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+        payContext.setSwap(swap as SomeSwap);
+
+        expect(await claimedAmountText()).toBe(shown);
+    });
+
+    test("leaves a post-position DEX output untouched", async () => {
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <TransactionClaimed />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+        payContext.setSwap({
+            type: SwapType.Reverse,
+            assetReceive: LBTC,
+            claimTx: "txid",
+            claimAddress: liquidRegtest.unconfidential,
+            blindingKey: "00".repeat(32),
+            receiveAmount: 100_000,
+            dex: {
+                position: SwapPosition.Post,
+                quoteAmount: 42_000,
+                hops: [{ to: BTC }],
+            },
+        } as unknown as SomeSwap);
+
+        expect(await claimedAmountText()).toBe("42000");
+    });
+
     test("explains post-bridge delivery is still in progress", async () => {
         render(
             () => (

--- a/tests/status/TransactionLockupFailedAutoAccept.spec.tsx
+++ b/tests/status/TransactionLockupFailedAutoAccept.spec.tsx
@@ -1,5 +1,7 @@
-import { render, waitFor } from "@solidjs/testing-library";
+import { render, screen, waitFor } from "@solidjs/testing-library";
 import { SwapPosition, SwapType } from "boltz-swaps/types";
+import { liquidUnconfidentialClaimExtra } from "boltz-swaps/utxo";
+import { Buffer } from "buffer";
 
 const mocks = vi.hoisted(() => ({
     swap: undefined as unknown,
@@ -48,6 +50,7 @@ vi.mock("../../src/pages/NotFound", () => ({
 
 vi.mock("../../src/consts/Assets", () => ({
     isEvmAsset: () => true,
+    LBTC: "L-BTC",
 }));
 
 vi.mock("../../src/context/Global", () => ({
@@ -59,6 +62,15 @@ vi.mock("../../src/context/Global", () => ({
             chain: {
                 FINAL: {
                     BTC: {
+                        fees: {
+                            minerFees: {
+                                user: {
+                                    claim: 0,
+                                },
+                            },
+                        },
+                    },
+                    "L-BTC": {
                         fees: {
                             minerFees: {
                                 user: {
@@ -113,6 +125,9 @@ vi.mock("../../src/utils/helper", () => ({
 vi.mock("../../src/utils/rescue", () => ({
     isRefundableSwapType: () => false,
 }));
+
+const { LBTC } = await import("../../src/consts/Assets");
+const { parseBlindingKey } = await import("../../src/utils/helper");
 
 const { default: TransactionLockupFailed } =
     await import("../../src/status/TransactionLockupFailed");
@@ -179,7 +194,7 @@ describe("TransactionLockupFailed pre-bridge auto-accept", () => {
         );
         expect(mocks.swap).toEqual(
             expect.objectContaining({
-                receiveAmount: 990,
+                receiveAmount: 991,
                 claimDetails: expect.objectContaining({
                     amount: 991,
                 }),
@@ -191,7 +206,7 @@ describe("TransactionLockupFailed pre-bridge auto-accept", () => {
     });
 
     test("does not auto-accept a pre-bridge replacement quote outside slippage", async () => {
-        mocks.getChainSwapNewQuote.mockResolvedValue({ amount: 990 });
+        mocks.getChainSwapNewQuote.mockResolvedValue({ amount: 989 });
 
         render(() => (
             <TransactionLockupFailed
@@ -207,5 +222,77 @@ describe("TransactionLockupFailed pre-bridge auto-accept", () => {
 
         expect(mocks.acceptChainSwapNewQuote).not.toHaveBeenCalled();
         expect(mocks.modifySwapStorage).not.toHaveBeenCalled();
+    });
+
+    describe("unconfidential Liquid destination", () => {
+        beforeEach(() => {
+            vi.mocked(parseBlindingKey).mockReturnValue(Buffer.alloc(32));
+            mocks.swap = {
+                ...makeSwap(),
+                assetReceive: LBTC,
+                claimAddress: "ert1q0k9g02evldg5eylnd8lrch0awd05u89p9len8l",
+            };
+        });
+
+        test("offers the amount the claim will deliver", async () => {
+            mocks.getChainSwapNewQuote.mockResolvedValue({ amount: 900 });
+
+            render(() => (
+                <TransactionLockupFailed
+                    setStatusOverride={mocks.setStatusOverride}
+                />
+            ));
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText(
+                        String(900 - liquidUnconfidentialClaimExtra),
+                    ),
+                ).toBeDefined();
+            });
+        });
+
+        // The rendered amount is the DEX output in another asset, not the
+        // Boltz claim output the surcharge comes out of
+        test("leaves a post-position DEX output untouched", async () => {
+            mocks.swap = {
+                ...(mocks.swap as object),
+                dex: {
+                    position: SwapPosition.Post,
+                    quoteAmount: "100",
+                    hops: [{ to: "FINAL" }],
+                },
+            };
+            mocks.getChainSwapNewQuote.mockResolvedValue({ amount: 900 });
+
+            render(() => (
+                <TransactionLockupFailed
+                    setStatusOverride={mocks.setStatusOverride}
+                />
+            ));
+
+            await waitFor(() => {
+                expect(screen.getByText("900")).toBeDefined();
+            });
+        });
+
+        // The claim layer reserves the surcharge itself, so persisting the
+        // landed amount would subtract it twice
+        test("persists the amount the claim requests", async () => {
+            mocks.getChainSwapNewQuote.mockResolvedValue({ amount: 991 });
+
+            render(() => (
+                <TransactionLockupFailed
+                    setStatusOverride={mocks.setStatusOverride}
+                />
+            ));
+
+            await waitFor(() => {
+                expect(mocks.modifySwapStorage).toHaveBeenCalled();
+            });
+            expect(
+                (mocks.swap as { receiveAmount: number }).receiveAmount,
+            ).toBe(991);
+        });
     });
 });

--- a/tests/utils/magicRoutingHint.spec.ts
+++ b/tests/utils/magicRoutingHint.spec.ts
@@ -1,0 +1,65 @@
+import { BigNumber } from "bignumber.js";
+import type { ChainPairTypeTaproot } from "boltz-swaps/client";
+import { SwapType } from "boltz-swaps/types";
+import { liquidUnconfidentialClaimExtra } from "boltz-swaps/utxo";
+
+import { BTC, LBTC } from "../../src/consts/Assets";
+import { calculateSendAmount } from "../../src/utils/calculate";
+import { magicRoutingHintAmounts } from "../../src/utils/magicRoutingHint";
+
+const unconfidential = "ert1q0k9g02evldg5eylnd8lrch0awd05u89p9len8l";
+const confidential =
+    "el1qqgept38a77emd94r554av0ptj4eelxnx5z9wekxmynd2qe4wvunhylv2s74je763fjflx60783wl6u6lfcw2zjc5pm5n3gq32";
+
+const chainPair = {
+    fees: {
+        percentage: 0.1,
+        minerFees: { server: 150, user: { claim: 143, lockup: 152 } },
+    },
+} as ChainPairTypeTaproot;
+
+const bip21AmountSats = BigNumber(100_000);
+
+const expectedSendAmount = (receiveAmount: BigNumber) =>
+    calculateSendAmount(
+        receiveAmount,
+        chainPair.fees.percentage,
+        chainPair.fees.minerFees.server + chainPair.fees.minerFees.user.claim,
+        SwapType.Chain,
+    );
+
+describe("magicRoutingHintAmounts", () => {
+    test("requests the surcharge on top of the invoiced amount", () => {
+        const amounts = magicRoutingHintAmounts(
+            chainPair,
+            bip21AmountSats,
+            LBTC,
+            unconfidential,
+        );
+
+        expect(amounts.surcharge).toEqual(liquidUnconfidentialClaimExtra);
+        expect(amounts.receiveAmount).toEqual(
+            bip21AmountSats.plus(liquidUnconfidentialClaimExtra),
+        );
+        expect(amounts.sendAmount).toEqual(
+            expectedSendAmount(amounts.receiveAmount),
+        );
+    });
+
+    test.each`
+        name               | asset   | address
+        ${"confidential"}  | ${LBTC} | ${confidential}
+        ${"a BTC address"} | ${BTC}  | ${"bcrt1qxyz"}
+    `("charges nothing for $name", ({ asset, address }) => {
+        const amounts = magicRoutingHintAmounts(
+            chainPair,
+            bip21AmountSats,
+            asset,
+            address,
+        );
+
+        expect(amounts.surcharge).toEqual(0);
+        expect(amounts.receiveAmount).toEqual(bip21AmountSats);
+        expect(amounts.sendAmount).toEqual(expectedSendAmount(bip21AmountSats));
+    });
+});

--- a/tests/utils/unconfidential.spec.ts
+++ b/tests/utils/unconfidential.spec.ts
@@ -1,0 +1,72 @@
+import { SwapType } from "boltz-swaps/types";
+import { liquidUnconfidentialClaimExtra } from "boltz-swaps/utxo";
+
+import { BTC, LBTC } from "../../src/consts/Assets";
+import type { SomeSwap } from "../../src/utils/swapCreator";
+import {
+    claimSurchargeForAddress,
+    claimSurchargeForSwap,
+} from "../../src/utils/unconfidential";
+
+const unconfidential = "ert1q0k9g02evldg5eylnd8lrch0awd05u89p9len8l";
+const confidential =
+    "el1qqgept38a77emd94r554av0ptj4eelxnx5z9wekxmynd2qe4wvunhylv2s74je763fjflx60783wl6u6lfcw2zjc5pm5n3gq32";
+
+describe("claimSurchargeForAddress", () => {
+    test.each`
+        asset   | address             | expected
+        ${LBTC} | ${unconfidential}   | ${liquidUnconfidentialClaimExtra}
+        ${LBTC} | ${confidential}     | ${0}
+        ${LBTC} | ${undefined}        | ${0}
+        ${LBTC} | ${""}               | ${0}
+        ${LBTC} | ${"not-an-address"} | ${0}
+        ${BTC}  | ${"bcrt1qxyz"}      | ${0}
+    `(
+        "is $expected for $asset and $address",
+        ({ asset, address, expected }) => {
+            expect(claimSurchargeForAddress(asset, address)).toEqual(expected);
+        },
+    );
+});
+
+describe("claimSurchargeForSwap", () => {
+    const swap = (extra: Record<string, unknown>) =>
+        ({
+            type: SwapType.Reverse,
+            assetReceive: LBTC,
+            claimAddress: unconfidential,
+            blindingKey: "00".repeat(32),
+            ...extra,
+        }) as unknown as SomeSwap;
+
+    test("charges an unconfidential destination", () => {
+        expect(claimSurchargeForSwap(swap({}))).toEqual(
+            liquidUnconfidentialClaimExtra,
+        );
+    });
+
+    test("reads the lockup blinding key of a chain swap", () => {
+        expect(
+            claimSurchargeForSwap(
+                swap({
+                    type: SwapType.Chain,
+                    blindingKey: undefined,
+                    claimDetails: { blindingKey: "00".repeat(32) },
+                }),
+            ),
+        ).toEqual(liquidUnconfidentialClaimExtra);
+    });
+
+    // No blinded input means boltz-core adds no OP_RETURN
+    test("does not charge without a lockup blinding key", () => {
+        expect(claimSurchargeForSwap(swap({ blindingKey: undefined }))).toEqual(
+            0,
+        );
+    });
+
+    test("does not charge a submarine swap", () => {
+        expect(
+            claimSurchargeForSwap(swap({ type: SwapType.Submarine })),
+        ).toEqual(0);
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added chain and reverse swap support for unconfidential Liquid destinations, including surcharge-aware amount handling.
  * Enhanced Magic Routing Hint quoting with surcharge-aware receive/send calculations.
* **Bug Fixes**
  * “Receive”/status displays now reflect the actual landed amount after claim fees and any unconfidential surcharges.
  * Improved fee estimation and validation for unconfidential Liquid destinations, including more accurate replacement/claim budgeting.
* **Tests**
  * Expanded unit, integration, and end-to-end coverage for unconfidential Liquid claim transactions, fee budgeting, and landed-amount verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->