### PR TITLE
fix: claim EVM swap via rescue

### DIFF
--- a/src/pages/external-rescue/useExternalRescueSearch.ts
+++ b/src/pages/external-rescue/useExternalRescueSearch.ts
@@ -152,7 +152,7 @@ type RestoreRescueResult = Extract<
     { source: RescueResultSource.Restore }
 >;
 
-export const getRestorePreimageHash = (swap: { preimageHash?: string }) =>
+export const getRestorePreimageHash = (swap: RestoreSwapAssets) =>
     normalizeEvmId(swap.preimageHash);
 
 export const isEvmRestoreCandidate = (swap: RestoreSwapAssets) =>
@@ -166,7 +166,13 @@ export const isEvmRestoreCandidate = (swap: RestoreSwapAssets) =>
 export const shouldShowEvmRestoreResult = (
     swap: RestoreSwapAssets,
     evmRescuePreimageHashes: Set<string>,
+    action?: RescueAction,
 ) => {
+    // Only the restore row can claim; the EVM lockup row refunds or waits
+    if (action === RescueAction.Claim) {
+        return true;
+    }
+
     if (!isEvmRestoreCandidate(swap)) {
         return true;
     }
@@ -401,12 +407,13 @@ export const useExternalRescueSearch = () => {
                     .map(normalizeEvmId),
             ),
     );
-    const shouldShowRestoreResult = (swap: RestoreSwapAssets) =>
-        shouldShowEvmRestoreResult(swap, evmRescuePreimageHashes());
+    const shouldShowRestoreResult = (
+        swap: RestoreSwapAssets,
+        action?: RescueAction,
+    ) => shouldShowEvmRestoreResult(swap, evmRescuePreimageHashes(), action);
 
     const unifiedResults = createMemo(() => {
         const restoreResults: RestoreRescueResult[] = (btcRescueList() ?? [])
-            .filter(shouldShowRestoreResult)
             .map((swap): RestoreRescueResult => {
                 const action = swap.action ?? RescueAction.Pending;
                 return {
@@ -417,7 +424,10 @@ export const useExternalRescueSearch = () => {
                     sortValue: getSwapDate(swap),
                     swap,
                 };
-            });
+            })
+            .filter((result) =>
+                shouldShowRestoreResult(result.swap, result.action),
+            );
         const linkedEvmRefundRestoreIds = new Set(
             visibleEvmSwaps()
                 .map(restoredOriginalSwapId)
@@ -428,17 +438,35 @@ export const useExternalRescueSearch = () => {
                 result.action === RescueAction.Claim ||
                 !linkedEvmRefundRestoreIds.has(result.swap.id),
         );
+        const claimableRestores = restoreResults.filter(
+            (result) => result.action === RescueAction.Claim,
+        );
         const claimableRestoreIds = new Set(
-            restoreResults
-                .filter((result) => result.action === RescueAction.Claim)
-                .map((result) => result.swap.id),
+            claimableRestores.map((result) => result.swap.id),
+        );
+        // The EVM lockup row of a claimable swap is the duplicate now: dropping
+        // it keeps a single row per swap that opens the claim flow
+        const claimableRestorePreimageHashes = new Set(
+            claimableRestores
+                .map((result) => getRestorePreimageHash(result.swap))
+                .filter(
+                    (preimageHash) =>
+                        preimageHash !== "" &&
+                        !isEmptyPreimageHash(preimageHash),
+                ),
         );
         const evmResults: UnifiedRescueResult[] = visibleEvmSwaps()
             .filter((swap) => {
                 const restoreId = restoredOriginalSwapId(swap);
-                return (
-                    restoreId === undefined ||
-                    !claimableRestoreIds.has(restoreId)
+                if (
+                    restoreId !== undefined &&
+                    claimableRestoreIds.has(restoreId)
+                ) {
+                    return false;
+                }
+
+                return !claimableRestorePreimageHashes.has(
+                    normalizeEvmId(swap.preimageHash),
                 );
             })
             .map((swap) => {

--- a/tests/pages/RescueExternalEvmScan.spec.tsx
+++ b/tests/pages/RescueExternalEvmScan.spec.tsx
@@ -1225,6 +1225,123 @@ describe("Rescue EVM scan", () => {
         ).toHaveLength(1);
     });
 
+    test("prioritizes a restored claim over the EVM lockup of the same swap", async () => {
+        const user = userEvent.setup();
+        const mnemonic =
+            "awake father sword slab matrix myth cargo lock river thumb inspire speed";
+        const swapId = "QzNPe7rckJCp";
+        const preimageHash =
+            "c75a1b92ece410e13823372edceb1fc148c37d36586c2ccd8b2c78dac1556a8e";
+        const transactionHash =
+            "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        vi.stubEnv("VITE_ARBITRUM_LOG_SCAN_ENDPOINT", "http://localhost:8547");
+
+        const restoredSwap: RestorableSwap = {
+            id: swapId,
+            type: SwapType.Chain,
+            status: "transaction.server.confirmed",
+            createdAt: 1782787562,
+            from: TBTC,
+            to: "L-BTC",
+            preimageHash,
+            claimDetails: {
+                amount: 13_341,
+                blindingKey:
+                    "c43345f5cbf63cd5be4044c0eb7b0991cc2465599fcf2e8d6127ec3847943dc4",
+                keyIndex: 71,
+                lockupAddress: "claim-lockup",
+                serverPublicKey:
+                    "03bb779740ad43c9337bf89a23062a8564b2cf5a75fd7e317a352965ee1b4a51b2",
+                timeoutBlockHeight: 3953207,
+                transaction: {
+                    id: "6ba69b919aaf28f5ec746f97cde06da136c77390082de0b52674954b58a51aa1",
+                    vout: 1,
+                },
+                tree: {
+                    claimLeaf: { version: 196, output: "51" },
+                    refundLeaf: { version: 196, output: "51" },
+                },
+            },
+        };
+        mockGetRestorableSwaps.mockResolvedValueOnce([restoredSwap]);
+        mockCreateRescueList.mockImplementation(
+            (swaps: Record<string, unknown>[]) =>
+                Promise.resolve(
+                    swaps.map((swap) => ({ ...swap, action: "claim" })),
+                ),
+        );
+        mockScanLockupEvents.mockImplementation(async function* (
+            ...args: unknown[]
+        ) {
+            await Promise.resolve();
+            const config = args[2] as {
+                action?: RskRescueMode;
+                asset?: string;
+            };
+            const events =
+                config.action === RskRescueMode.Refund && config.asset === TBTC
+                    ? [
+                          {
+                              asset: TBTC,
+                              blockNumber: 100,
+                              transactionHash,
+                              preimageHash: `0x${preimageHash}`,
+                              amount: 13_500_000_000_000n,
+                              claimAddress:
+                                  "0x0000000000000000000000000000000000000001",
+                              refundAddress:
+                                  "0x0000000000000000000000000000000000000002",
+                              timelock: 123n,
+                          },
+                      ]
+                    : [];
+            yield {
+                derivedKeys: undefined,
+                events,
+                progress: 1,
+                unmatchedSwaps: 0,
+            };
+        });
+
+        render(
+            () => (
+                <>
+                    <TestComponent />
+                    <Rescue />
+                </>
+            ),
+            { wrapper: contextWrapper },
+        );
+
+        const uploadInput = await screen.findByTestId("refundUpload");
+        const rescueFile = new File(["{}"], "rescue.json", {
+            type: "application/json",
+        });
+        (rescueFile as File & { text: () => Promise<string> }).text = () =>
+            Promise.resolve(JSON.stringify({ mnemonic }));
+
+        await user.upload(uploadInput, rescueFile);
+        await user.click(screen.getByRole("button", { name: i18n.en.rescue }));
+
+        const claimRow = await screen.findByTestId(
+            `swaplist-item-${swapId}`,
+            undefined,
+            { timeout: 5_000 },
+        );
+        expect(claimRow).not.toHaveClass("disabled");
+        expect(claimRow).toHaveTextContent(i18n.en.claim);
+        expect(
+            screen.queryByTestId(
+                `swaplist-item-evm:${RskRescueMode.Refund}:${TBTC}:${transactionHash}`,
+            ),
+        ).toBeNull();
+        expect(
+            document.querySelectorAll(
+                ".rescue-external-results .swaplist-item",
+            ),
+        ).toHaveLength(1);
+    });
+
     test("scans WBTC and TBTC on Arbitrum", async () => {
         const user = userEvent.setup();
         vi.stubEnv("VITE_ARBITRUM_LOG_SCAN_ENDPOINT", "http://localhost:8547");

--- a/tests/pages/externalRescueScan.spec.ts
+++ b/tests/pages/externalRescueScan.spec.ts
@@ -36,6 +36,7 @@ import {
     isEvmRestoreCandidate,
     shouldShowEvmRestoreResult,
 } from "../../src/pages/external-rescue/useExternalRescueSearch";
+import { RescueAction } from "../../src/utils/rescue";
 import {
     type RescueFile,
     derivePreimageFromRescueKey,
@@ -533,6 +534,37 @@ describe("external EVM rescue scan helpers", () => {
         expect(shouldShowEvmRestoreResult(restoreRow, evmPreimageHashes)).toBe(
             false,
         );
+        expect(
+            shouldShowEvmRestoreResult(
+                restoreRow,
+                evmPreimageHashes,
+                RescueAction.Pending,
+            ),
+        ).toBe(false);
+    });
+
+    test("keeps a claimable restore row when the EVM lockup row exists", () => {
+        const restoreRow = {
+            id: "QzNPe7rckJCp",
+            type: SwapType.Chain,
+            status: "transaction.server.confirmed",
+            createdAt: 1782787562,
+            from: "TBTC",
+            to: "L-BTC",
+            preimageHash:
+                "c75a1b92ece410e13823372edceb1fc148c37d36586c2ccd8b2c78dac1556a8e",
+        };
+        const evmPreimageHashes = new Set([
+            "c75a1b92ece410e13823372edceb1fc148c37d36586c2ccd8b2c78dac1556a8e",
+        ]);
+
+        expect(
+            shouldShowEvmRestoreResult(
+                restoreRow,
+                evmPreimageHashes,
+                RescueAction.Claim,
+            ),
+        ).toBe(true);
     });
 
     test("shows unmatched EVM restore rows while the chain scan is still running", () => {


### PR DESCRIPTION
How to reproduce the bug:
1. create a TBTC/WBTC -> BTC/LBTC swap;
2. don't allow claim to happen after sending funds;
3. on a new browser, use rescue key and connect a wallet to rescue the swap;
4. swap will show up as "in progress" instead of "claimable";

This PR fixes this so user can claim via Rescue after Boltz locks its transaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Claimable restored swaps now appear correctly in external rescue results.
  * Prevented duplicate EVM refund rows from appearing when a corresponding restored claim is available.
  * Improved filtering so restore results remain visible when they are eligible for claiming.
  * Ensured rescue results display only one applicable entry per restored swap.

* **Tests**
  * Added coverage for claim-versus-refund prioritization and restore-result filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->