### PR TITLE
fix: persist full route amounts as dex.quoteAmount

### DIFF
--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -127,7 +127,7 @@ const buildBridgeDetail = (
     };
 };
 
-const buildDexDetail = (
+export const buildDexDetail = (
     hops: EncodedHop[],
     position: SwapPosition | undefined,
     sendAmount: BigNumber,
@@ -587,10 +587,7 @@ const CreateButton = () => {
             let dex: SwapMetadataSource["dex"];
             let bridge: SwapMetadataSource["bridge"];
             const buildCreationMetadata = async (
-                creationData?: Pick<
-                    CreationData,
-                    "hops" | "hopsPosition" | "sendAmount" | "receiveAmount"
-                >,
+                creationData?: Pick<CreationData, "hops" | "hopsPosition">,
             ): Promise<string | undefined> => {
                 const sourceAmount =
                     amountChanged() === Side.Send ? sendAmount() : undefined;
@@ -606,8 +603,13 @@ const CreateButton = () => {
                         ? buildDexDetail(
                               creationData.hops,
                               creationData.hopsPosition,
-                              creationData.sendAmount,
-                              creationData.receiveAmount,
+                              // Full route amounts: creationData holds the Boltz
+                              // leg only, which is the intermediate asset for a
+                              // routed swap. Consumers of quoteAmount compare it
+                              // against the final DEX output (post) or display it
+                              // as the amount the user sent (pre).
+                              sendAmount(),
+                              receiveAmount(),
                               // If the bridge is involved, the source amount is already
                               // persisted on the bridge and isn't involved in the DEX quote.
                               bridge === undefined ? sourceAmount : undefined,

--- a/tests/components/CreateButton.spec.tsx
+++ b/tests/components/CreateButton.spec.tsx
@@ -1,10 +1,12 @@
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { BigNumber } from "bignumber.js";
 import type { Pairs } from "boltz-swaps/client";
+import { calculateAmountOutMin } from "boltz-swaps/helper";
 import type * as InvoiceModule from "boltz-swaps/invoice";
 import { SwapPosition, SwapType } from "boltz-swaps/types";
 
 import CreateButton, {
+    buildDexDetail,
     getClaimAddress,
 } from "../../src/components/CreateButton";
 import type * as ConfigModule from "../../src/config";
@@ -25,10 +27,12 @@ import { useGlobalContext } from "../../src/context/Global";
 import i18n from "../../src/i18n/i18n";
 import * as rifSigner from "../../src/rif/Signer";
 import Pair from "../../src/utils/Pair";
+import type * as SwapCreatorModule from "../../src/utils/swapCreator";
 import {
     GasAbstractionType,
     createUniformGasAbstraction,
 } from "../../src/utils/swapCreator";
+import type * as ValidationModule from "../../src/utils/validation";
 import {
     TestComponent,
     contextWrapper,
@@ -36,6 +40,35 @@ import {
     signals,
 } from "../helper";
 import { pairs as testPairs } from "../pairs";
+
+const { createSubmarineMock, validateResponseMock, actualModules } = vi.hoisted(
+    () => ({
+        createSubmarineMock: vi.fn(),
+        validateResponseMock: vi.fn(),
+        actualModules: {} as {
+            createSubmarine?: typeof SwapCreatorModule.createSubmarine;
+            validateResponse?: typeof ValidationModule.validateResponse;
+        },
+    }),
+);
+
+vi.mock("../../src/utils/validation", async (importActual) => {
+    const actual = await importActual<typeof ValidationModule>();
+    actualModules.validateResponse = actual.validateResponse;
+    return {
+        ...actual,
+        validateResponse: validateResponseMock,
+    };
+});
+
+vi.mock("../../src/utils/swapCreator", async (importActual) => {
+    const actual = await importActual<typeof SwapCreatorModule>();
+    actualModules.createSubmarine = actual.createSubmarine;
+    return {
+        ...actual,
+        createSubmarine: createSubmarineMock,
+    };
+});
 
 vi.mock("boltz-swaps/invoice", async (importActual) => {
     const actual = await importActual<typeof InvoiceModule>();
@@ -237,6 +270,15 @@ const setupPreDexCommitmentButton = async (destination = "") => {
 
 describe("CreateButton", () => {
     beforeEach(() => {
+        // Delegate to the real implementations unless a test overrides them
+        createSubmarineMock.mockImplementation(
+            (...args: Parameters<typeof SwapCreatorModule.createSubmarine>) =>
+                actualModules.createSubmarine!(...args),
+        );
+        validateResponseMock.mockImplementation(
+            (...args: Parameters<typeof ValidationModule.validateResponse>) =>
+                actualModules.validateResponse!(...args),
+        );
         window.history.pushState({}, "", "/");
         Object.defineProperty(window.navigator, "locks", {
             configurable: true,
@@ -817,6 +859,72 @@ describe("CreateButton", () => {
         });
     });
 
+    test("persists the full route amounts in the created swap metadata", async () => {
+        renderCreateButton();
+
+        await globalSignals.clearSwaps();
+        globalSignals.setOnline(true);
+        // Full route: the user sends 100_000 USDC and receives 99_000 sats
+        signals.setSendAmount(BigNumber(100_000));
+        signals.setReceiveAmount(BigNumber(99_000));
+        signals.setAmountChanged(Side.Send);
+        signals.setAmountValid(true);
+        signals.setInvoice(invoice);
+        signals.setInvoiceValid(true);
+        setPairAssetsWithPairs(usdt0Pairs, USDC, LN);
+        // The Boltz leg alone runs on the intermediate asset
+        signals.pair().creationData = vi.fn().mockResolvedValue({
+            type: SwapType.Submarine,
+            from: TBTC,
+            to: BTC,
+            sendAmount: BigNumber(80_000),
+            receiveAmount: BigNumber(79_000),
+            pairHash: "tbtc-ln-pair-hash",
+            hops: [
+                {
+                    type: SwapType.Dex,
+                    from: USDC,
+                    to: TBTC,
+                },
+            ],
+            hopsPosition: SwapPosition.Pre,
+        });
+        validateResponseMock.mockResolvedValue(undefined);
+        createSubmarineMock.mockResolvedValue({
+            id: "routed-submarine",
+            type: SwapType.Submarine,
+            assetSend: TBTC,
+            assetReceive: BTC,
+            sendAmount: 80_000,
+            expectedAmount: 80_000,
+            receiveAmount: 79_000,
+            date: 0,
+        });
+
+        const btn = (await screen.findByTestId(
+            "create-swap-button",
+        )) as HTMLButtonElement;
+        await waitFor(() => {
+            expect(btn.disabled).toBe(false);
+        });
+        fireEvent.click(btn);
+
+        await waitFor(() => {
+            expect(createSubmarineMock).toHaveBeenCalled();
+        });
+        await waitFor(async () => {
+            const [swap] = await globalSignals.getSwaps();
+            expect(swap).toMatchObject({
+                id: "routed-submarine",
+                dex: {
+                    position: SwapPosition.Pre,
+                    quoteAmount: 100_000,
+                    sourceAmount: "100000",
+                },
+            });
+        });
+    });
+
     test("should defer invoice fetching for send-side pre-dex commitments", async () => {
         const btn = await setupPreDexCommitmentButton(bolt12Offer);
         fireEvent.click(btn);
@@ -1265,5 +1373,121 @@ describe("CreateButton", () => {
         await waitFor(() => expect(signals.invoiceValid()).toBe(false));
         expect(signals.lnurl()).toBe("test@example.com");
         await waitFor(() => expect(btn.disabled).toBeFalsy());
+    });
+});
+
+describe("buildDexDetail", () => {
+    const preHops = [
+        {
+            type: SwapType.Dex,
+            from: USDC,
+            to: TBTC,
+        },
+    ] as never;
+    const postHops = [
+        {
+            type: SwapType.Dex,
+            from: TBTC,
+            to: USDT0,
+        },
+    ] as never;
+
+    // Full route amounts: the user sends 0.01 BTC and receives 1000 USDT0.
+    // The Boltz leg alone would be ~1e6 sats of TBTC, a different asset and
+    // a different unit, so it must never reach quoteAmount.
+    const fullRouteSend = BigNumber(1_000_000);
+    const fullRouteReceive = BigNumber(1_000_000_000);
+
+    test("returns undefined without a hop position", () => {
+        expect(
+            buildDexDetail(
+                postHops,
+                undefined,
+                fullRouteSend,
+                fullRouteReceive,
+            ),
+        ).toBeUndefined();
+    });
+
+    test("persists the final receive amount for post hops", () => {
+        expect(
+            buildDexDetail(
+                postHops,
+                SwapPosition.Post,
+                fullRouteSend,
+                fullRouteReceive,
+            ),
+        ).toEqual({
+            hops: postHops,
+            position: SwapPosition.Post,
+            quoteAmount: 1_000_000_000,
+        });
+    });
+
+    test("ignores the source amount for post hops", () => {
+        expect(
+            buildDexDetail(
+                postHops,
+                SwapPosition.Post,
+                fullRouteSend,
+                fullRouteReceive,
+                fullRouteSend,
+            ),
+        ).not.toHaveProperty("sourceAmount");
+    });
+
+    test("persists the source send amount for pre hops", () => {
+        expect(
+            buildDexDetail(
+                preHops,
+                SwapPosition.Pre,
+                BigNumber(100_000),
+                BigNumber(99_000),
+                BigNumber(100_000),
+            ),
+        ).toEqual({
+            hops: preHops,
+            position: SwapPosition.Pre,
+            quoteAmount: 100_000,
+            sourceAmount: "100000",
+        });
+    });
+
+    test("omits the source amount for pre hops when it is unknown", () => {
+        const dex = buildDexDetail(
+            preHops,
+            SwapPosition.Pre,
+            BigNumber(100_000),
+            BigNumber(99_000),
+        );
+
+        expect(dex).toEqual({
+            hops: preHops,
+            position: SwapPosition.Pre,
+            quoteAmount: 100_000,
+        });
+        expect(dex).not.toHaveProperty("sourceAmount");
+    });
+
+    test("never persists the intermediate Boltz leg amount", () => {
+        const boltzLegReceive = BigNumber(998_000);
+        const dex = buildDexDetail(
+            postHops,
+            SwapPosition.Post,
+            fullRouteSend,
+            fullRouteReceive,
+        );
+
+        expect(dex!.quoteAmount).not.toBe(boltzLegReceive.toNumber());
+        // Claim time compares a fresh DEX quote against this baseline, so a
+        // halved fill has to fall below it
+        const halvedFill = BigInt(dex!.quoteAmount) / 2n;
+        const threshold = calculateAmountOutMin(BigInt(dex!.quoteAmount), 0.01);
+        expect(halvedFill < threshold).toBe(true);
+        // The intermediate amount would make that check unreachable
+        expect(
+            halvedFill <
+                calculateAmountOutMin(BigInt(boltzLegReceive.toNumber()), 0.01),
+        ).toBe(false);
     });
 });

--- a/tests/utils/Pair.spec.ts
+++ b/tests/utils/Pair.spec.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "bignumber.js";
 import type * as BoltzClientModule from "boltz-swaps/client";
 import type { Pairs, QuoteData } from "boltz-swaps/client";
-import { CctpReceiveMode, SwapType } from "boltz-swaps/types";
+import { CctpReceiveMode, SwapPosition, SwapType } from "boltz-swaps/types";
 import log from "loglevel";
 
 import type * as ConfigModule from "../../src/config";
@@ -1129,5 +1129,43 @@ describe("Pair", () => {
                 recipient,
             ),
         ).rejects.toBe(error);
+    });
+
+    test("quotes the Boltz leg and the full route in different assets", async () => {
+        // Force BTC -> USDT0 to route as chain BTC->TBTC plus a post DEX hop
+        const pairsWithoutDirectChain: Pairs = {
+            ...pairs,
+            chain: {
+                ...pairs.chain,
+                BTC: {
+                    [TBTC]: pairs.chain.BTC[TBTC],
+                },
+            },
+        };
+
+        // 1_000_000 TBTC sats swap out to 1_000 USDT0 (1e9 in base units)
+        fetchDexQuoteMock.mockResolvedValue({
+            trade: {
+                amountIn: BigInt(tbtcAssetAmount(1_000_000)),
+                amountOut: 1_000_000_000n,
+                data: { route: "exact-in" },
+            },
+        } as never);
+
+        const pair = new Pair(pairsWithoutDirectChain, BTC, USDT0);
+        const sendAmount = BigNumber(1_000_000);
+
+        const fullRouteReceive = await pair.calculateReceiveAmount(
+            sendAmount,
+            0,
+        );
+        const creationData = await pair.creationData(sendAmount, 0);
+
+        expect(creationData?.hopsPosition).toBe(SwapPosition.Post);
+        // What the user actually receives: USDT0 base units
+        expect(fullRouteReceive.toNumber()).toBe(1_000_000_000);
+        // The Boltz leg alone settles in TBTC sats, so creation amounts must
+        // never be persisted as the route quote (see buildDexDetail)
+        expect(creationData!.receiveAmount.toNumber()).toBe(1_000_000);
     });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved routed swap metadata to preserve accurate full-route amounts when creating swaps.
  - Corrected amount handling for routes that settle in different assets or include intermediate swap legs.
  - Ensured route details accurately reflect hop positions and exclude intermediate amounts where appropriate.

- **Tests**
  - Added coverage for routed swap creation, DEX route details, minimum output calculations, and cross-asset settlement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->