### PR TITLE
fix: bind swap metadata to the swap id at creation

### DIFF
--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -81,6 +81,7 @@ import {
     type SwapMetadataSource,
     buildSwapMetadataPayload,
     encryptSwapMetadata,
+    patchEncryptedSwapMetadata,
 } from "../utils/swapMetadata";
 import { validateResponse } from "../utils/validation";
 import LoadingSpinner from "./LoadingSpinner";
@@ -907,7 +908,7 @@ const CreateButton = () => {
                 ),
             });
 
-            await setSwapStorage({
+            const storedSwap = {
                 ...data,
                 getGasToken: getGasToken(),
                 dex,
@@ -926,7 +927,10 @@ const CreateButton = () => {
                                   .provider as unknown as HardwareSigner
                           ).getDerivationPath()
                         : undefined,
-            });
+            };
+
+            await setSwapStorage(storedSwap);
+            await patchEncryptedSwapMetadata(storedSwap, rescueFile());
 
             setInvoice("");
             setInvoiceValid(false);

--- a/src/components/CreateButton.tsx
+++ b/src/components/CreateButton.tsx
@@ -72,6 +72,7 @@ import {
     GasAbstractionType,
     type ReverseSwap,
     type SubmarineSwap,
+    type SwapMetadataFactory,
     createChain,
     createCommitmentSwap,
     createReverse,
@@ -587,9 +588,9 @@ const CreateButton = () => {
             let data!: SubmarineSwap | ReverseSwap | ChainSwap;
             let dex: SwapMetadataSource["dex"];
             let bridge: SwapMetadataSource["bridge"];
-            const buildCreationMetadata = async (
+            const buildRouteDetails = (
                 creationData?: Pick<CreationData, "hops" | "hopsPosition">,
-            ): Promise<string | undefined> => {
+            ) => {
                 const sourceAmount =
                     amountChanged() === Side.Send ? sendAmount() : undefined;
                 bridge =
@@ -616,7 +617,11 @@ const CreateButton = () => {
                               bridge === undefined ? sourceAmount : undefined,
                           )
                         : undefined;
+            };
 
+            const buildCreationMetadata: SwapMetadataFactory = async (
+                preimageHash,
+            ) => {
                 const payload = buildSwapMetadataPayload({
                     dex,
                     bridge,
@@ -630,7 +635,10 @@ const CreateButton = () => {
                     return undefined;
                 }
 
-                return await encryptSwapMetadata(mnemonic, payload);
+                return await encryptSwapMetadata(mnemonic, {
+                    ...payload,
+                    preimageHash,
+                });
             };
 
             switch (swapType()) {
@@ -643,8 +651,7 @@ const CreateButton = () => {
                         if (creationData === undefined) {
                             throw new Error("missing swap creation data");
                         }
-                        const metadata =
-                            await buildCreationMetadata(creationData);
+                        buildRouteDetails(creationData);
                         const refundAddress =
                             bridge?.position === SwapPosition.Pre
                                 ? getGasAbstractionSigner(
@@ -661,7 +668,7 @@ const CreateButton = () => {
                             gasAbstraction,
                             newKey,
                             originalDestination(),
-                            metadata,
+                            buildCreationMetadata,
                             refundAddress,
                         );
                     };
@@ -785,7 +792,7 @@ const CreateButton = () => {
                         if (mrhRescue === null) {
                             throw new Error("missing rescue file");
                         }
-                        const metadata = await buildCreationMetadata();
+                        buildRouteDetails();
                         const chainSwap = await createChain(
                             assetSend(),
                             bip21Asset,
@@ -797,7 +804,7 @@ const CreateButton = () => {
                             mrhRescue,
                             newKey,
                             originalDestination(),
-                            metadata,
+                            buildCreationMetadata,
                         );
 
                         data = {
@@ -836,7 +843,7 @@ const CreateButton = () => {
                     if (rescue === null) {
                         throw new Error("missing rescue file");
                     }
-                    const metadata = await buildCreationMetadata(creationData);
+                    buildRouteDetails(creationData);
                     data = await createReverse(
                         creationData.from,
                         creationData.to,
@@ -848,7 +855,7 @@ const CreateButton = () => {
                         rescue,
                         newKey,
                         getOriginalDestination(),
-                        metadata,
+                        buildCreationMetadata,
                     );
                     break;
                 }
@@ -865,7 +872,7 @@ const CreateButton = () => {
                     if (rescue === null) {
                         throw new Error("missing rescue file");
                     }
-                    const metadata = await buildCreationMetadata(creationData);
+                    buildRouteDetails(creationData);
                     data = await createChain(
                         creationData.from,
                         creationData.to,
@@ -877,7 +884,7 @@ const CreateButton = () => {
                         rescue,
                         newKey,
                         getOriginalDestination(),
-                        metadata,
+                        buildCreationMetadata,
                     );
                     break;
                 }

--- a/src/utils/swapCreator.ts
+++ b/src/utils/swapCreator.ts
@@ -17,6 +17,7 @@ import {
     createSubmarineSwap,
 } from "boltz-swaps/client";
 import type { AlchemyCall } from "boltz-swaps/evm";
+import { decodeInvoice } from "boltz-swaps/invoice";
 import {
     type BridgeKind,
     GasAbstractionType,
@@ -131,6 +132,11 @@ export type SwapBaseData = {
     // Bridge routes for bridging before lockup or after claim.
     bridge?: BridgeDetail;
 };
+
+// A factory because the preimage it binds to is derived inside the create call
+export type SwapMetadataFactory = (
+    preimageHash: string,
+) => Promise<string | undefined>;
 
 export type SwapBase = SwapBaseData & {
     sendAmount: number;
@@ -350,7 +356,7 @@ export const createSubmarine = async (
     gasAbstraction: GasAbstraction,
     newKey: newKeyFn,
     originalDestination?: string,
-    metadata?: string,
+    metadata?: SwapMetadataFactory,
     refundAddress?: string,
 ): Promise<SubmarineSwap> => {
     const key = await newKey(assetSend as AssetType);
@@ -362,7 +368,7 @@ export const createSubmarine = async (
         key !== undefined
             ? Buffer.from(key.key.publicKey).toString("hex")
             : undefined,
-        metadata,
+        await metadata?.(decodeInvoice(invoice).preimageHash),
         refundAddress,
     );
 
@@ -393,7 +399,7 @@ export const createReverse = async (
     rescueFile: RescueFile,
     newKey: newKeyFn,
     originalDestination?: string,
-    metadata?: string,
+    metadata?: SwapMetadataFactory,
 ): Promise<ReverseSwap> => {
     const key = await newKey(assetReceive as AssetType);
     const preimage = generatePreimage({
@@ -401,18 +407,19 @@ export const createReverse = async (
         keyIndex: key?.index,
         rescueFile,
     });
+    const preimageHash = hex.encode(sha256(preimage));
 
     const res = await createReverseSwap(
         assetSend,
         assetReceive,
         Number(sendAmount),
-        hex.encode(sha256(preimage)),
+        preimageHash,
         pairHash,
         key !== undefined
             ? Buffer.from(key.key.publicKey).toString("hex")
             : undefined,
         claimAddress,
-        metadata,
+        await metadata?.(preimageHash),
     );
 
     return {
@@ -443,7 +450,7 @@ export const createChain = async (
     rescueFile: RescueFile,
     newKey: newKeyFn,
     originalDestination?: string,
-    metadata?: string,
+    metadata?: SwapMetadataFactory,
 ): Promise<ChainSwap> => {
     const claimKey = await newKey(assetReceive as AssetType);
     const refundKey = await newKey(assetSend as AssetType);
@@ -452,13 +459,14 @@ export const createChain = async (
         keyIndex: claimKey?.index,
         rescueFile,
     });
+    const preimageHash = hex.encode(sha256(preimage));
     const res = await createChainSwap(
         assetSend,
         assetReceive,
         sendAmount.isZero() || sendAmount.isNaN()
             ? undefined
             : Number(sendAmount),
-        hex.encode(sha256(preimage)),
+        preimageHash,
         claimKey !== undefined
             ? Buffer.from(claimKey.key.publicKey).toString("hex")
             : undefined,
@@ -467,7 +475,7 @@ export const createChain = async (
             : undefined,
         claimAddress,
         pairHash,
-        metadata,
+        await metadata?.(preimageHash),
     );
 
     return {

--- a/src/utils/swapMetadata.ts
+++ b/src/utils/swapMetadata.ts
@@ -200,7 +200,7 @@ const parseSwapMetadataPlaintext = parseObject<SwapMetadataPlaintext>({
     preimageHash: parseOptional(parseString),
 });
 
-const normalizeBinding = (value: string): string =>
+const normalizeHexBinding = (value: string): string =>
     value.replace(/^0x/i, "").toLowerCase();
 
 // Returns whether the binding was actually checked, not whether it matched
@@ -208,12 +208,13 @@ const verifyBinding = (
     bound: string | undefined,
     expected: string | undefined,
     name: string,
+    normalize: (value: string) => string = (value) => value,
 ): boolean => {
     if (bound === undefined || expected === undefined) {
         return false;
     }
 
-    if (normalizeBinding(bound) !== normalizeBinding(expected)) {
+    if (normalize(bound) !== normalize(expected)) {
         throw new Error(`swap metadata is bound to a different ${name}`);
     }
 
@@ -324,7 +325,12 @@ export const decryptSwapMetadata = async (
 
     const verified = [
         verifyBinding(boundSwapId, binding.swapId, "swap"),
-        verifyBinding(boundPreimageHash, binding.preimageHash, "preimage hash"),
+        verifyBinding(
+            boundPreimageHash,
+            binding.preimageHash,
+            "preimage hash",
+            normalizeHexBinding,
+        ),
     ].some(Boolean);
 
     // Anything the reader cannot tie to this swap is a replay candidate,

--- a/src/utils/swapMetadata.ts
+++ b/src/utils/swapMetadata.ts
@@ -371,11 +371,7 @@ export const patchEncryptedSwapMetadata = async (
     }
 
     const payload = buildSwapMetadataPayloadFromSwap(swap);
-    if (
-        payload === undefined ||
-        !hasRouteMetadata(payload) ||
-        !hasMetadataTxIdentity(payload)
-    ) {
+    if (payload === undefined || !hasRouteMetadata(payload)) {
         return;
     }
 

--- a/src/utils/swapMetadata.ts
+++ b/src/utils/swapMetadata.ts
@@ -1,5 +1,7 @@
+import { sha256 } from "@noble/hashes/sha2.js";
 import { hex } from "@scure/base";
 import { type RestorableSwap, patchSwapMetadata } from "boltz-swaps/client";
+import { decodeInvoice } from "boltz-swaps/invoice";
 import { BridgeKind, SwapPosition, SwapType } from "boltz-swaps/types";
 import log from "loglevel";
 
@@ -48,12 +50,16 @@ export type SwapMetadataLocalFields = Pick<
     | "originalDestination"
 >;
 
-// The payload plus the id of the swap it belongs to, sealed in so that
-// the backend cannot serve one swap's metadata for another. Optional only
-// because the creation flow encrypts before the backend assigns an id;
-// payloads carrying a lockup transaction must always be bound
+// Sealed in so the backend cannot serve one swap's metadata for another. Either
+// alone suffices; creation binds the hash before an id exists.
 type SwapMetadataPlaintext = SwapMetadataPayload & {
     swapId?: string;
+    preimageHash?: string;
+};
+
+export type SwapMetadataBinding = {
+    swapId: string;
+    preimageHash?: string;
 };
 
 const IV_LENGTH = 12;
@@ -191,11 +197,28 @@ const parseSwapMetadataPlaintext = parseObject<SwapMetadataPlaintext>({
     commitmentLockupTxHash: parseOptional(parseString),
     originalDestination: parseOptional(parseString),
     swapId: parseOptional(parseString),
+    preimageHash: parseOptional(parseString),
 });
 
-const hasMetadataTxIdentity = (payload: SwapMetadataPayload): boolean =>
-    payload.lockupTx !== undefined ||
-    payload.commitmentLockupTxHash !== undefined;
+const normalizeBinding = (value: string): string =>
+    value.replace(/^0x/i, "").toLowerCase();
+
+// Returns whether the binding was actually checked, not whether it matched
+const verifyBinding = (
+    bound: string | undefined,
+    expected: string | undefined,
+    name: string,
+): boolean => {
+    if (bound === undefined || expected === undefined) {
+        return false;
+    }
+
+    if (normalizeBinding(bound) !== normalizeBinding(expected)) {
+        throw new Error(`swap metadata is bound to a different ${name}`);
+    }
+
+    return true;
+};
 
 const hasRouteMetadata = (payload: SwapMetadataPayload): boolean =>
     payload.dex !== undefined || payload.bridge !== undefined;
@@ -240,10 +263,8 @@ export const encryptSwapMetadata = async (
     mnemonic: string,
     payload: SwapMetadataPlaintext,
 ): Promise<string> => {
-    if (payload.swapId === undefined && hasMetadataTxIdentity(payload)) {
-        throw new Error(
-            "swap metadata with a lockup transaction must be bound to a swap",
-        );
+    if (payload.swapId === undefined && payload.preimageHash === undefined) {
+        throw new Error("swap metadata must be bound to a swap");
     }
 
     const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
@@ -273,7 +294,7 @@ export const encryptSwapMetadata = async (
 
 export const decryptSwapMetadata = async (
     mnemonic: string,
-    swapId: string,
+    binding: SwapMetadataBinding,
     metadata: string,
 ): Promise<SwapMetadataPayload> => {
     const envelope = hex.decode(metadata);
@@ -295,19 +316,21 @@ export const decryptSwapMetadata = async (
     const parsed: unknown = JSON.parse(textDecoder.decode(plaintext));
     assertSupportedVersion(parsed);
 
-    const { swapId: boundSwapId, ...payload } = parseSwapMetadataPlaintext(
-        parsed,
-        "swap metadata",
-    );
+    const {
+        swapId: boundSwapId,
+        preimageHash: boundPreimageHash,
+        ...payload
+    } = parseSwapMetadataPlaintext(parsed, "swap metadata");
 
-    if (boundSwapId !== undefined && boundSwapId !== swapId) {
-        throw new Error("swap metadata is bound to a different swap");
-    }
+    const verified = [
+        verifyBinding(boundSwapId, binding.swapId, "swap"),
+        verifyBinding(boundPreimageHash, binding.preimageHash, "preimage hash"),
+    ].some(Boolean);
 
-    if (boundSwapId === undefined && hasMetadataTxIdentity(payload)) {
-        throw new Error(
-            "swap metadata with a lockup transaction must be bound to a swap",
-        );
+    // Anything the reader cannot tie to this swap is a replay candidate,
+    // including blobs written before the binding existed
+    if (!verified) {
+        throw new Error("swap metadata must be bound to a swap");
     }
 
     return payload;
@@ -362,6 +385,28 @@ export const buildSwapMetadataPayloadFromSwap = (
         originalDestination: swap.originalDestination,
     });
 
+export const getSwapPreimageHash = (swap: SomeSwap): string | undefined => {
+    try {
+        switch (swap.type) {
+            case SwapType.Submarine:
+                return decodeInvoice(swap.invoice).preimageHash;
+
+            case SwapType.Reverse:
+            case SwapType.Chain:
+                return hex.encode(sha256(hex.decode(swap.preimage)));
+
+            default:
+                return undefined;
+        }
+    } catch (error) {
+        log.warn("Cannot derive swap preimage hash", {
+            swapId: swap.id,
+            error,
+        });
+        return undefined;
+    }
+};
+
 export const patchEncryptedSwapMetadata = async (
     swap: SomeSwap,
     rescueFile: RescueFile | null | undefined,
@@ -389,6 +434,7 @@ export const patchEncryptedSwapMetadata = async (
             await encryptSwapMetadata(mnemonic, {
                 ...payload,
                 swapId: swap.id,
+                preimageHash: getSwapPreimageHash(swap),
             }),
         );
     } catch (error) {
@@ -439,7 +485,14 @@ export const hydrateRestorableSwapMetadata = async <T extends RestorableSwap>(
         return {
             ...swap,
             ...swapMetadataToLocalFields(
-                await decryptSwapMetadata(mnemonic, swap.id, swap.metadata),
+                await decryptSwapMetadata(
+                    mnemonic,
+                    {
+                        swapId: swap.id,
+                        preimageHash: swap.preimageHash,
+                    },
+                    swap.metadata,
+                ),
             ),
         };
     } catch (e) {

--- a/tests/pages/RescueExternal.spec.tsx
+++ b/tests/pages/RescueExternal.spec.tsx
@@ -618,6 +618,7 @@ describe("Rescue", () => {
             claimDetails,
             refundDetails: claimDetails,
             metadata: await encryptSwapMetadata(mnemonic, {
+                swapId: "metadata-swap",
                 dex: {
                     hops: [{ type: SwapType.Dex, from: "TBTC", to: "USDT0" }],
                     position: SwapPosition.Post,

--- a/tests/pages/RescueExternalEvmScan.spec.tsx
+++ b/tests/pages/RescueExternalEvmScan.spec.tsx
@@ -966,6 +966,7 @@ describe("Rescue EVM scan", () => {
                 },
             },
             metadata: await encryptSwapMetadata(mnemonic, {
+                swapId: "QzNPe7rckJCp",
                 dex: {
                     hops: [
                         {

--- a/tests/pages/externalRescueScan.spec.ts
+++ b/tests/pages/externalRescueScan.spec.ts
@@ -471,6 +471,7 @@ describe("external EVM rescue scan helpers", () => {
                             "c75a1b92ece410e13823372edceb1fc148c37d36586c2ccd8b2c78dac1556a8e",
                     },
                     metadata: await encryptSwapMetadata(mnemonic, {
+                        swapId: "QzNPe7rckJCp",
                         dex: {
                             hops: [
                                 {

--- a/tests/utils/swapCreator.spec.ts
+++ b/tests/utils/swapCreator.spec.ts
@@ -1,12 +1,20 @@
+import { BigNumber } from "bignumber.js";
+import type * as ClientModule from "boltz-swaps/client";
+import type * as InvoiceModule from "boltz-swaps/invoice";
 import { BridgeKind, SwapPosition, SwapType } from "boltz-swaps/types";
+import { vi } from "vitest";
 
 import { BTC, LBTC, LN, USDT0 } from "../../src/consts/Assets";
+import type { RescueFile } from "../../src/utils/rescueFile";
 import {
     type BridgeDetail,
     type DexDetail,
     type SwapAssetRoute,
     type SwapBase,
+    createChain,
     createLocalSwapId,
+    createReverse,
+    createSubmarine,
     getFinalAssetReceive,
     getFinalAssetSend,
     getPostBridgeDetail,
@@ -14,6 +22,31 @@ import {
     getRefundBridgeDetail,
     noGasAbstraction,
 } from "../../src/utils/swapCreator";
+
+const mocks = vi.hoisted(() => ({
+    createSubmarineSwap: vi.fn(),
+    createReverseSwap: vi.fn(),
+    createChainSwap: vi.fn(),
+}));
+
+vi.mock("boltz-swaps/client", async (importActual) => ({
+    ...(await importActual<typeof ClientModule>()),
+    ...mocks,
+}));
+
+const invoicePreimageHash = "cc".repeat(32);
+
+vi.mock("boltz-swaps/invoice", async (importActual) => {
+    const actual = await importActual<typeof InvoiceModule>();
+    return {
+        ...actual,
+        decodeInvoice: () => ({
+            type: actual.InvoiceType.Bolt11,
+            satoshis: 10_000,
+            preimageHash: invoicePreimageHash,
+        }),
+    };
+});
 
 const makeBridge = (
     sourceAsset: string,
@@ -270,5 +303,115 @@ describe("getFinalAssetReceive", () => {
             assetReceive: BTC,
         };
         expect(getFinalAssetReceive(route)).toBe(BTC);
+    });
+});
+
+describe("swap metadata factory", () => {
+    const rescueFile: RescueFile = {
+        mnemonic:
+            "invite smile evidence shield frost source truly ball odor unfold example nuclear",
+    };
+
+    const newKey = () =>
+        Promise.resolve({
+            index: 0,
+            key: { publicKey: new Uint8Array(33) } as never,
+        });
+
+    const buildMetadata = () =>
+        vi.fn((preimageHash: string) =>
+            Promise.resolve(`encrypted:${preimageHash}`),
+        );
+
+    beforeEach(() => {
+        mocks.createSubmarineSwap.mockReset().mockResolvedValue({});
+        mocks.createReverseSwap.mockReset().mockResolvedValue({});
+        mocks.createChainSwap.mockReset().mockResolvedValue({});
+    });
+
+    test("binds submarine metadata to the invoice preimage hash", async () => {
+        const metadata = buildMetadata();
+
+        await createSubmarine(
+            BTC,
+            LN,
+            BigNumber(10_000),
+            BigNumber(9_900),
+            "lnbc1",
+            "pair-hash",
+            noGasAbstraction(),
+            newKey,
+            undefined,
+            metadata,
+        );
+
+        expect(metadata).toHaveBeenCalledWith(invoicePreimageHash);
+        expect(mocks.createSubmarineSwap.mock.calls[0][5]).toBe(
+            `encrypted:${invoicePreimageHash}`,
+        );
+    });
+
+    test("binds reverse metadata to the hash sent to the backend", async () => {
+        const metadata = buildMetadata();
+
+        await createReverse(
+            LN,
+            BTC,
+            BigNumber(10_000),
+            BigNumber(9_900),
+            "claim-address",
+            "pair-hash",
+            noGasAbstraction(),
+            rescueFile,
+            newKey,
+            undefined,
+            metadata,
+        );
+
+        const [preimageHash] = metadata.mock.calls[0];
+        expect(preimageHash).toMatch(/^[0-9a-f]{64}$/);
+        expect(mocks.createReverseSwap.mock.calls[0][3]).toBe(preimageHash);
+        expect(mocks.createReverseSwap.mock.calls[0][7]).toBe(
+            `encrypted:${preimageHash}`,
+        );
+    });
+
+    test("binds chain metadata to the hash sent to the backend", async () => {
+        const metadata = buildMetadata();
+
+        await createChain(
+            LBTC,
+            BTC,
+            BigNumber(10_000),
+            BigNumber(9_900),
+            "claim-address",
+            "pair-hash",
+            noGasAbstraction(),
+            rescueFile,
+            newKey,
+            undefined,
+            metadata,
+        );
+
+        const [preimageHash] = metadata.mock.calls[0];
+        expect(mocks.createChainSwap.mock.calls[0][3]).toBe(preimageHash);
+        expect(mocks.createChainSwap.mock.calls[0][8]).toBe(
+            `encrypted:${preimageHash}`,
+        );
+    });
+
+    test("creates without metadata when none is built", async () => {
+        await createSubmarine(
+            BTC,
+            LN,
+            BigNumber(10_000),
+            BigNumber(9_900),
+            "lnbc1",
+            "pair-hash",
+            noGasAbstraction(),
+            newKey,
+        );
+
+        expect(mocks.createSubmarineSwap.mock.calls[0][5]).toBeUndefined();
     });
 });

--- a/tests/utils/swapMetadata.spec.ts
+++ b/tests/utils/swapMetadata.spec.ts
@@ -246,6 +246,26 @@ describe("swapMetadata crypto", () => {
         ).resolves.toEqual(samplePayload);
     });
 
+    test("compares swap ids exactly", async () => {
+        // Swap ids are case sensitive, so a differently cased id is another swap
+        const casedSwapId = "QzNPe7rckJCp";
+        const metadata = await encryptSwapMetadata(mnemonic, {
+            ...samplePayload,
+            swapId: casedSwapId,
+        });
+
+        await expect(
+            decryptSwapMetadata(
+                mnemonic,
+                { swapId: casedSwapId.toLowerCase() },
+                metadata,
+            ),
+        ).rejects.toThrow("swap metadata is bound to a different swap");
+        await expect(
+            decryptSwapMetadata(mnemonic, { swapId: casedSwapId }, metadata),
+        ).resolves.toEqual(samplePayload);
+    });
+
     test("rejects a blob predating the binding", async () => {
         // Route-only with no binding; forged, as encryptSwapMetadata refuses it
         const preBindingVector =

--- a/tests/utils/swapMetadata.spec.ts
+++ b/tests/utils/swapMetadata.spec.ts
@@ -407,7 +407,7 @@ describe("patchEncryptedSwapMetadata", () => {
         expect(mocks.patchSwapMetadata).not.toHaveBeenCalled();
     });
 
-    test("does not patch route metadata without tx identity", async () => {
+    test("binds route metadata without tx identity to the swap id", async () => {
         await patchEncryptedSwapMetadata(
             {
                 type: SwapType.Submarine,
@@ -417,6 +417,11 @@ describe("patchEncryptedSwapMetadata", () => {
             rescueFile,
         );
 
-        expect(mocks.patchSwapMetadata).not.toHaveBeenCalled();
+        expect(mocks.patchSwapMetadata).toHaveBeenCalledTimes(1);
+        const [swapId, metadata] = mocks.patchSwapMetadata.mock.calls[0];
+        expect(swapId).toBe("swap-id");
+        await expect(
+            decryptSwapMetadata(mnemonic, "another-swap-id", metadata),
+        ).rejects.toThrow("swap metadata is bound to a different swap");
     });
 });

--- a/tests/utils/swapMetadata.spec.ts
+++ b/tests/utils/swapMetadata.spec.ts
@@ -1,4 +1,6 @@
+import { sha256 } from "@noble/hashes/sha2.js";
 import { hex } from "@scure/base";
+import type * as InvoiceModule from "boltz-swaps/invoice";
 import { BridgeKind, SwapPosition, SwapType } from "boltz-swaps/types";
 import { beforeEach, vi } from "vitest";
 
@@ -7,15 +9,23 @@ import {
     buildSwapMetadataPayloadFromSwap,
     decryptSwapMetadata,
     encryptSwapMetadata,
+    getSwapPreimageHash,
+    hydrateRestorableSwapMetadata,
     patchEncryptedSwapMetadata,
 } from "../../src/utils/swapMetadata";
 
 const mocks = vi.hoisted(() => ({
     patchSwapMetadata: vi.fn(),
+    decodeInvoice: vi.fn(),
 }));
 
 vi.mock("boltz-swaps/client", () => ({
     patchSwapMetadata: mocks.patchSwapMetadata,
+}));
+
+vi.mock("boltz-swaps/invoice", async (importActual) => ({
+    ...(await importActual<typeof InvoiceModule>()),
+    decodeInvoice: mocks.decodeInvoice,
 }));
 
 const mnemonic =
@@ -28,6 +38,8 @@ const backendMetadataRegex = /^(?:[0-9a-fA-F]{2})+$/;
 const rescueFile = { mnemonic } as never;
 
 const swapId = "swap-id";
+const preimageHash =
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
 const samplePayload: SwapMetadataPayload = {
     dex: {
@@ -91,7 +103,11 @@ describe("swapMetadata crypto", () => {
         const metadata = await encryptSwapMetadata(mnemonic, boundPayload);
         expect(typeof metadata).toBe("string");
 
-        const decrypted = await decryptSwapMetadata(mnemonic, swapId, metadata);
+        const decrypted = await decryptSwapMetadata(
+            mnemonic,
+            { swapId },
+            metadata,
+        );
         expect(decrypted).toEqual(samplePayload);
     });
 
@@ -108,13 +124,17 @@ describe("swapMetadata crypto", () => {
             ...payload,
             swapId,
         });
-        const decrypted = await decryptSwapMetadata(mnemonic, swapId, metadata);
+        const decrypted = await decryptSwapMetadata(
+            mnemonic,
+            { swapId },
+            metadata,
+        );
         expect(decrypted.bridge?.txHash).toEqual("0xbridgetx");
     });
 
     test("decrypts the golden vector (wire format is frozen)", async () => {
         await expect(
-            decryptSwapMetadata(mnemonic, swapId, goldenVector),
+            decryptSwapMetadata(mnemonic, { swapId }, goldenVector),
         ).resolves.toEqual(legacyGoldenPayload);
     });
 
@@ -127,13 +147,13 @@ describe("swapMetadata crypto", () => {
             "c886e3cec1a5301423";
 
         await expect(
-            decryptSwapMetadata(mnemonic, swapId, unsupportedVersionVector),
+            decryptSwapMetadata(mnemonic, { swapId }, unsupportedVersionVector),
         ).rejects.toThrow(/unsupported swap metadata version/);
     });
 
     test("rejects a legacy version-less metadata blob", async () => {
         await expect(
-            decryptSwapMetadata(mnemonic, swapId, legacyVersionlessVector),
+            decryptSwapMetadata(mnemonic, { swapId }, legacyVersionlessVector),
         ).rejects.toThrow(/unsupported swap metadata version/);
     });
 
@@ -152,20 +172,102 @@ describe("swapMetadata crypto", () => {
     test("fails to decrypt with the wrong mnemonic", async () => {
         const metadata = await encryptSwapMetadata(mnemonic, boundPayload);
         await expect(
-            decryptSwapMetadata(otherMnemonic, swapId, metadata),
+            decryptSwapMetadata(otherMnemonic, { swapId }, metadata),
         ).rejects.toBeDefined();
     });
 
     test("rejects metadata bound to a different swap", async () => {
         const metadata = await encryptSwapMetadata(mnemonic, boundPayload);
         await expect(
-            decryptSwapMetadata(mnemonic, "other-swap", metadata),
+            decryptSwapMetadata(mnemonic, { swapId: "other-swap" }, metadata),
         ).rejects.toThrow(/bound to a different swap/);
     });
 
-    test("refuses to encrypt a lockup transaction without a swap binding", async () => {
+    test("refuses to encrypt anything without a binding", async () => {
         await expect(
             encryptSwapMetadata(mnemonic, samplePayload),
+        ).rejects.toThrow(/must be bound to a swap/);
+
+        await expect(
+            encryptSwapMetadata(mnemonic, { dex: samplePayload.dex }),
+        ).rejects.toThrow(/must be bound to a swap/);
+    });
+
+    test("rejects metadata bound to a different preimage hash", async () => {
+        const metadata = await encryptSwapMetadata(mnemonic, {
+            ...samplePayload,
+            preimageHash,
+        });
+
+        await expect(
+            decryptSwapMetadata(
+                mnemonic,
+                { swapId, preimageHash: preimageHash.replace("a", "b") },
+                metadata,
+            ),
+        ).rejects.toThrow(/bound to a different preimage hash/);
+    });
+
+    test("rejects a blob bound to both when either identifier differs", async () => {
+        const metadata = await encryptSwapMetadata(mnemonic, {
+            ...boundPayload,
+            preimageHash,
+        });
+
+        await expect(
+            decryptSwapMetadata(
+                mnemonic,
+                { swapId: "other-swap", preimageHash },
+                metadata,
+            ),
+        ).rejects.toThrow(/bound to a different swap/);
+
+        await expect(
+            decryptSwapMetadata(
+                mnemonic,
+                { swapId, preimageHash: preimageHash.replace("a", "b") },
+                metadata,
+            ),
+        ).rejects.toThrow(/bound to a different preimage hash/);
+    });
+
+    test("compares bindings ignoring hex case and 0x prefix", async () => {
+        const metadata = await encryptSwapMetadata(mnemonic, {
+            ...samplePayload,
+            preimageHash,
+        });
+
+        await expect(
+            decryptSwapMetadata(
+                mnemonic,
+                { swapId, preimageHash: `0x${preimageHash.toUpperCase()}` },
+                metadata,
+            ),
+        ).resolves.toEqual(samplePayload);
+    });
+
+    test("rejects a blob predating the binding", async () => {
+        // Route-only with no binding; forged, as encryptSwapMetadata refuses it
+        const preBindingVector =
+            "0000000000000000000000006278def9a95878147415e3cc9c173444873e6286" +
+            "e046250e28f554f5569f841981e56a9d58e8bae3c8713481175890e02b707241" +
+            "dfc7ac5a0ddfa1c18ffc70188415c795d619dc38abc9c6db23e37cf657de1bc7" +
+            "1caf5831361d2b905d22ae1e62971724b423c97a954483ba4ce6a45ac1d87450" +
+            "0cb55b42f664721d6b";
+
+        await expect(
+            decryptSwapMetadata(mnemonic, { swapId }, preBindingVector),
+        ).rejects.toThrow(/must be bound to a swap/);
+    });
+
+    test("rejects a bound blob the reader cannot check", async () => {
+        const metadata = await encryptSwapMetadata(mnemonic, {
+            dex: samplePayload.dex,
+            preimageHash,
+        });
+
+        await expect(
+            decryptSwapMetadata(mnemonic, { swapId }, metadata),
         ).rejects.toThrow(/must be bound to a swap/);
     });
 
@@ -179,14 +281,14 @@ describe("swapMetadata crypto", () => {
             "b2d4a8ea0e670b993c7c919324df496f43efdc11cac4c53915c74ad61f5bb9";
 
         await expect(
-            decryptSwapMetadata(mnemonic, swapId, unboundLockupVector),
+            decryptSwapMetadata(mnemonic, { swapId }, unboundLockupVector),
         ).rejects.toThrow(/must be bound to a swap/);
     });
 
     test("rejects an envelope that is too short", async () => {
         const tooShort = hex.encode(new Uint8Array(12));
         await expect(
-            decryptSwapMetadata(mnemonic, swapId, tooShort),
+            decryptSwapMetadata(mnemonic, { swapId }, tooShort),
         ).rejects.toThrow(/too short/);
     });
 
@@ -197,12 +299,13 @@ describe("swapMetadata crypto", () => {
         } as never);
 
         await expect(
-            decryptSwapMetadata(mnemonic, swapId, metadata),
+            decryptSwapMetadata(mnemonic, { swapId }, metadata),
         ).resolves.toEqual(samplePayload);
     });
 
     test("rejects malformed DEX metadata", async () => {
         const metadata = await encryptSwapMetadata(mnemonic, {
+            swapId,
             dex: {
                 hops: [],
                 position: SwapPosition.Post,
@@ -210,12 +313,13 @@ describe("swapMetadata crypto", () => {
         } as never);
 
         await expect(
-            decryptSwapMetadata(mnemonic, swapId, metadata),
+            decryptSwapMetadata(mnemonic, { swapId }, metadata),
         ).rejects.toThrow(/quoteAmount/);
     });
 
     test("ignores unexpected DEX hop fields (forward-compatible additive)", async () => {
         const metadata = await encryptSwapMetadata(mnemonic, {
+            swapId,
             dex: {
                 hops: [
                     {
@@ -231,7 +335,7 @@ describe("swapMetadata crypto", () => {
         } as never);
 
         await expect(
-            decryptSwapMetadata(mnemonic, swapId, metadata),
+            decryptSwapMetadata(mnemonic, { swapId }, metadata),
         ).resolves.toEqual({
             dex: {
                 hops: [{ type: SwapType.Dex, from: "TBTC", to: "USDT0" }],
@@ -243,6 +347,7 @@ describe("swapMetadata crypto", () => {
 
     test("rejects malformed DEX hop details", async () => {
         const metadata = await encryptSwapMetadata(mnemonic, {
+            swapId,
             dex: {
                 hops: [
                     {
@@ -262,7 +367,7 @@ describe("swapMetadata crypto", () => {
         } as never);
 
         await expect(
-            decryptSwapMetadata(mnemonic, swapId, metadata),
+            decryptSwapMetadata(mnemonic, { swapId }, metadata),
         ).rejects.toThrow(/dexDetails\.tokenIn must be a string/);
     });
 });
@@ -278,7 +383,7 @@ describe("buildSwapMetadataPayloadFromSwap", () => {
         ).toEqual({ lockupTx: "0xtx" });
     });
 
-    test("route metadata can be encrypted before lockup tx identity exists", async () => {
+    test("route metadata binds the preimage hash before a swap id exists", async () => {
         const payload = buildSwapMetadataPayloadFromSwap({
             type: SwapType.Submarine,
             id: "swap-id",
@@ -294,9 +399,12 @@ describe("buildSwapMetadataPayloadFromSwap", () => {
             bridge: samplePayload.bridge,
         });
 
-        const metadata = await encryptSwapMetadata(mnemonic, payload!);
+        const metadata = await encryptSwapMetadata(mnemonic, {
+            ...payload!,
+            preimageHash,
+        });
         await expect(
-            decryptSwapMetadata(mnemonic, swapId, metadata),
+            decryptSwapMetadata(mnemonic, { swapId, preimageHash }, metadata),
         ).resolves.toEqual({
             dex: samplePayload.dex,
             bridge: samplePayload.bridge,
@@ -342,7 +450,7 @@ describe("patchEncryptedSwapMetadata", () => {
         const [patchedSwapId, metadata] = mocks.patchSwapMetadata.mock.calls[0];
         expect(patchedSwapId).toBe("swap-id");
         await expect(
-            decryptSwapMetadata(mnemonic, "swap-id", metadata),
+            decryptSwapMetadata(mnemonic, { swapId: "swap-id" }, metadata),
         ).resolves.toEqual({
             lockupTx: "0xtx",
             dex: samplePayload.dex,
@@ -351,7 +459,7 @@ describe("patchEncryptedSwapMetadata", () => {
 
         // The blob must not decrypt for any other swap.
         await expect(
-            decryptSwapMetadata(mnemonic, "other-swap", metadata),
+            decryptSwapMetadata(mnemonic, { swapId: "other-swap" }, metadata),
         ).rejects.toThrow(/bound to a different swap/);
     });
 
@@ -371,7 +479,11 @@ describe("patchEncryptedSwapMetadata", () => {
         const [patchedSwapId, metadata] = mocks.patchSwapMetadata.mock.calls[0];
         expect(patchedSwapId).toBe("backend-swap-id");
         await expect(
-            decryptSwapMetadata(mnemonic, "backend-swap-id", metadata),
+            decryptSwapMetadata(
+                mnemonic,
+                { swapId: "backend-swap-id" },
+                metadata,
+            ),
         ).resolves.toEqual({
             commitmentLockupTxHash: "0xcommitment",
             dex: samplePayload.dex,
@@ -421,7 +533,199 @@ describe("patchEncryptedSwapMetadata", () => {
         const [swapId, metadata] = mocks.patchSwapMetadata.mock.calls[0];
         expect(swapId).toBe("swap-id");
         await expect(
-            decryptSwapMetadata(mnemonic, "another-swap-id", metadata),
+            decryptSwapMetadata(
+                mnemonic,
+                { swapId: "another-swap-id" },
+                metadata,
+            ),
         ).rejects.toThrow("swap metadata is bound to a different swap");
+    });
+
+    test("keeps the preimage hash the creation blob was bound to", async () => {
+        const preimage = "11".repeat(32);
+        const swapPreimageHash = hex.encode(sha256(hex.decode(preimage)));
+
+        await patchEncryptedSwapMetadata(
+            {
+                type: SwapType.Reverse,
+                id: "reverse-swap-id",
+                preimage,
+                lockupTx: "0xtx",
+                dex: samplePayload.dex,
+            } as never,
+            rescueFile,
+        );
+
+        expect(mocks.patchSwapMetadata).toHaveBeenCalledTimes(1);
+        const [, metadata] = mocks.patchSwapMetadata.mock.calls[0];
+        await expect(
+            decryptSwapMetadata(
+                mnemonic,
+                { swapId: "reverse-swap-id", preimageHash: swapPreimageHash },
+                metadata,
+            ),
+        ).resolves.toEqual({ lockupTx: "0xtx", dex: samplePayload.dex });
+
+        await expect(
+            decryptSwapMetadata(
+                mnemonic,
+                { swapId: "reverse-swap-id", preimageHash },
+                metadata,
+            ),
+        ).rejects.toThrow(/bound to a different preimage hash/);
+    });
+
+    test("binds a submarine patch to the invoice preimage hash", async () => {
+        mocks.decodeInvoice.mockReturnValue({ preimageHash });
+
+        await patchEncryptedSwapMetadata(
+            {
+                type: SwapType.Submarine,
+                id: "submarine-swap-id",
+                invoice: "lnbc1",
+                lockupTx: "0xtx",
+                dex: samplePayload.dex,
+            } as never,
+            rescueFile,
+        );
+
+        const [, metadata] = mocks.patchSwapMetadata.mock.calls[0];
+        await expect(
+            decryptSwapMetadata(
+                mnemonic,
+                { swapId: "submarine-swap-id", preimageHash },
+                metadata,
+            ),
+        ).resolves.toEqual({ lockupTx: "0xtx", dex: samplePayload.dex });
+    });
+});
+
+describe("getSwapPreimageHash", () => {
+    const preimage = "11".repeat(32);
+    const preimageHashOfPreimage = hex.encode(sha256(hex.decode(preimage)));
+
+    beforeEach(() => {
+        mocks.decodeInvoice.mockReset();
+    });
+
+    test("decodes the invoice for submarine swaps", () => {
+        mocks.decodeInvoice.mockReturnValue({ preimageHash });
+
+        expect(
+            getSwapPreimageHash({
+                type: SwapType.Submarine,
+                invoice: "lnbc1",
+            } as never),
+        ).toBe(preimageHash);
+    });
+
+    test.each([SwapType.Reverse, SwapType.Chain])(
+        "hashes the preimage for %s swaps",
+        (type) => {
+            expect(getSwapPreimageHash({ type, preimage } as never)).toBe(
+                preimageHashOfPreimage,
+            );
+        },
+    );
+
+    test("returns undefined for commitment swaps", () => {
+        expect(
+            getSwapPreimageHash({ type: SwapType.Commitment } as never),
+        ).toBeUndefined();
+    });
+
+    test("returns undefined instead of throwing on an undecodable invoice", () => {
+        mocks.decodeInvoice.mockImplementation(() => {
+            throw new Error("invalid invoice");
+        });
+
+        expect(
+            getSwapPreimageHash({
+                type: SwapType.Submarine,
+                id: "swap-id",
+                invoice: "not-an-invoice",
+            } as never),
+        ).toBeUndefined();
+    });
+});
+
+describe("hydrateRestorableSwapMetadata", () => {
+    const restorable = {
+        id: swapId,
+        type: SwapType.Chain,
+        status: "created",
+        from: "L-BTC",
+        to: "TBTC",
+        createdAt: 1,
+    };
+
+    test("returns the swap untouched without metadata", async () => {
+        await expect(
+            hydrateRestorableSwapMetadata(restorable as never, mnemonic),
+        ).resolves.toEqual(restorable);
+    });
+
+    test("merges the decrypted route onto the swap", async () => {
+        const metadata = await encryptSwapMetadata(mnemonic, {
+            swapId,
+            dex: samplePayload.dex,
+            originalDestination: "0xdestination",
+        });
+
+        await expect(
+            hydrateRestorableSwapMetadata(
+                { ...restorable, metadata } as never,
+                mnemonic,
+            ),
+        ).resolves.toMatchObject({
+            dex: samplePayload.dex,
+            originalDestination: "0xdestination",
+        });
+    });
+
+    test("drops a route replayed from another swap", async () => {
+        const metadata = await encryptSwapMetadata(mnemonic, {
+            swapId: "other-swap",
+            dex: samplePayload.dex,
+            originalDestination: "0xdestination",
+        });
+
+        const hydrated = await hydrateRestorableSwapMetadata(
+            { ...restorable, metadata } as never,
+            mnemonic,
+        );
+
+        expect(hydrated).not.toHaveProperty("dex");
+        expect(hydrated).not.toHaveProperty("originalDestination");
+    });
+
+    test("drops a hash-bound route when the backend withholds the hash", async () => {
+        const metadata = await encryptSwapMetadata(mnemonic, {
+            preimageHash,
+            dex: samplePayload.dex,
+            originalDestination: "0xdestination",
+        });
+
+        const hydrated = await hydrateRestorableSwapMetadata(
+            { ...restorable, metadata } as never,
+            mnemonic,
+        );
+
+        expect(hydrated).not.toHaveProperty("originalDestination");
+    });
+
+    test("keeps a hash-bound route the backend does report", async () => {
+        const metadata = await encryptSwapMetadata(mnemonic, {
+            preimageHash,
+            dex: samplePayload.dex,
+            originalDestination: "0xdestination",
+        });
+
+        await expect(
+            hydrateRestorableSwapMetadata(
+                { ...restorable, preimageHash, metadata } as never,
+                mnemonic,
+            ),
+        ).resolves.toMatchObject({ originalDestination: "0xdestination" });
     });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Encrypted swap metadata is now generated and validated using the swap’s preimage hash (where available) to improve routed swap restoration consistency.

* **Bug Fixes**
  * Restored routed swaps now retain route details even when transaction-identity data is missing.
  * Encrypted metadata is finalized more reliably after saving.
  * Stronger binding checks prevent decrypted metadata from being applied to the wrong swap.

* **Tests**
  * Expanded coverage for metadata binding (swap ID vs preimage hash), route patching without tx identity, and preimage-hash derivation across swap types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->